### PR TITLE
basic indexing for models and metastreams

### DIFF
--- a/app/indexers/concerns/curator/indexer/administrative_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/administrative_indexer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Indexer
+  class Indexer < Traject::Indexer
     module AdministrativeIndexer
       extend ActiveSupport::Concern
       included do

--- a/app/indexers/concerns/curator/indexer/administrative_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/administrative_indexer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer
+    module AdministrativeIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field 'destination_site_ssim', obj_extract('administrative', 'destination_site')
+          to_field 'harvesting_status_bsi', obj_extract('administrative', 'harvestable')
+          to_field 'flagged_content_ssi' do |record, accumulator|
+            accumulator << true if record.administrative.flagged
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/administrative_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/administrative_indexer.rb
@@ -9,7 +9,7 @@ module Curator
           to_field 'destination_site_ssim', obj_extract('administrative', 'destination_site')
           to_field 'harvesting_status_bsi', obj_extract('administrative', 'harvestable')
           to_field 'flagged_content_ssi' do |record, accumulator|
-            accumulator << true if record.administrative.flagged
+            accumulator << true if record.administrative&.flagged
           end
         end
       end

--- a/app/indexers/concerns/curator/indexer/obj_extract.rb
+++ b/app/indexers/concerns/curator/indexer/obj_extract.rb
@@ -55,8 +55,14 @@ module Curator
                    obj.send(first)
                  end
 
-        if result.nil? || rest.empty?
-          result
+        if result.nil?
+          nil
+        elsif rest.empty?
+          if result.kind_of?(Array)
+            result.collect { |v| v == '' ? nil : v }.compact # remove empty string and nil
+          else
+            result == '' ? nil : result # turn empty strings to nil
+          end
         else
           # recurse
           obj_extractor(result, rest)

--- a/app/indexers/concerns/curator/indexer/workflow_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/workflow_indexer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Indexer
+  class Indexer < Traject::Indexer
     module WorkflowIndexer
       extend ActiveSupport::Concern
       included do

--- a/app/indexers/concerns/curator/indexer/workflow_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/workflow_indexer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer
+    module WorkflowIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field 'publishing_state_ssi', obj_extract('workflow', 'publishing_state')
+          to_field 'processing_state_ssi', obj_extract('workflow', 'processing_state')
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -2,6 +2,10 @@
 
 module Curator
   class CollectionIndexer < Curator::Indexer
+    # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
+    #   institution_pid_ssi->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
+    #   institution_name_tsim->institution_name_tsi
+
     # TODO: add indexing for:
     #         publishing_state_ssi destination_site_ssim harvesting_status_bsi
     #         genre_basic_ssim genre_basic_tsim
@@ -11,14 +15,13 @@ module Curator
         accumulator << Curator::Parsers::InputParser.get_proper_title(record.send(:name)).last
       end
       to_field 'abstract_tsi', obj_extract('abstract')
-      to_field %w(physical_location_ssim physical_location_tsim institution_name_ssim institution_name_tsim),
+      to_field %w(physical_location_ssim physical_location_tsim institution_name_ssi institution_name_tsi),
                obj_extract('institution', 'name')
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
 
-      to_field 'exemplary_image_ssi',
-               obj_extract('exemplary_image_mappings', 'first', 'exemplary_file_set', 'ark_id')
+      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
       to_field 'exemplary_image_iiif_bsi' do |record, accumulator, _context|
-        exemplary_file_set_type = record.exemplary_image_mappings.first&.exemplary_file_set_type
+        exemplary_file_set_type = record.exemplary_file_set&.file_set_type
         accumulator << false unless exemplary_file_set_type == 'Curator::Filestreams::Image'
       end
     end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -2,7 +2,10 @@
 
 module Curator
   class CollectionIndexer < Curator::Indexer
-    # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
+    # NOTE: fields below were previously set in Bplmodels::Collection#to_solr, but no longer needed(?):
+    #   label_ssim
+
+    # NOTE: fields below were previously set in Bplmodels::Collection#to_solr, but have been updated:
     #   institution_pid_ssi->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
     #   institution_name_tsim->institution_name_tsi
 

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Curator
+  class CollectionIndexer < Curator::Indexer
+    # TODO: add indexing for:
+    #         publishing_state_ssi destination_site_ssim harvesting_status_bsi
+    #         genre_basic_ssim genre_basic_tsim
+    configure do
+      to_field 'title_info_primary_tsi', obj_extract('name')
+      to_field 'title_info_primary_ssort' do |record, accumulator, _context|
+        accumulator << Curator::Parsers::InputParser.get_proper_title(record.send(:name)).last
+      end
+      to_field 'abstract_tsi', obj_extract('abstract')
+      to_field %w(physical_location_ssim physical_location_tsim institution_name_ssim institution_name_tsim),
+               obj_extract('institution', 'name')
+      to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
+
+      to_field 'exemplary_image_ssi',
+               obj_extract('exemplary_image_mappings', 'first', 'exemplary_file_set', 'ark_id')
+      to_field 'exemplary_image_iiif_bsi' do |record, accumulator, _context|
+        exemplary_file_set_type = record.exemplary_image_mappings.first&.exemplary_file_set_type
+        accumulator << false unless exemplary_file_set_type == 'Curator::Filestreams::Image'
+      end
+    end
+  end
+end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -2,6 +2,9 @@
 
 module Curator
   class CollectionIndexer < Curator::Indexer
+    include Curator::Indexer::WorkflowIndexer
+    include Curator::Indexer::AdministrativeIndexer
+
     # NOTE: fields below were previously set in Bplmodels::Collection#to_solr, but no longer needed(?):
     #   label_ssim
 
@@ -10,8 +13,7 @@ module Curator
     #   institution_name_tsim->institution_name_tsi
 
     # TODO: add indexing for:
-    #         publishing_state_ssi destination_site_ssim harvesting_status_bsi
-    #         genre_basic_ssim genre_basic_tsim
+    #         genre_basic_ssim genre_basic_tsim edit_access_group_ssim
     configure do
       to_field 'title_info_primary_tsi', obj_extract('name')
       to_field 'title_info_primary_ssort' do |record, accumulator, _context|

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -3,7 +3,7 @@
 module Curator
   class DigitalObjectIndexer < Curator::Indexer
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but no longer needed(?):
-    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim
+    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim label_ssim
     #
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
     #   institution_pid_si->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
@@ -22,7 +22,7 @@ module Curator
 
     # TODO: add indexing for:
     #         publishing_state_ssi processing_state_ssi destination_site_ssim harvesting_status_bsi flagged_content_ssi
-    #         ocr_tiv has_searchable_text_bsi filenames_ssim
+    #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi
     #
     #         DESCRIPTIVE:
     #         title_info_primary_tsi title_info_primary_ssort title_info_partnum_tsi title_info_partname_tsi

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -2,6 +2,9 @@
 
 module Curator
   class DigitalObjectIndexer < Curator::Indexer
+    include Curator::Indexer::WorkflowIndexer
+    include Curator::Indexer::AdministrativeIndexer
+
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but no longer needed(?):
     #   internet_media_type_ssim title_info_uniform_ssim classification_tsim label_ssim
     #
@@ -21,8 +24,7 @@ module Curator
     #   rights_ssm->rights_ss restrictions_on_access_ssm->restrictions_on_access_ss
 
     # TODO: add indexing for:
-    #         publishing_state_ssi processing_state_ssi destination_site_ssim harvesting_status_bsi flagged_content_ssi
-    #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi
+    #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi edit_access_group_ssim
     #
     #         DESCRIPTIVE:
     #         title_info_primary_tsi title_info_primary_ssort title_info_partnum_tsi title_info_partname_tsi

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Curator
+  class DigitalObjectIndexer < Curator::Indexer
+    # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but no longer needed(?):
+    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim
+    #
+    # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
+    #   institution_pid_si->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
+    #   institution_name_tsim->institution_name_tsi collection_pid_ssm->collection_ark_id_ssim
+    #   admin_set_name_ssim->admin_set_name_ssi admin_set_name_tsim admin_set_pid_ssm->admin_set_ark_id_ssi
+    #   name_personal_tsim->name_tsim name_personal_role_tsim->name_role_tsim
+    #   name_corporate_tsim->name_tsim name_corporate_role_tsim->name_role_tsim
+    #   name_generic_tsim->name_tsim name_generic_role_tsim->name_role_tsim
+    #   subject_name_personal_tsim->subject_name_tsim subject_name_corporate_tsim->subject_name_tsim
+    #   subject_name_conference_tsim->subject_name_tsim
+    #   subject_temporal_start_tsim->subject_date_start_tsim subject_temporal_start_dtsim->subject_date_start_dtsim
+    #   subject_temporal_end_tsim->subject_date_end_tsim subject_temporal_end_dtsim->subject_date_end_dtsim
+    #   subject_scale_tsim->scale_tsim subject_projection_tsim->projection_tsi
+    #   edition_tsim->edition_name_tsim issuance_tsim->issuance_tsi
+    #   rights_ssm->rights_ss restrictions_on_access_ssm->restrictions_on_access_ss
+
+    # TODO: add indexing for:
+    #         publishing_state_ssi processing_state_ssi destination_site_ssim harvesting_status_bsi flagged_content_ssi
+    #         ocr_tiv has_searchable_text_bsi filenames_ssim
+    #
+    #         DESCRIPTIVE:
+    #         title_info_primary_tsi title_info_primary_ssort title_info_partnum_tsi title_info_partname_tsi
+    #         title_info_primary_trans_tsim title_info_translated_tsim
+    #         title_info_alternative_tsim title_info_uniform_tsim
+    #         supplied_title_bs supplied_alternative_title_bs title_info_alternative_label_ssm subtitle_tsim
+    #         genre_basic_tsim genre_basic_ssim genre_specific_tsim genre_specific_ssim
+    #         type_of_resource_ssim resource_type_manuscript_bsi extent_tsi digital_origin_ssi
+    #         physical_location_ssim physical_location_tsim sub_location_tsim shelf_locator_tsim
+    #         abstract_tsim table_of_contents_tsi table_of_contents_url_ss
+    #         date_start_dtsi date_start_tsim date_end_dtsi date_end_tsim date_facet_ssim
+    #         date_type_ssm date_start_qualifier_ssm
+    #         publisher_tsim pubplace_tsim issuance_tsi frequency_tsi
+    #         edition_name_tsi edition_number_tsi volume_tsi issue_number_tsi text_direction_ssi
+    #         lang_term_ssim
+    #         related_item_constiuent_tsim related_item_constiuent_ssim
+    #         related_item_host_tsim related_item_host_ssim
+    #         related_item_series_tsim related_item_series_ssim
+    #         related_item_subseries_tsim related_item_subseries_ssim
+    #         related_item_subsubseries_tsim related_item_subsubseries_ssim
+    #         related_item_isreferencedby_ssm
+    #         identifier_local_other_tsim identifier_local_other_invalid_tsim
+    #         identifier_local_call_tsim identifier_local_call_invalid_tsim
+    #         identifier_local_barcode_tsim identifier_local_barcode_invalid_tsim
+    #         identifier_local_accession_tsim identifier_isbn_tsim identifier_lccn_tsim
+    #         identifier_ia_id_ssi identifier_uri_ss
+    #         name_tsim name_role_tsim name_facet_ssim
+    #         note_tsim note_resp_tsim note_performers_tsim note_acquisition_tsim note_ownership_tsim
+    #         note_citation_tsim note_reference_tsim note_venue_tsim note_physical_tsim note_date_tsim
+    #         subject_facet_ssim
+    #         subject_topic_tsim
+    #         subject_date_start_tsim subject_date_start_dtsim subject_date_end_tsim subject_date_end_dtsim
+    #         subject_temporal_tsim subject_temporal_facet_ssim
+    #         subject_title_tsim
+    #         subject_geo_country_ssim subject_geo_province_ssim subject_geo_region_ssim subject_geo_territory_ssim
+    #         subject_geo_state_ssim subject_geo_county_ssim subject_geo_city_ssim subject_geo_citysection_ssim
+    #         subject_geo_island_ssim subject_geo_area_ssim
+    #         subject_geographic_tsim subject_geographic_ssim
+    #         subject_coordinates_geospatial subject_point_geospatial subject_bbox_geospatial
+    #         subject_geojson_facet_ssim subject_hiergeo_geojson_ssm subject_geo_nonhier_ssim
+    #         scale_tsim projection_tsi
+    #         rights_ss license_ssm reuse_allowed_ssi restrictions_on_access_ss
+    configure do
+      to_field 'admin_set_name_ssi', obj_extract('admin_set', 'name')
+      to_field 'admin_set_ark_id_ssi', obj_extract('admin_set', 'ark_id')
+      to_field %w(institution_name_ssi institution_name_tsi), obj_extract('institution', 'name')
+      to_field %w(collection_name_ssim collection_name_tsim) do |record, accumulator|
+        record.is_member_of_collection.each { |col| accumulator << col.name }
+      end
+      to_field 'collection_ark_id_ssim' do |record, accumulator|
+        record.is_member_of_collection.each { |col| accumulator << col.ark_id }
+      end
+      to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
+      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
+    end
+  end
+end

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -71,13 +71,13 @@ module Curator
       to_field 'admin_set_name_ssi', obj_extract('admin_set', 'name')
       to_field 'admin_set_ark_id_ssi', obj_extract('admin_set', 'ark_id')
       to_field %w(institution_name_ssi institution_name_tsi), obj_extract('institution', 'name')
+      to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
       to_field %w(collection_name_ssim collection_name_tsim) do |record, accumulator|
         record.is_member_of_collection.each { |col| accumulator << col.name }
       end
       to_field 'collection_ark_id_ssim' do |record, accumulator|
         record.is_member_of_collection.each { |col| accumulator << col.ark_id }
       end
-      to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
       to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
     end
   end

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -5,19 +5,37 @@ module Curator
     include Curator::Indexer::WorkflowIndexer
 
     # NOTE: fields below were previously set in Bplmodels::File#to_solr, but no longer needed(?):
-    #   label_ssi filename_ssi page_num_label_type_ssi
+    #   label_ssi filename_ssi page_num_label_type_ssi mime_type_tesim(set on Blob instead)
+    #   is_image_of_ssim is_audio_of_ssim is_document_of_ssim is_ereader_of_ssim is_volume_of_ssim
+    #   is_following_image_of_ssim is_following_audio_of_ssim is_following_document_of_ssim is_following_ereader_of_ssim
+    #   is_preceding_image_of_ssim is_preceding_audio_of_ssim is_preceding_document_of_ssim is_preceding_ereader_of_ssim
 
     # NOTE: fields below were previously set in Bplmodels::File#to_solr, but have been updated:
-    #   derivative_processsed_ssi->processing_state_ssi
+    #   derivative_processsed_ssi->processing_state_ssi is_file_of_ssim->is_file_set_of_ssim
+    #   hand_side_ssi->page_hand_side_ssi
 
     # TODO: add indexing for:
     #         ocr_tsiv has_ocr_text_bsi edit_access_group_ssim
     #         has_djvu_json_ssi georeferenced_bsi
     configure do
+      to_field 'is_file_set_of_ssim', obj_extract('file_set_of', 'ark_id')
+      to_field 'is_exemplary_image_of_ssim' do |record, accumulator|
+        if record.respond_to?(:exemplary_image_objects)
+          record.exemplary_image_objects.each do |exemplary_object|
+            accumulator << exemplary_object.ark_id
+          end
+        end
+        if record.respond_to?(:exemplary_image_collections)
+          record.exemplary_image_collections.each do |exemplary_col|
+            accumulator << exemplary_col.ark_id
+          end
+        end
+      end
       to_field 'filename_base_ssi', obj_extract('file_name_base')
-      to_field 'position_fsi', obj_extract('position', 'to_f')
+      to_field 'position_isi', obj_extract('position')
       to_field('page_type_ssi') { |rec, acc| acc << rec.pagination['page_type'] }
       to_field('page_num_label_ssi') { |rec, acc| acc << rec.pagination['page_label'] }
+      to_field('page_hand_side_ssi') { |rec, acc| acc << rec.pagination['hand_side'] }
     end
   end
 end

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -2,15 +2,16 @@
 
 module Curator
   class FileSetIndexer < Curator::Indexer
+    include Curator::Indexer::WorkflowIndexer
+
     # NOTE: fields below were previously set in Bplmodels::File#to_solr, but no longer needed(?):
-    #   label_ssim filename_ssi
+    #   label_ssi filename_ssi page_num_label_type_ssi
 
     # NOTE: fields below were previously set in Bplmodels::File#to_solr, but have been updated:
-    #
+    #   derivative_processsed_ssi->processing_state_ssi
 
     # TODO: add indexing for:
-    #         derivative_processsed_ssi ocr_tsiv has_ocr_text_bsi
-    #         page_num_label_type_ssi
+    #         ocr_tsiv has_ocr_text_bsi edit_access_group_ssim
     #         has_djvu_json_ssi georeferenced_bsi
     configure do
       to_field 'filename_base_ssi', obj_extract('file_name_base')

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Curator
+  class FileSetIndexer < Curator::Indexer
+    # NOTE: fields below were previously set in Bplmodels::File#to_solr, but no longer needed(?):
+    #   label_ssim filename_ssi
+
+    # NOTE: fields below were previously set in Bplmodels::File#to_solr, but have been updated:
+    #
+
+    # TODO: add indexing for:
+    #         derivative_processsed_ssi ocr_tsiv has_ocr_text_bsi
+    #         page_num_label_type_ssi
+    #         has_djvu_json_ssi georeferenced_bsi
+    configure do
+      to_field 'filename_base_ssi', obj_extract('file_name_base')
+      to_field 'position_fsi', obj_extract('position', 'to_f')
+      to_field('page_type_ssi') { |rec, acc| acc << rec.pagination['page_type'] }
+      to_field('page_num_label_ssi') { |rec, acc| acc << rec.pagination['page_label'] }
+    end
+  end
+end

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -15,7 +15,7 @@ module Curator
     configure do
       to_field %w(title_info_primary_tsi physical_location_ssim), obj_extract('name')
       to_field 'title_info_primary_ssort' do |record, accumulator, _context|
-        accumulator << Curator::Parsers::InputParser.get_proper_title(record.send(:name)).last
+        accumulator << Curator::Parsers::InputParser.get_proper_title(record.name).last
       end
       to_field 'abstract_tsi', obj_extract('abstract')
       to_field 'institution_url_ss', obj_extract('url')

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -4,7 +4,7 @@ module Curator
   class InstitutionIndexer < Curator::Indexer
     # NOTE: fields below were previously set in Bplmodels::Institution#to_solr, but no longer needed(?):
     #   ingest_origin_ssim ingest_path_ssim exemplary_image_ssi physical_location_tsim
-    #   institution_pid_si institution_pid_ssi
+    #   institution_pid_si institution_pid_ssi label_ssim
 
     # TODO: add indexing for:
     #         publishing_state_ssi destination_site_ssim

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -2,12 +2,15 @@
 
 module Curator
   class InstitutionIndexer < Curator::Indexer
+    include Curator::Indexer::WorkflowIndexer
+    include Curator::Indexer::AdministrativeIndexer
+
     # NOTE: fields below were previously set in Bplmodels::Institution#to_solr, but no longer needed(?):
     #   ingest_origin_ssim ingest_path_ssim exemplary_image_ssi physical_location_tsim
     #   institution_pid_si institution_pid_ssi label_ssim
 
     # TODO: add indexing for:
-    #         publishing_state_ssi destination_site_ssim
+    #         edit_access_group_ssim
     #         subject_geo_country_ssim subject_geo_state_ssim subject_geo_county_ssim
     #         subject_geo_city_ssim subject_geo_citysection_ssim
     #         subject_geographic_tsim subject_geographic_ssim

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -4,6 +4,7 @@ module Curator
   class InstitutionIndexer < Curator::Indexer
     # NOTE: fields below were previously set in Bplmodels::Institution#to_solr, but no longer needed(?):
     #   ingest_origin_ssim ingest_path_ssim exemplary_image_ssi physical_location_tsim
+    #   institution_pid_si institution_pid_ssi
 
     # TODO: add indexing for:
     #         publishing_state_ssi destination_site_ssim

--- a/app/models/concerns/curator/mappings/exemplary.rb
+++ b/app/models/concerns/curator/mappings/exemplary.rb
@@ -6,7 +6,11 @@ module Curator
       module ObjectImagable
         extend ActiveSupport::Concern
         included do
-          has_many :exemplary_image_mappings, as: :exemplary_object, inverse_of: :exemplary_object, class_name: 'Curator::Mappings::ExemplaryImage', dependent: :destroy
+          has_one :exemplary_image_mappings, as: :exemplary_object, inverse_of: :exemplary_object, class_name: 'Curator::Mappings::ExemplaryImage', dependent: :destroy
+        end
+
+        def exemplary_file_set
+          exemplary_image_mappings.presence&.exemplary_file_set
         end
       end
       module FileSetImagable

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -15,5 +15,10 @@ module Curator
     has_many :collection_members, inverse_of: :collection, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
 
     self.curator_indexable_mapper = Curator::CollectionIndexer.new
+
+    def exemplary_file_set
+      exemplary_image_mapping = exemplary_image_mappings.first
+      exemplary_image_mapping ? exemplary_image_mapping.exemplary_file_set : nil
+    end
   end
 end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -6,11 +6,14 @@ module Curator
     include Curator::Metastreams::Administratable
     include Curator::Metastreams::Workflowable
     include Curator::Mappings::Exemplary::ObjectImagable
+    include Curator::Indexable
 
     belongs_to :institution, inverse_of: :collections, class_name: 'Curator::Institution'
 
     has_many :admin_set_objects, inverse_of: :admin_set, class_name: 'Curator::DigitalObject', foreign_key: :admin_set_id, dependent: :destroy
 
     has_many :collection_members, inverse_of: :collection, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
+
+    self.curator_indexable_mapper = Curator::CollectionIndexer.new
   end
 end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -15,10 +15,5 @@ module Curator
     has_many :collection_members, inverse_of: :collection, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
 
     self.curator_indexable_mapper = Curator::CollectionIndexer.new
-
-    def exemplary_file_set
-      exemplary_image_mapping = exemplary_image_mappings.first
-      exemplary_image_mapping ? exemplary_image_mapping.exemplary_file_set : nil
-    end
   end
 end

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -10,6 +10,7 @@ module Curator
     before_create :add_admin_set_to_members, if: proc { |d| d.admin_set.present? } # Should Fail if admin set is not present
 
     belongs_to :admin_set, inverse_of: :admin_set_objects, class_name: 'Curator::Collection'
+    has_one :institution, through: :admin_set, class_name: 'Curator::Institution'
 
     with_options inverse_of: :file_set_of, foreign_key: :file_set_of_id, dependent: :destroy do
       has_many :audio_file_sets, class_name: 'Curator::Filestreams::Audio'
@@ -35,15 +36,6 @@ module Curator
     end
 
     self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
-
-    def institution
-      admin_set.institution
-    end
-
-    def exemplary_file_set
-      exemplary_image_mapping = exemplary_image_mappings.first
-      exemplary_image_mapping ? exemplary_image_mapping.exemplary_file_set : nil
-    end
 
     private
 

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -5,6 +5,7 @@ module Curator
     include Curator::Mintable
     include Curator::Metastreamable
     include Curator::Mappings::Exemplary::ObjectImagable
+    include Curator::Indexable
 
     before_create :add_admin_set_to_members, if: proc { |d| d.admin_set.present? } # Should Fail if admin set is not present
 
@@ -31,6 +32,17 @@ module Curator
     with_options class_name: 'Curator::DigitalObject' do
       has_one :issue_of, through: :issue_mapping, source: :issue_of
       has_one :issue_for, through: :issue_mapping_for, source: :digital_object
+    end
+
+    self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
+
+    def institution
+      admin_set.institution
+    end
+
+    def exemplary_file_set
+      exemplary_image_mapping = exemplary_image_mappings.first
+      exemplary_image_mapping ? exemplary_image_mapping.exemplary_file_set : nil
     end
 
     private

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -7,10 +7,13 @@ module Curator
     include Curator::Mintable
     include Curator::Metastreams::Workflowable
     include Curator::Metastreams::Administratable
+    include Curator::Indexable
 
     has_one_attached :metadata_foxml
 
     validates :file_name_base, presence: true
     validates :file_set_type, presence: true, inclusion: { in: Filestreams.file_set_types.collect { |type| "Curator::Filestreams::#{type}" } }
+
+    self.curator_indexable_mapper = Curator::FileSetIndexer.new
   end
 end

--- a/app/models/curator/mappings/exemplary_image.rb
+++ b/app/models/curator/mappings/exemplary_image.rb
@@ -11,6 +11,8 @@ module Curator
 
     validates :exemplary_file_set_id, uniqueness: { scope: [:exemplary_file_set_type, :exemplary_object_type, :exemplary_object_id] }, on: :create
 
+    validates :exemplary_object_id, uniqueness: true, on: :create
+
     validates :exemplary_object_type, inclusion: { in: VALID_EXEMPLARY_OBJECT_TYPES.collect { |obj_type| "Curator::#{obj_type}" } }, on: :create
 
     validates :exemplary_file_set_type, inclusion: { in: VALID_EXEMPLARY_FILE_SET_TYPES.collect { |fset_type| "Curator::Filestreams::#{fset_type}" } }, on: :create

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -5,7 +5,7 @@ module Curator
     belongs_to :workflowable, polymorphic: true, inverse_of: :workflow
 
     enum publishing_state: { draft: 0, review: 1, published: 2 }.freeze
-    enum processing_state: { dervivatives: 0, complete: 1 }.freeze
+    enum processing_state: { derivatives: 0, complete: 1 }.freeze
 
     validates :ingest_origin, presence: true
     validates :workflowable_id, uniqueness: { scope: :workflowable_type }, on: :create

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'paper_trail', '~> 10.3' # have not implemented this yet but does version control
   spec.add_dependency 'rails', '~> 5.2.3'
   spec.add_dependency 'rsolr', '~> 2.0.2'
-  spec.add_dependency 'traject', '~> 3.2.0'
+  spec.add_dependency 'traject', '~> 3.3.0'
 
   spec.add_development_dependency 'mini_magick', '~> 4.9.5'
   spec.add_development_dependency 'pg', '~> 1.1'

--- a/db/migrate/20190923155026_create_curator_mappings_exemplary_images.rb
+++ b/db/migrate/20190923155026_create_curator_mappings_exemplary_images.rb
@@ -4,7 +4,7 @@ class CreateCuratorMappingsExemplaryImages < ActiveRecord::Migration[5.2]
   def change
     create_table :curator_mappings_exemplary_images do |t|
       t.belongs_to :exemplary_file_set, polymorphic: true, index: { using: :btree, name: 'idx_map_exemp_on_exemp_file_set_poly' }, null: false
-      t.belongs_to :exemplary_object, polymorphic: true, index: { using: :btree, name: 'idx_map_exemp_img_on_exemp_obj_poly' }, null: false
+      t.belongs_to :exemplary_object, polymorphic: true, index: { using: :btree, name: 'idx_map_exemp_img_on_exemp_obj_poly' }, null: false, unique: true
       t.index [:exemplary_file_set_id, :exemplary_file_set_type, :exemplary_object_id, :exemplary_object_type], name: 'uniq_idx_map_exemp_img_on_exemp_obj_poly_and_exemp_fset_poly', unique: true, using: :btree
     end
   end

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_digital_object, class: 'Curator::DigitalObject' do
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     association :admin_set, factory: :curator_collection
     archived_at { nil }
   end

--- a/spec/factories/curator/filestreams/images.rb
+++ b/spec/factories/curator/filestreams/images.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Image' }
     file_name_base { Faker::Artist.name }
     position { 1 }
-    pagination { {} }
+    pagination { { 'hand_side' => 'left', 'page_type' => 'TOC', 'page_label' => '3' } }
     archived_at { nil }
   end
 end

--- a/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::AdministrativeIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::AdministrativeIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:administratable_object) do
+      admin_obj = create(:curator_institution)
+      admin_obj.administrative = create(:curator_metastreams_administrative)
+      admin_obj.administrative.flagged = true # so we can test indexing
+      admin_obj
+    end
+    let(:indexed) { indexer.map_record(administratable_object) }
+    let(:administrative) { administratable_object.administrative }
+
+    it 'sets the destination_site field' do
+      expect(indexed['destination_site_ssim']).to eq administrative.destination_site
+    end
+
+    it 'sets the harvesting_status field' do
+      expect(indexed['harvesting_status_bsi']).to eq [administrative.harvestable]
+    end
+
+    it 'sets the flagged field' do
+      expect(indexed['flagged_content_ssi']).to eq [administrative.flagged]
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/obj_extract_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/obj_extract_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe Curator::Indexer::ObjExtract do
       result = indexer.map_record(OpenStruct.new(title: 'title value'))
       expect(result['result']).to eq(['title value'])
     end
+
+    it 'ignores empty string' do
+      result = indexer.map_record(OpenStruct.new(title: ''))
+      expect(result['result']).to be_nil
+      expect(result.keys).not_to include('result')
+    end
+
+    it 'indexes false' do
+      result = indexer.map_record(OpenStruct.new(title: false))
+      expect(result['result']).to eq([false])
+    end
   end
 
   describe 'primitive array attribute' do
@@ -46,6 +57,22 @@ RSpec.describe Curator::Indexer::ObjExtract do
       result = indexer.map_record(OpenStruct.new(title: ['title value1', 'title value2']))
       expect(result['result']).to eq(['title value1', 'title value2'])
     end
+
+    it 'filters out empty strings' do
+      result = indexer.map_record(OpenStruct.new(title: ['value1', 'value2', '', '']))
+      expect(result['result']).to eq(['value1', 'value2'])
+    end
+
+    it 'ignores all empty string value' do
+      result = indexer.map_record(OpenStruct.new(title: ['', '']))
+      expect(result['result']).to be_nil
+      expect(result.keys).not_to include('result')
+    end
+
+    it 'allows false values' do
+      result = indexer.map_record(OpenStruct.new(title: [false]))
+      expect(result['result']).to eq([false])
+    end
   end
 
   describe 'model attribute' do
@@ -63,6 +90,12 @@ RSpec.describe Curator::Indexer::ObjExtract do
     it 'indexes nil without raising' do
       result = indexer.map_record(OpenStruct.new(creator: nil))
       expect(result).to eq({})
+    end
+
+    it 'ignores empty string' do
+      result = indexer.map_record(OpenStruct.new(creator: OpenStruct.new(type: 'engraver', name: '')))
+      expect(result['result']).to be_nil
+      expect(result.keys).not_to include('result')
     end
 
     describe 'as array' do
@@ -86,6 +119,12 @@ RSpec.describe Curator::Indexer::ObjExtract do
           )
         )
         expect(result).to eq({ 'result' => ['Doe, Jane', 'Tame, Puddin'] })
+      end
+
+      it 'ignores empty string' do
+        result = indexer.map_record(OpenStruct.new(creator: [OpenStruct.new(type: 'engraver', name: '')]))
+        expect(result['result']).to be_nil
+        expect(result.keys).not_to include('result')
       end
     end
 
@@ -125,6 +164,12 @@ RSpec.describe Curator::Indexer::ObjExtract do
     it 'indexes empty array' do
       result = indexer.map_record(OpenStruct.new(creator: []))
       expect(result).to eq({})
+    end
+
+    it 'ignores empty string' do
+      result = indexer.map_record(OpenStruct.new(creator: { type: 'engraver', name: '' }))
+      expect(result['result']).to be_nil
+      expect(result.keys).not_to include('result')
     end
   end
 end

--- a/spec/indexers/concerns/curator/indexer/workflow_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/workflow_indexer_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::WorkflowIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::WorkflowIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:workflowable_object) do
+      workflow_obj = create(:curator_institution)
+      workflow_obj.workflow = create(:curator_metastreams_workflow)
+      workflow_obj
+    end
+    let(:indexed) { indexer.map_record(workflowable_object) }
+    let(:workflow) { workflowable_object.workflow }
+
+    it 'sets the publishing_state field' do
+      expect(indexed['publishing_state_ssi']).to eq [workflow.publishing_state]
+    end
+
+    it 'sets the processing_state field' do
+      expect(indexed['processing_state_ssi']).to eq [workflow.processing_state]
+    end
+  end
+end

--- a/spec/indexers/curator/collection_indexer_spec.rb
+++ b/spec/indexers/curator/collection_indexer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::CollectionIndexer do
+  # set exemplary mapping here, relationship not created by factory
+  before(:all) do
+    @collection = create(:curator_collection)
+    exemplary_file_set = create(:curator_filestreams_image)
+    exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: @collection,
+                                                              exemplary_file_set: exemplary_file_set)
+    exemplary_mapping.save!
+  end
+
+  describe 'indexing' do
+    let(:indexer) { described_class.new }
+    let(:indexed) { indexer.map_record(@collection) }
+
+    it 'sets the title fields' do
+      expect(indexed['title_info_primary_tsi']).to eq [@collection.name]
+      expect(
+        indexed['title_info_primary_ssort']
+      ).to eq [Curator::Parsers::InputParser.get_proper_title(@collection.name).last]
+    end
+
+    it 'sets the abstract field' do
+      expect(indexed['abstract_tsi']).to eq [@collection.abstract]
+    end
+
+    it 'sets the physical location and institution fields' do
+      pi_fields = %w(physical_location_ssim physical_location_tsim institution_name_ssi institution_name_tsi)
+      pi_fields.each do |field|
+        expect(indexed[field]).to eq [@collection.institution.name]
+      end
+      expect(indexed['institution_ark_id_ssi']).to eq [@collection.institution.ark_id]
+    end
+
+    it 'sets the exemplary image field' do
+      expect(indexed['exemplary_image_ssi']).to eq [@collection.exemplary_file_set.ark_id]
+    end
+  end
+end

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -3,9 +3,13 @@
 require 'rails_helper'
 RSpec.describe Curator::DigitalObjectIndexer do
   describe 'indexing' do
-    # use :curator_mappings_exemplary_image factory to create DigitalObject,
-    # slightly indirect, but easier than creating exemplary mapping objects in before(:all) block
-    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
+    # use DigitalObject from :curator_mappings_exemplary_image factory
+    # otherwise exemplary_image indexing doesn't work
+    let(:exemplary_image_mapping) do
+      create(:curator_mappings_exemplary_image,
+             exemplary_object: create(:curator_digital_object),
+             exemplary_file_set: create(:curator_filestreams_image))
+    end
     let(:digital_object) { exemplary_image_mapping.exemplary_object }
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(digital_object) }

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::DigitalObjectIndexer do
+  describe 'indexing' do
+    # use :curator_mappings_exemplary_image factory to create DigitalObject,
+    # slightly indirect, but easier than creating exemplary mapping objects in before(:all) block
+    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
+    let(:digital_object) { exemplary_image_mapping.exemplary_object }
+    let(:indexer) { described_class.new }
+    let(:indexed) { indexer.map_record(digital_object) }
+    let(:collections) { digital_object.is_member_of_collection }
+
+    it 'sets the admin set fields' do
+      expect(indexed['admin_set_name_ssi']).to eq [digital_object.admin_set.name]
+      expect(indexed['admin_set_ark_id_ssi']).to eq [digital_object.admin_set.ark_id]
+    end
+
+    it 'sets the institution fields' do
+      %w(institution_name_ssi institution_name_tsi).each do |field|
+        expect(indexed[field]).to eq [digital_object.institution.name]
+      end
+      expect(indexed['institution_ark_id_ssi']).to eq [digital_object.institution.ark_id]
+    end
+
+    it 'sets the collection fields' do
+      %w(collection_name_ssim collection_name_tsim).each do |field|
+        expect(indexed[field]).to eq collections.map { |c| c.name }
+      end
+      expect(indexed['collection_ark_id_ssim']).to eq collections.map { |c| c.ark_id }
+    end
+
+    it 'sets the exemplary image field' do
+      expect(indexed['exemplary_image_ssi']).to eq [digital_object.exemplary_file_set.ark_id]
+    end
+  end
+end

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe Curator::DigitalObjectIndexer do
   describe 'indexing' do
     # use DigitalObject from :curator_mappings_exemplary_image factory
     # otherwise exemplary_image indexing doesn't work
-    let(:exemplary_image_mapping) do
-      create(:curator_mappings_exemplary_image,
-             exemplary_object: create(:curator_digital_object),
-             exemplary_file_set: create(:curator_filestreams_image))
-    end
+    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
     let(:digital_object) { exemplary_image_mapping.exemplary_object }
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(digital_object) }

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::FileSetIndexer do
+  describe 'indexing' do
+    # use :curator_mappings_exemplary_image factory to create FileSet,
+    # slightly indirect, but easier than creating exemplary mapping objects in before(:all) block
+    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
+    let(:file_set) { exemplary_image_mapping.exemplary_file_set }
+    let(:indexer) { described_class.new }
+    let(:indexed) { indexer.map_record(file_set) }
+
+    it 'sets the file_set_of field' do
+      expect(indexed['is_file_set_of_ssim']).to eq [file_set.file_set_of.ark_id]
+    end
+
+    it 'sets the file name field' do
+      expect(indexed['filename_base_ssi']).to eq [file_set.file_name_base]
+    end
+
+    it 'sets the position field' do
+      expect(indexed['position_isi']).to eq [file_set.position]
+    end
+
+    it 'sets the pagination fields' do
+      expect(indexed['page_type_ssi']).to eq [file_set.pagination['page_type']]
+      expect(indexed['page_num_label_ssi']).to eq [file_set.pagination['page_label']]
+      expect(indexed['page_hand_side_ssi']).to eq [file_set.pagination['hand_side']]
+    end
+
+    it 'sets the exemplary image field' do
+      expect(indexed['is_exemplary_image_of_ssim']).to eq(
+        file_set.exemplary_image_objects.map { |obj| obj.ark_id }
+      )
+    end
+  end
+end

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -3,9 +3,13 @@
 require 'rails_helper'
 RSpec.describe Curator::FileSetIndexer do
   describe 'indexing' do
-    # use :curator_mappings_exemplary_image factory to create FileSet,
-    # slightly indirect, but easier than creating exemplary mapping objects in before(:all) block
-    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
+    # use FileSet from :curator_mappings_exemplary_image factory
+    # otherwise exemplary_image indexing doesn't work
+    let(:exemplary_image_mapping) do
+      create(:curator_mappings_exemplary_image,
+             exemplary_object: create(:curator_digital_object),
+             exemplary_file_set: create(:curator_filestreams_image))
+    end
     let(:file_set) { exemplary_image_mapping.exemplary_file_set }
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(file_set) }

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe Curator::FileSetIndexer do
   describe 'indexing' do
     # use FileSet from :curator_mappings_exemplary_image factory
     # otherwise exemplary_image indexing doesn't work
-    let(:exemplary_image_mapping) do
-      create(:curator_mappings_exemplary_image,
-             exemplary_object: create(:curator_digital_object),
-             exemplary_file_set: create(:curator_filestreams_image))
-    end
+    let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
     let(:file_set) { exemplary_image_mapping.exemplary_file_set }
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(file_set) }

--- a/spec/indexers/curator/institution_indexer_spec.rb
+++ b/spec/indexers/curator/institution_indexer_spec.rb
@@ -7,28 +7,29 @@ RSpec.describe Curator::InstitutionIndexer do
     let(:institution) { create(:curator_institution) }
     let(:indexed) { indexer.map_record(institution) }
 
-    it 'sets the title fields correctly' do
+    it 'sets the title fields' do
       expect(indexed['title_info_primary_tsi']).to eq [institution.name]
       expect(
         indexed['title_info_primary_ssort']
       ).to eq [Curator::Parsers::InputParser.get_proper_title(institution.name).last]
     end
 
-    it 'sets the physical location field correctly' do
+    it 'sets the physical location field' do
       expect(indexed['physical_location_ssim']).to eq [institution.name]
     end
 
-    it 'sets the abstract field correctly' do
+    it 'sets the abstract field' do
       expect(indexed['abstract_tsi']).to eq [institution.abstract]
     end
 
-    it 'sets the uri field correctly' do
+    it 'sets the uri field' do
       expect(indexed['institution_url_ss']).to eq [institution.url]
     end
 
-    it 'sets the genre fields correctly' do
-      expect(indexed['genre_basic_ssim']).to eq [institution.class.name.demodulize]
-      expect(indexed['genre_basic_tsim']).to eq [institution.class.name.demodulize]
+    it 'sets the genre fields' do
+      %w(genre_basic_ssim genre_basic_tsim).each do |field|
+        expect(indexed[field]).to eq [institution.class.name.demodulize]
+      end
     end
   end
 end

--- a/spec/models/curator/collection_spec.rb
+++ b/spec/models/curator/collection_spec.rb
@@ -6,6 +6,7 @@ require_relative './shared/metastreamable'
 require_relative './shared/optimistic_lockable'
 require_relative './shared/timestampable'
 require_relative './shared/archivable'
+require_relative './shared/mappings/has_exemplary_file_set'
 
 RSpec.describe Curator::Collection, type: :model do
   subject { create(:curator_collection) }
@@ -37,4 +38,6 @@ RSpec.describe Curator::Collection, type: :model do
         inverse_of(:collection).
         class_name('Curator::Mappings::CollectionMember').dependent(:destroy) }
   end
+
+  it_behaves_like 'has_exemplary_file_set'
 end

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -6,6 +6,7 @@ require_relative './shared/metastreamable'
 require_relative './shared/optimistic_lockable'
 require_relative './shared/timestampable'
 require_relative './shared/archivable'
+require_relative './shared/mappings/has_exemplary_file_set'
 
 RSpec.describe Curator::DigitalObject, type: :model do
   subject { create(:curator_digital_object) }
@@ -95,4 +96,12 @@ RSpec.describe Curator::DigitalObject, type: :model do
         source(:digital_object).
         class_name('Curator::DigitalObject') }
   end
+
+  describe '#institution' do
+    it 'returns the parent Institution' do
+      expect(subject.institution).to be_an_instance_of Curator::Institution
+    end
+  end
+
+  it_behaves_like 'has_exemplary_file_set'
 end

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe Curator::DigitalObject, type: :model do
         class_name('Curator::Collection').
         required }
 
+    it { is_expected.to have_one(:institution).
+        through(:admin_set).class_name('Curator::Institution') }
+
     ########### FILE SETS ##################
     it { is_expected.to have_many(:audio_file_sets).
         inverse_of(file_set_options[:inverse_of]).
@@ -95,12 +98,6 @@ RSpec.describe Curator::DigitalObject, type: :model do
         through(:issue_mapping_for).
         source(:digital_object).
         class_name('Curator::DigitalObject') }
-  end
-
-  describe '#institution' do
-    it 'returns the parent Institution' do
-      expect(subject.institution).to be_an_instance_of Curator::Institution
-    end
   end
 
   it_behaves_like 'has_exemplary_file_set'

--- a/spec/models/curator/mappings/exemplary_image_spec.rb
+++ b/spec/models/curator/mappings/exemplary_image_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Curator::Mappings::ExemplaryImage, type: :model do
 
   it { is_expected.to have_db_index([:exemplary_file_set_id, :exemplary_file_set_type, :exemplary_object_id, :exemplary_object_type]).unique(true) }
 
+  it { is_expected.to validate_uniqueness_of(:exemplary_object_id).on(:create) }
+
   it { is_expected.to validate_uniqueness_of(:exemplary_file_set_id).
                       scoped_to([:exemplary_file_set_type, :exemplary_object_type, :exemplary_object_id]).
                       on(:create) }

--- a/spec/models/curator/metastreams/workflow_spec.rb
+++ b/spec/models/curator/metastreams/workflow_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Curator::Metastreams::Workflow, type: :model do
                       backed_by_column_of_type(:integer) }
 
   it { is_expected.to define_enum_for(:processing_state).
-                      with_values(dervivatives: 0, complete: 1).
+                      with_values(derivatives: 0, complete: 1).
                       backed_by_column_of_type(:integer) }
 
   describe 'Associations' do

--- a/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
+++ b/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
@@ -2,15 +2,12 @@
 
 RSpec.shared_examples 'has_exemplary_file_set', type: :model do
   describe '#exemplary_file_set' do
-    before do
-      @exemplary_file_set = create(:curator_filestreams_image)
-      exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: subject,
-                                                                exemplary_file_set: @exemplary_file_set)
-      exemplary_mapping.save!
-    end
-
     it 'returns the exemplary FileSet' do
-      expect(subject.exemplary_file_set.ark_id).to eq @exemplary_file_set.ark_id
+      exemplary_file_set = create(:curator_filestreams_image)
+      exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: subject,
+                                                                exemplary_file_set: exemplary_file_set)
+      exemplary_mapping.save!
+      expect(subject.exemplary_file_set.ark_id).to eq exemplary_file_set.ark_id
     end
   end
 end

--- a/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
+++ b/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'has_exemplary_file_set', type: :model do
+  describe '#exemplary_file_set' do
+    before do
+      @exemplary_file_set = create(:curator_filestreams_image)
+      exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: subject,
+                                                                exemplary_file_set: @exemplary_file_set)
+      exemplary_mapping.save!
+    end
+
+    it 'returns the exemplary FileSet' do
+      expect(subject.exemplary_file_set.ark_id).to eq @exemplary_file_set.ark_id
+    end
+  end
+end


### PR DESCRIPTION
* adds basic Solr indexing functionality for:
  * `Curator::Collection`
  * `Curator::DigitalObject`
  * `Curator::Filestreams::FileSet`
  * `Curator::Metastreams::Workflow `
  * `Curator::Metastreams::Administrative`

* adds some convenience methods to model classes to make indexing of associations easier

* specs for everything

* `traject` is updated to `3.3.0` to support indexing via included modules

(_Note:_ There are still a lot of TODOs for indexing (most notably `Curator::Metastreams::Descriptive`), going to submit PRs for this in stages to make review easier.)