### PR TITLE
descriptive metastream indexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
   postgresql: "9.6"
 
 before_install:
-  - gem update --system
+  - gem update --system 3.0.6
   - gem install bundler
 
 rvm:

--- a/app/indexers/concerns/curator/indexer/cartographic_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/cartographic_indexer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module CartographicIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field 'scale_tsim', obj_extract('descriptive', 'cartographic', 'scale')
+          to_field 'projection_tsi', obj_extract('descriptive', 'cartographic', 'projection')
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/date_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/date_indexer.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module DateIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            date_fields = %w(date_start_tsim date_end_tsim date_facet_yearly_ssim date_type_ssm
+                             date_start_qualifier_ssm date_edtf_ssim)
+            date_fields.each do |field|
+              context.output_hash[field] ||= []
+            end
+
+            dates_static = []
+            dates_start = []
+            dates_end = []
+
+            # iterate over date values, send them to #edtf_date_parser
+            mods_date_accessors = { created: 'dateCreated', issued: 'dateIssued', copyright: 'copyrightDate' }
+            mods_date_accessors.each do |k, v|
+              next unless record.descriptive.date.send(k)
+              context.output_hash['date_type_ssm'] << v
+              edtf_date = record.descriptive.date.send(k)
+              context.output_hash['date_edtf_ssim'] << edtf_date
+              parsed_date = edtf_date_parser(edtf_date)
+              dates_static << parsed_date[:static] if parsed_date[:static]
+              if parsed_date[:start] || parsed_date[:end]
+                dates_start << parsed_date[:start]
+                dates_end << parsed_date[:end]
+              end
+              context.output_hash['date_start_qualifier_ssm'] << parsed_date[:qualifier]
+            end
+
+            # push the parsed date values as-is into text fields for display
+            dates_static.each do |static_date|
+              context.output_hash['date_start_tsim'] << static_date
+              context.output_hash['date_end_tsim'] << 'nil' # hacky, but can't assign null in Solr
+            end
+            dates_start.each_with_index do |start_date, index|
+              context.output_hash['date_start_tsim'] << (start_date || 'unknown')
+              context.output_hash['date_end_tsim'] << (dates_end[index] || 'open')
+            end
+
+            # set the date ranges for date-time fields and yearly faceting
+            sorted_start_dates = (dates_static + dates_start.compact).sort
+            earliest_date = sorted_start_dates.first
+            date_facet_start = earliest_date[0..3].to_i
+            latest_date = dates_end.compact.sort.reverse.first
+
+            # set earliest date (date_start_dtsi)
+            start_date_suffix = 'T00:00:00.000Z'
+            if earliest_date.match?(/[0-9]{4}[0-9-]*\z/) # rough date format matching
+              start_date_for_index = if earliest_date.length == 4
+                                       "#{earliest_date}-01-01#{start_date_suffix}"
+                                     elsif earliest_date.length == 7
+                                       "#{earliest_date}-01#{start_date_suffix}"
+                                     elsif earliest_date.length > 11
+                                       earliest_date
+                                     else
+                                       "#{earliest_date}#{start_date_suffix}"
+                                     end
+              context.output_hash['date_start_dtsi'] = [start_date_for_index]
+            end
+
+            # set latest date (date_end_dtsi)
+            end_date_suffix = 'T23:59:59.999Z'
+            if latest_date && latest_date.match?(/[0-9]{4}[0-9-]*\z/)
+              date_facet_end = latest_date[0..3].to_i
+              end_date_for_index = if latest_date.length == 4
+                                     "#{latest_date}-12-31#{end_date_suffix}"
+                                   elsif latest_date.length == 7
+                                     "#{latest_date}-#{last_day_of_month(latest_date)}#{end_date_suffix}"
+                                   elsif latest_date.length > 11
+                                     latest_date
+                                   else
+                                     "#{latest_date}#{end_date_suffix}"
+                                   end
+              context.output_hash['date_end_dtsi'] = [end_date_for_index]
+            else
+              date_facet_end = 0
+              latest_start_date = sorted_start_dates.last
+              if latest_start_date.match?(/[0-9]{4}[0-9-]*\z/)
+                end_date_for_index = if latest_start_date.length == 4
+                                       "#{latest_start_date}-12-31#{end_date_suffix}"
+                                     elsif latest_start_date.length == 7
+                                       "#{latest_start_date}-#{last_day_of_month(latest_start_date)}#{end_date_suffix}"
+                                     elsif latest_start_date.length > 11
+                                       latest_start_date
+                                     else
+                                       "#{latest_start_date}#{end_date_suffix}"
+                                     end
+                context.output_hash['date_end_dtsi'] = [end_date_for_index]
+              end
+            end
+
+            # yearly faceting, starting with year 0 AD
+            (0..(Time.now.year + 2)).step(1) do |index|
+              if (date_facet_start >= index && date_facet_start < index + 1) ||
+                 (date_facet_end != -1 && index > date_facet_start && date_facet_end >= index)
+                context.output_hash['date_facet_yearly_ssim'] << index.to_s
+              end
+            end
+          end
+        end
+
+        ##
+        # TODO: deal with inferred dates
+        # takes an EDTF-formatted date string and returns a hash of MODS-y date values
+        # we support "/1945" (unknown start) and "1945/.." (open end)
+        # @param edtf_date_string [String]
+        # @return [Hash] { static: '', start: '', end: '', qualifier: '' }
+        def edtf_date_parser(edtf_date_string)
+          date_hash = { static: nil, start: nil, end: nil, qualifier: nil }
+          range = edtf_date_string.match?(/\//) ? true : false
+          split_range = edtf_date_string.split('/')
+          date_hash[:qualifier] = 'questionable' if split_range[0].match?(/\?/)
+          date_hash[:qualifier] = 'approximate' if split_range[0].match?(/~/)
+          if range
+            date_hash[:start] = remove_edtf_qualifier(split_range[0]).presence
+            date_hash[:end] = remove_edtf_qualifier(split_range[1]).presence
+          else
+            date_hash[:static] = remove_edtf_qualifier(split_range[0])
+          end
+          date_hash
+        end
+
+        ##
+        # remove EDTF qualifiers from date values: %w(? ~ ..)
+        # @param edtf_date_string [String]
+        # @return [String]
+        def remove_edtf_qualifier(edtf_date_string)
+          edtf_date_string.gsub(/(\?|~|\.\.)/, '')
+        end
+
+        ##
+        # return the last day for the given year and month
+        # @param year_plus_month [String] YYYY-MM
+        # @return [String] last day as two digits
+        def last_day_of_month(year_plus_month)
+          split_date = year_plus_month.split('-')
+          Date.new(split_date[0].to_i, split_date[1].to_i).end_of_month.day.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/date_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/date_indexer.rb
@@ -7,8 +7,8 @@ module Curator
       included do
         configure do
           each_record do |record, context|
-            date_fields = %w(date_start_tsim date_end_tsim date_facet_yearly_ssim date_type_ssm
-                             date_start_qualifier_ssm date_edtf_ssim)
+            date_fields = %w(date_start_tsim date_end_tsim date_facet_yearly_itim date_type_ssm
+                             date_start_qualifier_ssm date_edtf_ssm)
             date_fields.each do |field|
               context.output_hash[field] ||= []
             end
@@ -23,7 +23,7 @@ module Curator
               next unless record.descriptive.date.send(k)
               context.output_hash['date_type_ssm'] << v
               edtf_date = record.descriptive.date.send(k)
-              context.output_hash['date_edtf_ssim'] << edtf_date
+              context.output_hash['date_edtf_ssm'] << edtf_date
               parsed_date = edtf_date_parser(edtf_date)
               dates_static << parsed_date[:static] if parsed_date[:static]
               if parsed_date[:start] || parsed_date[:end]
@@ -99,7 +99,7 @@ module Curator
             (0..(Time.now.year + 2)).step(1) do |index|
               if (date_facet_start >= index && date_facet_start < index + 1) ||
                  (date_facet_end != -1 && index > date_facet_start && date_facet_end >= index)
-                context.output_hash['date_facet_yearly_ssim'] << index.to_s
+                context.output_hash['date_facet_yearly_itim'] << index.to_s
               end
             end
           end

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -5,9 +5,14 @@ module Curator
     module DescriptiveIndexer
       extend ActiveSupport::Concern
       include Curator::Indexer::GenreIndexer
+      include Curator::Indexer::NameRoleIndexer
       include Curator::Indexer::RelatedItemIndexer
+      include Curator::Indexer::PhysicalLocationIndexer
       include Curator::Indexer::IdentifierIndexer
       include Curator::Indexer::NoteIndexer
+      include Curator::Indexer::PublicationIndexer
+      include Curator::Indexer::CartographicIndexer
+      include Curator::Indexer::RightsLicenseIndexer
       included do
         configure do
           to_field 'digital_origin_ssi', obj_extract('descriptive', 'digital_origin')
@@ -23,6 +28,9 @@ module Curator
           to_field 'resource_type_manuscript_bsi', obj_extract('descriptive', 'resource_type_manuscript')
           to_field 'type_of_resource_ssim' do |record, accumulator|
             record.descriptive.resource_types.each { |type| accumulator << type.label }
+          end
+          to_field 'lang_term_ssim' do |record, accumulator|
+            record.descriptive.languages.each { |lang| accumulator << lang.label }
           end
         end
       end

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module DescriptiveIndexer
+      extend ActiveSupport::Concern
+      include Curator::Indexer::GenreIndexer
+      include Curator::Indexer::RelatedItemIndexer
+      include Curator::Indexer::IdentifierIndexer
+      include Curator::Indexer::NoteIndexer
+      included do
+        configure do
+          to_field 'digital_origin_ssi', obj_extract('descriptive', 'digital_origin')
+          to_field 'extent_tsi', obj_extract('descriptive', 'extent')
+          to_field 'abstract_tsi', obj_extract('descriptive', 'abstract')
+          to_field 'table_of_contents_tsi', obj_extract('descriptive', 'toc')
+          to_field 'table_of_contents_url_ss', obj_extract('descriptive', 'toc_url')
+          to_field 'publisher_tsi', obj_extract('descriptive', 'publisher')
+          to_field 'pubplace_tsi', obj_extract('descriptive', 'place_of_publication')
+          to_field 'issuance_tsi', obj_extract('descriptive', 'issuance')
+          to_field 'frequency_tsi', obj_extract('descriptive', 'frequency')
+          to_field 'text_direction_ssi', obj_extract('descriptive', 'text_direction')
+          to_field 'resource_type_manuscript_bsi', obj_extract('descriptive', 'resource_type_manuscript')
+          to_field 'type_of_resource_ssim' do |record, accumulator|
+            record.descriptive.resource_types.each { |type| accumulator << type.label }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -29,13 +29,13 @@ module Curator
           to_field 'text_direction_ssi', obj_extract('descriptive', 'text_direction')
           to_field 'resource_type_manuscript_bsi', obj_extract('descriptive', 'resource_type_manuscript')
           to_field 'type_of_resource_ssim' do |record, accumulator|
-            record.descriptive.resource_types.each do
-              |type| accumulator << type.label
+            record.descriptive.resource_types.each do |type|
+              accumulator << type.label
             end if record.descriptive&.resource_types
           end
           to_field 'lang_term_ssim' do |record, accumulator|
-            record.descriptive.languages.each do
-              |lang| accumulator << lang.label
+            record.descriptive.languages.each do |lang|
+              accumulator << lang.label
             end if record.descriptive&.languages
           end
         end

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -29,10 +29,14 @@ module Curator
           to_field 'text_direction_ssi', obj_extract('descriptive', 'text_direction')
           to_field 'resource_type_manuscript_bsi', obj_extract('descriptive', 'resource_type_manuscript')
           to_field 'type_of_resource_ssim' do |record, accumulator|
-            record.descriptive.resource_types.each { |type| accumulator << type.label }
+            record.descriptive.resource_types.each do
+              |type| accumulator << type.label
+            end if record.descriptive&.resource_types
           end
           to_field 'lang_term_ssim' do |record, accumulator|
-            record.descriptive.languages.each { |lang| accumulator << lang.label }
+            record.descriptive.languages.each do
+              |lang| accumulator << lang.label
+            end if record.descriptive&.languages
           end
         end
       end

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -4,6 +4,7 @@ module Curator
   class Indexer < Traject::Indexer
     module DescriptiveIndexer
       extend ActiveSupport::Concern
+      include Curator::Indexer::TitleIndexer
       include Curator::Indexer::GenreIndexer
       include Curator::Indexer::DateIndexer
       include Curator::Indexer::NameRoleIndexer

--- a/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/descriptive_indexer.rb
@@ -5,6 +5,7 @@ module Curator
     module DescriptiveIndexer
       extend ActiveSupport::Concern
       include Curator::Indexer::GenreIndexer
+      include Curator::Indexer::DateIndexer
       include Curator::Indexer::NameRoleIndexer
       include Curator::Indexer::RelatedItemIndexer
       include Curator::Indexer::PhysicalLocationIndexer

--- a/app/indexers/concerns/curator/indexer/genre_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/genre_indexer.rb
@@ -7,6 +7,8 @@ module Curator
       included do
         configure do
           each_record do |record, context|
+            next unless record.descriptive&.genres
+
             %w(genre_basic_tim genre_basic_ssim genre_specific_tim genre_specific_ssim).each do |field|
               context.output_hash[field] ||= []
             end

--- a/app/indexers/concerns/curator/indexer/genre_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/genre_indexer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module GenreIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            %w(genre_basic_tim genre_basic_ssim genre_specific_tim genre_specific_ssim).each do |field|
+              context.output_hash[field] ||= []
+            end
+            record.descriptive.genres.each do |genre|
+              label = genre.label
+              if genre.basic
+                %w(genre_basic_tim genre_basic_ssim).each do |basic_field|
+                  context.output_hash[basic_field] << label
+                end
+              else
+                %w(genre_specific_tim genre_specific_ssim).each do |specific_field|
+                  context.output_hash[specific_field] << label
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/identifier_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/identifier_indexer.rb
@@ -7,6 +7,8 @@ module Curator
       included do
         configure do
           each_record do |record, context|
+            next unless record.descriptive&.identifier
+
             id_fields = %w(identifier_local_other_tsim identifier_local_other_invalid_tsim
                            identifier_local_call_tsim identifier_local_call_invalid_tsim
                            identifier_local_barcode_tsim identifier_local_barcode_invalid_tsim

--- a/app/indexers/concerns/curator/indexer/identifier_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/identifier_indexer.rb
@@ -22,7 +22,7 @@ module Curator
                 context.output_hash["identifier_#{id_type}_invalid_tsim"] << label
               else
                 id_field = case id_type
-                           when 'ia_id'
+                           when 'internet-archive'
                              'identifier_ia_id_ssi'
                            when 'uri'
                              'identifier_uri_ss'

--- a/app/indexers/concerns/curator/indexer/identifier_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/identifier_indexer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module IdentifierIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            id_fields = %w(identifier_local_other_tsim identifier_local_other_invalid_tsim
+                           identifier_local_call_tsim identifier_local_call_invalid_tsim
+                           identifier_local_barcode_tsim identifier_local_barcode_invalid_tsim
+                           identifier_local_accession_tsim identifier_isbn_tsim identifier_lccn_tsim
+                           identifier_ia_id_ssi identifier_uri_ss)
+            id_fields.each { |field| context.output_hash[field] ||= [] }
+            record.descriptive.identifier.each do |identifier|
+              label = identifier.label
+              id_type = identifier.type.underscore
+              if identifier.invalid
+                context.output_hash["identifier_#{id_type}_invalid_tsim"] << label
+              else
+                id_field = case id_type
+                           when 'ia_id'
+                             'identifier_ia_id_ssi'
+                           when 'uri'
+                             'identifier_uri_ss'
+                           else
+                             "identifier_#{id_type}_tsim"
+                           end
+                context.output_hash[id_field] << label
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/name_role_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/name_role_indexer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module NameRoleIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            name_fields = %w(name_tsim name_role_tsim name_facet_ssim)
+            name_fields.each { |field| context.output_hash[field] ||= [] }
+            record.descriptive.name_roles.each do |name_role|
+              name = name_role.name&.label
+              context.output_hash['name_tsim'] << name
+              context.output_hash['name_facet_ssim'] << name
+              context.output_hash['name_role_tsim'] << name_role.role&.label
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/name_role_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/name_role_indexer.rb
@@ -7,6 +7,8 @@ module Curator
       included do
         configure do
           each_record do |record, context|
+            next unless record.descriptive&.name_roles
+
             name_fields = %w(name_tsim name_role_tsim name_facet_ssim)
             name_fields.each { |field| context.output_hash[field] ||= [] }
             record.descriptive.name_roles.each do |name_role|

--- a/app/indexers/concerns/curator/indexer/note_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/note_indexer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module NoteIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            note_fields = %w(arrangement resp performers acquisition ownership citation reference venue
+                             physical date language funding biographical publication credits)
+            note_fields.each { |field| context.output_hash["note_#{field}_tsim"] ||= [] }
+            context.output_hash['note_tsim'] ||= []
+            record.descriptive.note.each do |note|
+              label = note.label
+              note_type = note.type
+              note_field = case note_type
+                           when 'biographical/historical'
+                             'biographical'
+                           when 'citation/reference'
+                             'reference'
+                           when 'preferred citation'
+                             'citation'
+                           when 'creation/production credits'
+                             'credits'
+                           when 'physical-description'
+                             'physical'
+                           when 'statement of responsibility'
+                             'resp'
+                           else
+                             note_type
+                           end
+              if note_type
+                context.output_hash["note_#{note_field}_tsim"] << label
+              else
+                context.output_hash['note_tsim'] << label
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/note_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/note_indexer.rb
@@ -7,6 +7,8 @@ module Curator
       included do
         configure do
           each_record do |record, context|
+            next unless record.descriptive&.note
+
             note_fields = %w(arrangement resp performers acquisition ownership citation reference venue
                              physical date language funding biographical publication credits)
             note_fields.each { |field| context.output_hash["note_#{field}_tsim"] ||= [] }

--- a/app/indexers/concerns/curator/indexer/physical_location_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/physical_location_indexer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module PhysicalLocationIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field %w(physical_location_ssim physical_location_tim),
+                   obj_extract('descriptive', 'physical_location', 'label')
+          to_field 'sub_location_tsi', obj_extract('descriptive', 'physical_location_department')
+          to_field 'shelf_locator_tsi', obj_extract('descriptive', 'physical_location_shelf_locator')
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/publication_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/publication_indexer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module PublicationIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field 'volume_tsi', obj_extract('descriptive', 'publication', 'volume')
+          to_field 'edition_name_tsi', obj_extract('descriptive', 'publication', 'edition_name')
+          to_field 'edition_number_tsi', obj_extract('descriptive', 'publication', 'edition_number')
+          to_field 'issue_number_tsi', obj_extract('descriptive', 'publication', 'issue_number')
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/related_item_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/related_item_indexer.rb
@@ -7,7 +7,9 @@ module Curator
       included do
         configure do
           to_field %w(related_item_host_tim related_item_host_ssim) do |record, accumulator|
-            record.descriptive.host_collections.each { |hcol| accumulator << hcol.name }
+            record.descriptive.host_collections.each do
+              |hcol| accumulator << hcol.name
+            end if record.descriptive&.host_collections
           end
           to_field %w(related_item_series_tim related_item_series_ssim), obj_extract('descriptive', 'series')
           to_field %w(related_item_subseries_tim related_item_subseries_ssim), obj_extract('descriptive', 'subseries')

--- a/app/indexers/concerns/curator/indexer/related_item_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/related_item_indexer.rb
@@ -7,13 +7,13 @@ module Curator
       included do
         configure do
           to_field %w(related_item_host_tim related_item_host_ssim) do |record, accumulator|
-            record.descriptive.host_collections.each do
-              |hcol| accumulator << hcol.name
+            record.descriptive.host_collections.each do |hcol|
+              accumulator << hcol.name
             end if record.descriptive&.host_collections
           end
-          to_field %w(related_item_series_tim related_item_series_ssim), obj_extract('descriptive', 'series')
-          to_field %w(related_item_subseries_tim related_item_subseries_ssim), obj_extract('descriptive', 'subseries')
-          to_field %w(related_item_subsubseries_tim related_item_subsubseries_ssim), obj_extract('descriptive', 'subsubseries')
+          to_field %w(related_item_series_ti related_item_series_ssi), obj_extract('descriptive', 'series')
+          to_field %w(related_item_subseries_ti related_item_subseries_ssi), obj_extract('descriptive', 'subseries')
+          to_field %w(related_item_subsubseries_ti related_item_subsubseries_ssi), obj_extract('descriptive', 'subsubseries')
           to_field 'related_item_constituent_tsim', obj_extract('descriptive', 'related', 'constituent')
           to_field 'related_item_isreferencedby_ssm', obj_extract('descriptive', 'related', 'referenced_by_url')
         end

--- a/app/indexers/concerns/curator/indexer/related_item_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/related_item_indexer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module RelatedItemIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field %w(related_item_host_tim related_item_host_ssim) do |record, accumulator|
+            record.descriptive.host_collections.each { |hcol| accumulator << hcol.name }
+          end
+          to_field %w(related_item_series_tim related_item_series_ssim), obj_extract('descriptive', 'series')
+          to_field %w(related_item_subseries_tim related_item_subseries_ssim), obj_extract('descriptive', 'subseries')
+          to_field %w(related_item_subsubseries_tim related_item_subsubseries_ssim), obj_extract('descriptive', 'subsubseries')
+          to_field 'related_item_constituent_tsim', obj_extract('descriptive', 'related', 'constituent')
+          to_field 'related_item_isreferencedby_ssm', obj_extract('descriptive', 'related', 'referenced_by_url')
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
@@ -9,6 +9,8 @@ module Curator
           to_field 'rights_ss', obj_extract('descriptive', 'rights')
           to_field 'restrictions_on_access_ss', obj_extract('descriptive', 'access_restrictions')
           each_record do |record, context|
+            next unless record.descriptive&.licenses
+
             license_fields = %w(license_ssm reuse_allowed_ssi)
             license_fields.each { |field| context.output_hash[field] ||= [] }
             record.descriptive.licenses.each do |license|

--- a/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module RightsLicenseIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          to_field 'rights_ss', obj_extract('descriptive', 'rights')
+          to_field 'restrictions_on_access_ss', obj_extract('descriptive', 'access_restrictions')
+          each_record do |record, context|
+            license_fields = %w(license_ssm reuse_allowed_ssi)
+            license_fields.each { |field| context.output_hash[field] ||= [] }
+            record.descriptive.licenses.each do |license|
+              license_text = license.label
+              reuse = if license_text.downcase.include?('public domain') ||
+                         license_text.downcase.include?('no known restrictions')
+                        'no restrictions'
+                      elsif license_text.downcase.include?('creative commons')
+                        'creative commons'
+                      elsif license_text.downcase.include?('contact host')
+                        'contact host'
+                      elsif license_text.downcase.include?('all rights reserved')
+                        'all rights reserved'
+                      end
+              context.output_hash['license_ssm'] << license_text
+              context.output_hash['reuse_allowed_ssi'] << reuse
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
@@ -11,7 +11,7 @@ module Curator
           each_record do |record, context|
             next unless record.descriptive&.licenses
 
-            license_fields = %w(license_ssm reuse_allowed_ssi)
+            license_fields = %w(license_ssm license_uri_ssm reuse_allowed_ssi)
             license_fields.each { |field| context.output_hash[field] ||= [] }
             record.descriptive.licenses.each do |license|
               license_text = license.label
@@ -27,6 +27,7 @@ module Curator
                       end
               context.output_hash['license_ssm'] << license_text
               context.output_hash['reuse_allowed_ssi'] << reuse
+              context.output_hash['license_uri_ssm'] << license.uri
             end
           end
         end

--- a/app/indexers/concerns/curator/indexer/title_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/title_indexer.rb
@@ -10,19 +10,21 @@ module Curator
           to_field 'title_info_primary_tsi', obj_extract('descriptive', 'title', 'primary', 'label')
           to_field 'title_info_primary_ssort' do |record, accumulator|
             accumulator << Curator::Parsers::InputParser.get_proper_title(
-              record.descriptive.title&.primary&.label
-            ).last
+              record.descriptive.title.primary&.label
+            ).last if record.descriptive&.title
           end
           to_field 'title_info_partnum_tsi', obj_extract('descriptive', 'title', 'primary', 'part_number')
           to_field 'title_info_partname_tsi', obj_extract('descriptive', 'title', 'primary', 'part_name')
           to_field 'title_info_primary_subtitle_tsi', obj_extract('descriptive', 'title', 'primary', 'subtitle')
           # other title fields
           each_record do |record, context|
+            next unless record.descriptive&.title
+
             multival_title_fields = %w(title_info_primary_trans_tsim title_info_translated_tsim
                                        title_info_alternative_tsim title_info_uniform_tsim title_info_uniform_ssim
                                        title_info_alternative_label_ssm title_info_other_subtitle_tsim)
             multival_title_fields.each { |field| context.output_hash[field] ||= [] }
-            record.descriptive.title&.other&.each do |other_title|
+            record.descriptive.title.other&.each do |other_title|
               title_field = if other_title.type == 'translated'
                               other_title.usage == 'primary' ? ['title_info_primary_trans_tsim'] : ['title_info_translated_tsim']
                             elsif other_title.type == 'alternative' || other_title.type == 'abbreviated'

--- a/app/indexers/concerns/curator/indexer/title_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/title_indexer.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module TitleIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          # primary title fields
+          to_field 'title_info_primary_tsi', obj_extract('descriptive', 'title', 'primary', 'label')
+          to_field 'title_info_primary_ssort' do |record, accumulator|
+            accumulator << Curator::Parsers::InputParser.get_proper_title(
+              record.descriptive.title&.primary&.label
+            ).last
+          end
+          to_field 'title_info_partnum_tsi', obj_extract('descriptive', 'title', 'primary', 'part_number')
+          to_field 'title_info_partname_tsi', obj_extract('descriptive', 'title', 'primary', 'part_name')
+          to_field 'title_info_primary_subtitle_tsi', obj_extract('descriptive', 'title', 'primary', 'subtitle')
+          # other title fields
+          each_record do |record, context|
+            multival_title_fields = %w(title_info_primary_trans_tsim title_info_translated_tsim
+                                       title_info_alternative_tsim title_info_uniform_tsim title_info_uniform_ssim
+                                       title_info_alternative_label_ssm title_info_other_subtitle_tsim)
+            multival_title_fields.each { |field| context.output_hash[field] ||= [] }
+            record.descriptive.title&.other&.each do |other_title|
+              title_field = if other_title.type == 'translated'
+                              other_title.usage == 'primary' ? ['title_info_primary_trans_tsim'] : ['title_info_translated_tsim']
+                            elsif other_title.type == 'alternative' || other_title.type == 'abbreviated'
+                              ['title_info_alternative_tsim']
+                            elsif other_title.type == 'uniform'
+                              %w(title_info_uniform_tsim title_info_uniform_ssim)
+                            else
+                              raise "WEIRD TITLE TYPE (#{other_title.type}) FOUND FOR DIGITAL OBJECT #{record.ark_id}"
+                            end
+              title_field.each { |t| context.output_hash[t] << other_title.label }
+              context.output_hash['title_info_alternative_label_ssm'] << other_title.display
+              context.output_hash['title_info_other_subtitle_tsim'] << other_title.subtitle
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -10,7 +10,8 @@ module Curator
 
     # NOTE: fields below were previously set in Bplmodels::Collection#to_solr, but have been updated:
     #   institution_pid_ssi->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
-    #   institution_name_tsim->institution_name_tsi genre_basic_tsim->genre_basic_tim
+    #   institution_name_tsim->institution_name_ti genre_basic_tsim->genre_basic_tim
+    #   physical_location_tsim->physical_location_tim
 
     # TODO: add indexing for:
     #         genre_basic_ssim genre_basic_tim edit_access_group_ssim
@@ -20,7 +21,7 @@ module Curator
         accumulator << Curator::Parsers::InputParser.get_proper_title(record.name).last
       end
       to_field 'abstract_tsi', obj_extract('abstract')
-      to_field %w(physical_location_ssim physical_location_tsim institution_name_ssi institution_name_tsi),
+      to_field %w(physical_location_ssim physical_location_tim institution_name_ssi institution_name_ti),
                obj_extract('institution', 'name')
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
 

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -16,8 +16,8 @@ module Curator
     #         genre_basic_ssim genre_basic_tim edit_access_group_ssim
     configure do
       to_field 'title_info_primary_tsi', obj_extract('name')
-      to_field 'title_info_primary_ssort' do |record, accumulator, _context|
-        accumulator << Curator::Parsers::InputParser.get_proper_title(record.send(:name)).last
+      to_field 'title_info_primary_ssort' do |record, accumulator|
+        accumulator << Curator::Parsers::InputParser.get_proper_title(record.name).last
       end
       to_field 'abstract_tsi', obj_extract('abstract')
       to_field %w(physical_location_ssim physical_location_tsim institution_name_ssi institution_name_tsi),
@@ -25,7 +25,7 @@ module Curator
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
 
       to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
-      to_field 'exemplary_image_iiif_bsi' do |record, accumulator, _context|
+      to_field 'exemplary_image_iiif_bsi' do |record, accumulator|
         exemplary_file_set_type = record.exemplary_file_set&.file_set_type
         accumulator << false unless exemplary_file_set_type == 'Curator::Filestreams::Image'
       end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -10,10 +10,10 @@ module Curator
 
     # NOTE: fields below were previously set in Bplmodels::Collection#to_solr, but have been updated:
     #   institution_pid_ssi->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
-    #   institution_name_tsim->institution_name_tsi
+    #   institution_name_tsim->institution_name_tsi genre_basic_tsim->genre_basic_tim
 
     # TODO: add indexing for:
-    #         genre_basic_ssim genre_basic_tsim edit_access_group_ssim
+    #         genre_basic_ssim genre_basic_tim edit_access_group_ssim
     configure do
       to_field 'title_info_primary_tsi', obj_extract('name')
       to_field 'title_info_primary_ssort' do |record, accumulator, _context|

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -7,7 +7,8 @@ module Curator
     include Curator::Indexer::AdministrativeIndexer
 
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but no longer needed(?):
-    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim label_ssim date_facet_ssim
+    #   internet_media_type_ssim classification_tsim label_ssim date_facet_ssim supplied_alternative_title_bs
+    #   supplied_title_bs
     #
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
     #   institution_pid_si->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
@@ -29,15 +30,16 @@ module Curator
     #   related_item_subseries_tsim->related_item_subseries_tim related_item_subsubseries_tsim->related_item_subsubseries_tim
     #   institution_name_tsi->institution_name_ti collection_name_tsim->collection_name_tim
     #   physical_location_tsim->physical_location_tim sub_location_tsim->sub_location_tsi shelf_locator_tsim->shelf_locator_tsi
+    #   date_facet_yearly_ssim->date_facet_yearly_itim subtitle_tsim->title_info_other_subtitle_tsim
+    #
+    # NOTE: fields below are new:
+    #   title_info_primary_subtitle_tsi date_edtf_ssm
 
     # TODO: add indexing for:
     #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi edit_access_group_ssim
     #
     #         DESCRIPTIVE:
-    #         title_info_primary_tsi title_info_primary_ssort title_info_partnum_tsi title_info_partname_tsi
-    #         title_info_primary_trans_tsim title_info_translated_tsim
-    #         title_info_alternative_tsim title_info_uniform_tsim
-    #         supplied_title_bs supplied_alternative_title_bs title_info_alternative_label_ssm subtitle_tsim
+
     #
     #         subject_facet_ssim
     #         subject_topic_tsim

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -28,6 +28,7 @@ module Curator
     #   related_item_host_tsim->related_item_host_tim related_item_series_tsim->related_item_series_tim
     #   related_item_subseries_tsim->related_item_subseries_tim related_item_subsubseries_tsim->related_item_subsubseries_tim
     #   institution_name_tsi->institution_name_ti collection_name_tsim->collection_name_tim
+    #   physical_location_tsim->physical_location_tim sub_location_tsim->sub_location_tsi shelf_locator_tsim->shelf_locator_tsi
 
     # TODO: add indexing for:
     #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi edit_access_group_ssim
@@ -37,15 +38,9 @@ module Curator
     #         title_info_primary_trans_tsim title_info_translated_tsim
     #         title_info_alternative_tsim title_info_uniform_tsim
     #         supplied_title_bs supplied_alternative_title_bs title_info_alternative_label_ssm subtitle_tsim
-    #         physical_location_ssim physical_location_tsim sub_location_tsim shelf_locator_tsim
     #         date_start_dtsi date_start_tsim date_end_dtsi date_end_tsim date_facet_ssim
     #         date_type_ssm date_start_qualifier_ssm
-    #         edition_name_tsi edition_number_tsi volume_tsi issue_number_tsi
-    #         lang_term_ssim
-
-    #         name_tsim name_role_tsim name_facet_ssim
-    #         note_tsim note_resp_tsim note_performers_tsim note_acquisition_tsim note_ownership_tsim
-    #         note_citation_tsim note_reference_tsim note_venue_tsim note_physical_tsim note_date_tsim
+    #
     #         subject_facet_ssim
     #         subject_topic_tsim
     #         subject_date_start_tsim subject_date_start_dtsim subject_date_end_tsim subject_date_end_dtsim
@@ -57,8 +52,6 @@ module Curator
     #         subject_geographic_tsim subject_geographic_ssim
     #         subject_coordinates_geospatial subject_point_geospatial subject_bbox_geospatial
     #         subject_geojson_facet_ssim subject_hiergeo_geojson_ssm subject_geo_nonhier_ssim
-    #         scale_tsim projection_tsi
-    #         rights_ss license_ssm reuse_allowed_ssi restrictions_on_access_ss
     configure do
       to_field 'admin_set_name_ssi', obj_extract('admin_set', 'name')
       to_field 'admin_set_ark_id_ssi', obj_extract('admin_set', 'ark_id')

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -26,14 +26,16 @@ module Curator
     #   rights_ssm->rights_ss restrictions_on_access_ssm->restrictions_on_access_ss
     #   publisher_tsim->publisher_tsi pubplace_tsim->pubplace_tsi abstract_tsim->abstract_tsi
     #   genre_basic_tsim->genre_basic_tim genre_specific_tsim->genre_specific_tim
-    #   related_item_host_tsim->related_item_host_tim related_item_series_tsim->related_item_series_tim
-    #   related_item_subseries_tsim->related_item_subseries_tim related_item_subsubseries_tsim->related_item_subsubseries_tim
+    #   related_item_host_tsim->related_item_host_tim related_item_series_tsim->related_item_series_ti
+    #   related_item_series_ssim->related_item_series_ssi related_item_subseries_ssim->related_item_subseries_ssi
+    #   related_item_subseries_tsim->related_item_subseries_ti related_item_subsubseries_tsim->related_item_subsubseries_ti
+    #   related_item_subsubseries_ssim->related_item_subsubseries_ssi
     #   institution_name_tsi->institution_name_ti collection_name_tsim->collection_name_tim
     #   physical_location_tsim->physical_location_tim sub_location_tsim->sub_location_tsi shelf_locator_tsim->shelf_locator_tsi
     #   date_facet_yearly_ssim->date_facet_yearly_itim subtitle_tsim->title_info_other_subtitle_tsim
     #
     # NOTE: fields below are new:
-    #   title_info_primary_subtitle_tsi date_edtf_ssm
+    #   title_info_primary_subtitle_tsi date_edtf_ssm license_uri_ssm
 
     # TODO: add indexing for:
     #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi edit_access_group_ssim

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -7,7 +7,7 @@ module Curator
     include Curator::Indexer::AdministrativeIndexer
 
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but no longer needed(?):
-    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim label_ssim
+    #   internet_media_type_ssim title_info_uniform_ssim classification_tsim label_ssim date_facet_ssim
     #
     # NOTE: fields below were previously set in Bplmodels::ObjectBase#to_solr, but have been updated:
     #   institution_pid_si->institution_ark_id_ssi institution_name_ssim->institution_name_ssi
@@ -38,8 +38,6 @@ module Curator
     #         title_info_primary_trans_tsim title_info_translated_tsim
     #         title_info_alternative_tsim title_info_uniform_tsim
     #         supplied_title_bs supplied_alternative_title_bs title_info_alternative_label_ssm subtitle_tsim
-    #         date_start_dtsi date_start_tsim date_end_dtsi date_end_tsim date_facet_ssim
-    #         date_type_ssm date_start_qualifier_ssm
     #
     #         subject_facet_ssim
     #         subject_topic_tsim

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -2,6 +2,7 @@
 
 module Curator
   class DigitalObjectIndexer < Curator::Indexer
+    include Curator::Indexer::DescriptiveIndexer
     include Curator::Indexer::WorkflowIndexer
     include Curator::Indexer::AdministrativeIndexer
 
@@ -22,6 +23,11 @@ module Curator
     #   subject_scale_tsim->scale_tsim subject_projection_tsim->projection_tsi
     #   edition_tsim->edition_name_tsim issuance_tsim->issuance_tsi
     #   rights_ssm->rights_ss restrictions_on_access_ssm->restrictions_on_access_ss
+    #   publisher_tsim->publisher_tsi pubplace_tsim->pubplace_tsi abstract_tsim->abstract_tsi
+    #   genre_basic_tsim->genre_basic_tim genre_specific_tsim->genre_specific_tim
+    #   related_item_host_tsim->related_item_host_tim related_item_series_tsim->related_item_series_tim
+    #   related_item_subseries_tsim->related_item_subseries_tim related_item_subsubseries_tsim->related_item_subsubseries_tim
+    #   institution_name_tsi->institution_name_ti collection_name_tsim->collection_name_tim
 
     # TODO: add indexing for:
     #         ocr_tiv has_searchable_text_bsi filenames_ssim is_issue_of_ssim georeferenced_bsi edit_access_group_ssim
@@ -31,26 +37,12 @@ module Curator
     #         title_info_primary_trans_tsim title_info_translated_tsim
     #         title_info_alternative_tsim title_info_uniform_tsim
     #         supplied_title_bs supplied_alternative_title_bs title_info_alternative_label_ssm subtitle_tsim
-    #         genre_basic_tsim genre_basic_ssim genre_specific_tsim genre_specific_ssim
-    #         type_of_resource_ssim resource_type_manuscript_bsi extent_tsi digital_origin_ssi
     #         physical_location_ssim physical_location_tsim sub_location_tsim shelf_locator_tsim
-    #         abstract_tsim table_of_contents_tsi table_of_contents_url_ss
     #         date_start_dtsi date_start_tsim date_end_dtsi date_end_tsim date_facet_ssim
     #         date_type_ssm date_start_qualifier_ssm
-    #         publisher_tsim pubplace_tsim issuance_tsi frequency_tsi
-    #         edition_name_tsi edition_number_tsi volume_tsi issue_number_tsi text_direction_ssi
+    #         edition_name_tsi edition_number_tsi volume_tsi issue_number_tsi
     #         lang_term_ssim
-    #         related_item_constiuent_tsim related_item_constiuent_ssim
-    #         related_item_host_tsim related_item_host_ssim
-    #         related_item_series_tsim related_item_series_ssim
-    #         related_item_subseries_tsim related_item_subseries_ssim
-    #         related_item_subsubseries_tsim related_item_subsubseries_ssim
-    #         related_item_isreferencedby_ssm
-    #         identifier_local_other_tsim identifier_local_other_invalid_tsim
-    #         identifier_local_call_tsim identifier_local_call_invalid_tsim
-    #         identifier_local_barcode_tsim identifier_local_barcode_invalid_tsim
-    #         identifier_local_accession_tsim identifier_isbn_tsim identifier_lccn_tsim
-    #         identifier_ia_id_ssi identifier_uri_ss
+
     #         name_tsim name_role_tsim name_facet_ssim
     #         note_tsim note_resp_tsim note_performers_tsim note_acquisition_tsim note_ownership_tsim
     #         note_citation_tsim note_reference_tsim note_venue_tsim note_physical_tsim note_date_tsim
@@ -70,9 +62,9 @@ module Curator
     configure do
       to_field 'admin_set_name_ssi', obj_extract('admin_set', 'name')
       to_field 'admin_set_ark_id_ssi', obj_extract('admin_set', 'ark_id')
-      to_field %w(institution_name_ssi institution_name_tsi), obj_extract('institution', 'name')
+      to_field %w(institution_name_ssi institution_name_ti), obj_extract('institution', 'name')
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
-      to_field %w(collection_name_ssim collection_name_tsim) do |record, accumulator|
+      to_field %w(collection_name_ssim collection_name_tim) do |record, accumulator|
         record.is_member_of_collection.each { |col| accumulator << col.name }
       end
       to_field 'collection_ark_id_ssim' do |record, accumulator|

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -18,7 +18,7 @@ module Curator
     #         subject_geojson_facet_ssim subject_hiergeo_geojson_ssm
     configure do
       to_field %w(title_info_primary_tsi physical_location_ssim), obj_extract('name')
-      to_field 'title_info_primary_ssort' do |record, accumulator, _context|
+      to_field 'title_info_primary_ssort' do |record, accumulator|
         accumulator << Curator::Parsers::InputParser.get_proper_title(record.name).last
       end
       to_field 'abstract_tsi', obj_extract('abstract')

--- a/app/models/curator/descriptives/field_sets/note.rb
+++ b/app/models/curator/descriptives/field_sets/note.rb
@@ -5,6 +5,6 @@ module Curator
     attr_json :label, :string
     attr_json :type, :string
 
-    validates :type, presence: true, inclusion: { in: Descriptives::NOTE_TYPES }
+    validates :type, allow_blank: true, inclusion: { in: Descriptives::NOTE_TYPES }
   end
 end

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -42,7 +42,7 @@ module Curator
             simple_fields = %i(abstract access_restrictions digital_origin frequency
                                issuance origin_event extent physical_location_department
                                physical_location_shelf_locator place_of_publication
-                               publisher rights series subseries toc toc_url
+                               publisher rights series subseries subsubseries toc toc_url
                                resource_type_manuscript text_direction)
             simple_fields.each do |attr|
               descriptive.send("#{attr}=", @desc_json_attrs.fetch(attr, nil))

--- a/db/migrate/20190919202311_create_curator_metastreams_descriptives.rb
+++ b/db/migrate/20190919202311_create_curator_metastreams_descriptives.rb
@@ -26,6 +26,7 @@ class CreateCuratorMetastreamsDescriptives < ActiveRecord::Migration[5.2]
       t.string :physical_location_shelf_locator
       t.string :series
       t.string :subseries
+      t.string :subsubseries
       t.string :rights
       t.string :access_restrictions
       t.string :toc_url

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_collection, class: 'Curator::Collection' do
     association :institution, factory: :curator_institution
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     name { "#{Faker::FunnyName.four_word_name} Collection" }
     abstract { Faker::Lorem.paragraph }
     archived_at { nil }

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_collection, class: 'Curator::Collection' do
     association :institution, factory: :curator_institution
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     name { "#{Faker::FunnyName.four_word_name} Collection" }
     abstract { Faker::Lorem.paragraph }
     archived_at { nil }

--- a/spec/factories/curator/controlled_terms/genres.rb
+++ b/spec/factories/curator/controlled_terms/genres.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_genre, class: 'Curator::ControlledTerms::Genre' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Genre' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/genres.rb
+++ b/spec/factories/curator/controlled_terms/genres.rb
@@ -4,7 +4,9 @@ FactoryBot.define do
   factory :curator_controlled_terms_genre, class: 'Curator::ControlledTerms::Genre' do
     association :authority, factory: :curator_controlled_terms_authority
     sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+      { label: Faker::Lorem.sentence,
+        id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10),
+        basic: [true, false].sample }
     end
     type { 'Curator::ControlledTerms::Genre' }
     archived_at { nil }

--- a/spec/factories/curator/controlled_terms/geographics.rb
+++ b/spec/factories/curator/controlled_terms/geographics.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_geographic, class: 'Curator::ControlledTerms::Geographic' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Geographic' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/languages.rb
+++ b/spec/factories/curator/controlled_terms/languages.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_language, class: 'Curator::ControlledTerms::Language' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Language' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/licenses.rb
+++ b/spec/factories/curator/controlled_terms/licenses.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_controlled_terms_license, class: 'Curator::ControlledTerms::License' do
-    term_data { { label: Faker::Lorem.sentence, uri: Faker::Internet.url } }
+    sequence(:term_data) { |_n| { label: Faker::Lorem.sentence, uri: Faker::Internet.url } }
     type { 'Curator::ControlledTerms::License' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/names.rb
+++ b/spec/factories/curator/controlled_terms/names.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_name, class: 'Curator::ControlledTerms::Name' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Name' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/resource_types.rb
+++ b/spec/factories/curator/controlled_terms/resource_types.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_resource_type, class: 'Curator::ControlledTerms::ResourceType' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::ResourceType' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/roles.rb
+++ b/spec/factories/curator/controlled_terms/roles.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_role, class: 'Curator::ControlledTerms::Role' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Role' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/subjects.rb
+++ b/spec/factories/curator/controlled_terms/subjects.rb
@@ -3,7 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_subject, class: 'Curator::ControlledTerms::Subject' do
     association :authority, factory: :curator_controlled_terms_authority
-    term_data { { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) } }
+    sequence(:term_data) do |_n|
+      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+    end
     type { 'Curator::ControlledTerms::Subject' }
     archived_at { nil }
   end

--- a/spec/factories/curator/descriptives/field_sets/dates.rb
+++ b/spec/factories/curator/descriptives/field_sets/dates.rb
@@ -2,7 +2,9 @@
 
 FactoryBot.define do
   factory :curator_descriptives_date, class: 'Curator::Descriptives::Date' do
-    created { Faker::Date.birthday(min_age: 95, max_age: 160).to_s }
+    created do
+      "#{Faker::Date.birthday(min_age: 159, max_age: 160).year}/#{Faker::Date.birthday(min_age: 150, max_age: 155).year}?"
+    end
     issued { Faker::Date.birthday(min_age: 80, max_age: 140).to_s }
     copyright { Faker::Date.birthday(min_age: 50, max_age: 90).to_s }
     skip_create

--- a/spec/factories/curator/descriptives/field_sets/identifiers.rb
+++ b/spec/factories/curator/descriptives/field_sets/identifiers.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_descriptives_identifier, class: 'Curator::Descriptives::Identifier' do
     label { Faker::Lorem.sentence(word_count: 3) }
-    type { Curator::Descriptives::IDENTIFIER_TYPES.sample }
+    type { %w(local-other local-call local-barcode).sample }
     invalid { [true, false].sample }
     skip_create
     initialize_with { new(attributes) }

--- a/spec/factories/curator/descriptives/field_sets/notes.rb
+++ b/spec/factories/curator/descriptives/field_sets/notes.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_descriptives_note, class: 'Curator::Descriptives::Note' do
     label { Faker::Lorem.sentence(word_count: 3) }
-    type { Curator::Descriptives::NOTE_TYPES.sample }
+    type { %w(arrangement performers acquisition ownership).sample }
     skip_create
     initialize_with { new(attributes) }
   end

--- a/spec/factories/curator/descriptives/field_sets/titles.rb
+++ b/spec/factories/curator/descriptives/field_sets/titles.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_descriptives_title, class: 'Curator::Descriptives::Title' do
-    label { Faker::Lorem.word }
+    label { "The #{Faker::Lorem.word}" }
     subtitle { Faker::Lorem.sentence }
     display { 'Below Map' }
     display_label { Faker::Lorem.sentence }

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_digital_object, class: 'Curator::DigitalObject' do
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     association :admin_set, factory: :curator_collection
     archived_at { nil }
   end

--- a/spec/factories/curator/filestreams/audios.rb
+++ b/spec/factories/curator/filestreams/audios.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_audio, class: 'Curator::Filestreams::Audio' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Audio' }
     file_name_base { Faker::Music.album }
     position { 1 }

--- a/spec/factories/curator/filestreams/audios.rb
+++ b/spec/factories/curator/filestreams/audios.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_audio, class: 'Curator::Filestreams::Audio' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Audio' }
     file_name_base { Faker::Music.album }
     position { 1 }

--- a/spec/factories/curator/filestreams/documents.rb
+++ b/spec/factories/curator/filestreams/documents.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_document, class: 'Curator::Filestreams::Document' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Document' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/documents.rb
+++ b/spec/factories/curator/filestreams/documents.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_document, class: 'Curator::Filestreams::Document' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Document' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/ereaders.rb
+++ b/spec/factories/curator/filestreams/ereaders.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_ereader, class: 'Curator::Filestreams::Ereader' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Ereader' }
     file_name_base { Faker::Book.publisher }
     position { 1 }

--- a/spec/factories/curator/filestreams/ereaders.rb
+++ b/spec/factories/curator/filestreams/ereaders.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_ereader, class: 'Curator::Filestreams::Ereader' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Ereader' }
     file_name_base { Faker::Book.publisher }
     position { 1 }

--- a/spec/factories/curator/filestreams/images.rb
+++ b/spec/factories/curator/filestreams/images.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_image, class: 'Curator::Filestreams::Image' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Image' }
     file_name_base { Faker::Artist.name }
     position { 1 }

--- a/spec/factories/curator/filestreams/images.rb
+++ b/spec/factories/curator/filestreams/images.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_image, class: 'Curator::Filestreams::Image' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Image' }
     file_name_base { Faker::Artist.name }
     position { 1 }

--- a/spec/factories/curator/filestreams/metadata.rb
+++ b/spec/factories/curator/filestreams/metadata.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_metadata, class: 'Curator::Filestreams::Metadata' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Metadata' }
     file_name_base { Faker::Internet.uuid }
     position { 1 }

--- a/spec/factories/curator/filestreams/metadata.rb
+++ b/spec/factories/curator/filestreams/metadata.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_metadata, class: 'Curator::Filestreams::Metadata' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Metadata' }
     file_name_base { Faker::Internet.uuid }
     position { 1 }

--- a/spec/factories/curator/filestreams/texts.rb
+++ b/spec/factories/curator/filestreams/texts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_text, class: 'Curator::Filestreams::Text' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Text' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/texts.rb
+++ b/spec/factories/curator/filestreams/texts.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_text, class: 'Curator::Filestreams::Text' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Text' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/videos.rb
+++ b/spec/factories/curator/filestreams/videos.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_video, class: 'Curator::Filestreams::Video' do
     association :file_set_of, factory: :curator_digital_object
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     file_set_type { 'Curator::Filestreams::Video' }
     file_name_base { Faker::TvShows::Simpsons.character }
     position { 1 }

--- a/spec/factories/curator/filestreams/videos.rb
+++ b/spec/factories/curator/filestreams/videos.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :curator_filestreams_video, class: 'Curator::Filestreams::Video' do
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     file_set_type { 'Curator::Filestreams::Video' }
     file_name_base { Faker::TvShows::Simpsons.character }
     position { 1 }

--- a/spec/factories/curator/institutions.rb
+++ b/spec/factories/curator/institutions.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_institution, class: 'Curator::Institution' do
-    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
     name { Faker::University.name }
     abstract { Faker::Lorem.paragraph }
     url { Faker::Internet.unique.url(host: 'example.org') }

--- a/spec/factories/curator/institutions.rb
+++ b/spec/factories/curator/institutions.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_institution, class: 'Curator::Institution' do
-    ark_id { "commonwealth:#{SecureRandom.hex(5)}" }
+    sequence(:ark_id) { |_n| "commonwealth:#{SecureRandom.hex(5)}" }
     name { Faker::University.name }
     abstract { Faker::Lorem.paragraph }
     url { Faker::Internet.unique.url(host: 'example.org') }

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
     physical_location_shelf_locator { Faker::Lorem.sentence }
     series { Faker::Lorem.sentence }
     subseries { Faker::Lorem.sentence }
+    subsubseries { Faker::Lorem.sentence }
     rights { Faker::Lorem.sentence }
     access_restrictions { Faker::Lorem.sentence }
     toc_url { Faker::Internet.url }

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -134,6 +134,9 @@
         ],
         "note": [
           {
+            "label": "Generic typeless note"
+          },
+          {
             "label": "Date from accompanying item.",
             "type": "date"
           },

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -217,6 +217,7 @@
         ],
         "series": "Series value the first",
         "subseries": "Subseries value",
+        "subsubseries": "Subsubseries value",
         "physical_location": {
           "label": "Boston Public Library",
           "name_type": "corporate",

--- a/spec/indexers/concerns/curator/indexer/cartographic_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/cartographic_indexer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::CartographicIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::CartographicIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the scale field' do
+      expect(indexed['scale_tsim']).to eq descriptive.cartographic.scale
+    end
+
+    it 'sets the projection field' do
+      expect(indexed['projection_tsi']).to eq [descriptive.cartographic.projection]
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/date_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/date_indexer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::DateIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::DateIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the start date fields' do
+      expect(indexed['date_start_tsim']).not_to be_blank
+      expect(indexed['date_start_tsim'].first).to match(/\A\d{4}/)
+      expect(indexed['date_start_dtsi'].first).to match(/\A\d{4}-\d{2}-\d{2}T00:00:00.000Z\z/)
+    end
+
+    it 'sets the end date fields' do
+      expect(indexed['date_end_tsim']).not_to be_blank
+      expect(indexed['date_end_dtsi'].first).to match(/\A\d{4}-\d{2}-\d{2}T23:59:59.999Z\z/)
+    end
+
+    it 'sets the date_type field' do
+      expect(indexed['date_type_ssm'].first).to match(/dateCreated|dateIssued|copyrightDate/)
+    end
+
+    it 'sets the date_facet_yearly field' do
+      expect(indexed['date_facet_yearly_itim']).not_to be_blank
+      expect(indexed['date_facet_yearly_itim'].map(&:class).uniq.first).to eq Integer
+    end
+
+    it 'sets the date_start_qualifier field' do
+      expect(indexed['date_start_qualifier_ssm'].first).to match(/questionable|approximate|inferred|nil/)
+    end
+
+    it 'sets the date_edtf field' do
+      expect(indexed['date_edtf_ssm']).not_to be_blank
+      expect(indexed['date_edtf_ssm'].first).to match(/\A\d{4}/)
+    end
+
+    describe ''
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/descriptive_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/descriptive_indexer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::DescriptiveIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::DescriptiveIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) do
+      descriptive_ms = create(:curator_metastreams_descriptive)
+      descriptive_ms.resource_types << create(:curator_controlled_terms_resource_type)
+      descriptive_ms.languages << create(:curator_controlled_terms_language)
+      descriptive_ms
+    end
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the digital_origin field' do
+      expect(indexed['digital_origin_ssi']).to eq [descriptive.digital_origin]
+    end
+
+    it 'sets the extent field' do
+      expect(indexed['extent_tsi']).to eq [descriptive.extent]
+    end
+
+    it 'sets the abstract field' do
+      expect(indexed['abstract_tsi']).to eq [descriptive.abstract]
+    end
+
+    it 'sets the table_of_contents field' do
+      expect(indexed['table_of_contents_tsi']).to eq [descriptive.toc]
+    end
+
+    it 'sets the table_of_contents_url field' do
+      expect(indexed['table_of_contents_url_ss']).to eq [descriptive.toc_url]
+    end
+
+    it 'sets the publisher field' do
+      expect(indexed['publisher_tsi']).to eq [descriptive.publisher]
+    end
+
+    it 'sets the pubplace field' do
+      expect(indexed['pubplace_tsi']).to eq [descriptive.place_of_publication]
+    end
+
+    it 'sets the issuance field' do
+      expect(indexed['issuance_tsi']).to eq [descriptive.issuance]
+    end
+
+    it 'sets the frequency field' do
+      expect(indexed['frequency_tsi']).to eq [descriptive.frequency]
+    end
+
+    it 'sets the text_direction field' do
+      expect(indexed['text_direction_ssi']).to eq [descriptive.text_direction]
+    end
+
+    it 'sets the resource_type_manuscript field' do
+      expect(indexed['resource_type_manuscript_bsi']).to eq [descriptive.resource_type_manuscript]
+    end
+
+    it 'sets the type_of_resource field' do
+      expect(indexed['type_of_resource_ssim']).to eq descriptive.resource_types.map(&:label)
+    end
+
+    it 'sets the lang_term field' do
+      expect(indexed['lang_term_ssim']).to eq descriptive.languages.map(&:label)
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/genre_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/genre_indexer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::GenreIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::GenreIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) do
+      descriptive_ms = create(:curator_metastreams_descriptive)
+      create_list(:curator_controlled_terms_genre, 4).each do |genre|
+        descriptive_ms.genres << genre
+      end
+      descriptive_ms
+    end
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the basic genre fields' do
+      basic_genres = descriptive.genres.select { |g| g.basic }.map(&:label)
+      %w(genre_basic_tim genre_basic_ssim).each do |field|
+        expect(indexed[field]).to eq basic_genres
+      end
+    end
+
+    it 'sets the specific genre fields' do
+      specific_genres = descriptive.genres.select { |g| !g.basic }.map(&:label)
+      %w(genre_specific_tim genre_specific_ssim).each do |field|
+        expect(indexed[field]).to eq specific_genres
+      end
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/identifier_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/identifier_indexer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::IdentifierIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::IdentifierIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the identifier fields' do
+      descriptive.identifier.each do |identifier|
+        identifier_field = identifier.type.underscore + (identifier.invalid ? '_invalid' : '')
+        expect(indexed["identifier_#{identifier_field}_tsim"]).to include(identifier.label)
+      end
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/name_role_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/name_role_indexer_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::NameRoleIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::NameRoleIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) do
+      descriptive_ms = create(:curator_metastreams_descriptive)
+      create_list(:curator_mappings_desc_name_role, 2).each do |name_role|
+        descriptive_ms.name_roles << name_role
+      end
+      descriptive_ms
+    end
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the name field' do
+      expect(indexed['name_tsim']).to eq descriptive.name_roles.map { |nr| nr.name.label }
+    end
+
+    it 'sets the name_facet field' do
+      expect(indexed['name_facet_ssim']).to eq descriptive.name_roles.map { |nr| nr.name.label }
+    end
+
+    it 'sets the name_role field' do
+      expect(indexed['name_role_tsim']).to eq descriptive.name_roles.map { |nr| nr.role.label }
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/note_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/note_indexer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::NoteIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::NoteIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the identifier fields' do
+      descriptive.note.each do |note|
+        expect(indexed["note_#{note.type}_tsim"]).to include(note.label)
+      end
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/physical_location_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/physical_location_indexer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::PhysicalLocationIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::PhysicalLocationIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the physical_location fields' do
+      %w(physical_location_ssim physical_location_tim).each do |field|
+        expect(indexed[field]).to eq [descriptive.physical_location.label]
+      end
+    end
+
+    it 'sets the sub_location field' do
+      expect(indexed['sub_location_tsi']).to eq [descriptive.physical_location_department]
+    end
+
+    it 'sets the shelf_locator field' do
+      expect(indexed['shelf_locator_tsi']).to eq [descriptive.physical_location_shelf_locator]
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/publication_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/publication_indexer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::PublicationIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::PublicationIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the volume field' do
+      expect(indexed['volume_tsi']).to eq [descriptive.publication.volume]
+    end
+
+    it 'sets the edition_name field' do
+      expect(indexed['edition_name_tsi']).to eq [descriptive.publication.edition_name]
+    end
+
+    it 'sets the edition_number field' do
+      expect(indexed['edition_number_tsi']).to eq [descriptive.publication.edition_number]
+    end
+
+    it 'sets the issue_number field' do
+      expect(indexed['issue_number_tsi']).to eq [descriptive.publication.issue_number]
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/related_item_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/related_item_indexer_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::RelatedItemIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::RelatedItemIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) do
+      descriptive_ms = create(:curator_metastreams_descriptive)
+      create_list(:curator_mappings_host_collection, 2).each do |hcol|
+        descriptive_ms.host_collections << hcol
+      end
+      descriptive_ms
+    end
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the related_item_host fields' do
+      %w(related_item_host_tim related_item_host_ssim).each do |field|
+        expect(indexed[field]).to eq descriptive.host_collections.map(&:name)
+      end
+    end
+
+    it 'sets the related_item_series fields' do
+      %w(related_item_series_ti related_item_series_ssi).each do |field|
+        expect(indexed[field]).to eq [descriptive.series]
+      end
+    end
+
+    it 'sets the related_item_subseries fields' do
+      %w(related_item_subseries_ti related_item_subseries_ssi).each do |field|
+        expect(indexed[field]).to eq [descriptive.subseries]
+      end
+    end
+
+    it 'sets the related_item_subsubseries fields' do
+      %w(related_item_subsubseries_ti related_item_subsubseries_ssi).each do |field|
+        expect(indexed[field]).to eq [descriptive.subsubseries]
+      end
+    end
+
+    it 'sets the related_item_constituent field' do
+      expect(indexed['related_item_constituent_tsim']).to eq [descriptive.related.constituent]
+    end
+
+    it 'sets the related_item_isreferencedby field' do
+      expect(indexed['related_item_isreferencedby_ssm']).to eq descriptive.related.referenced_by_url
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/rights_license_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/rights_license_indexer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::RightsLicenseIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::RightsLicenseIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) do
+      descriptive_ms = create(:curator_metastreams_descriptive)
+      descriptive_ms.licenses << create(:curator_controlled_terms_license)
+      descriptive_ms
+    end
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    it 'sets the rights field' do
+      expect(indexed['rights_ss']).to eq [descriptive.rights]
+    end
+
+    it 'sets the restrictions_on_access field' do
+      expect(indexed['restrictions_on_access_ss']).to eq [descriptive.access_restrictions]
+    end
+
+    it 'sets the license field' do
+      expect(indexed['license_ssm']).to eq descriptive.licenses.map(&:label)
+    end
+
+    it 'sets the license_uri field' do
+      expect(indexed['license_uri_ssm']).to eq descriptive.licenses.map(&:uri)
+    end
+
+    it 'sets the reuse_allowed field' do
+      expect(indexed['reuse_allowed_ssi']).to_not be_blank
+    end
+  end
+end

--- a/spec/indexers/concerns/curator/indexer/title_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/title_indexer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::TitleIndexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::TitleIndexer
+      end
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:descriptive) { create(:curator_metastreams_descriptive) }
+    let(:descriptable_object) { descriptive.descriptable }
+    let(:indexed) { indexer.map_record(descriptable_object) }
+
+    describe 'primary title' do
+      it 'sets the title_info_primary label fields' do
+        title_string = descriptive.title.primary.label
+        expect(indexed['title_info_primary_tsi']).to eq [title_string]
+        expect(indexed['title_info_primary_ssort']).to eq [Curator::Parsers::InputParser.get_proper_title(title_string).last]
+      end
+
+      it 'sets the subtitle_field' do
+        expect(indexed['title_info_primary_subtitle_tsi']).to eq [descriptive.title.primary.subtitle]
+      end
+
+      it 'sets the part fields' do
+        expect(indexed['title_info_partnum_tsi']).to eq [descriptive.title.primary.part_number]
+        expect(indexed['title_info_partname_tsi']).to eq [descriptive.title.primary.part_name]
+      end
+    end
+
+    describe 'other titles' do
+      it 'sets the title_info_alternative field' do
+        expect(indexed['title_info_alternative_tsim']).to eq(
+          descriptive.title.other.select { |t| t.type == 'alternative' }.map(&:label)
+        )
+      end
+
+      it 'sets the title_info_uniform field' do
+        expect(indexed['title_info_uniform_tsim']).to eq(
+          descriptive.title.other.select { |t| t.type == 'uniform' }.map(&:label)
+        )
+      end
+
+      it 'sets the display label field' do
+        expect(indexed['title_info_alternative_label_ssm'].first).to eq descriptive.title.other.first.display
+      end
+
+      it 'sets the title_info_other_subtitle field' do
+        expect(indexed['title_info_other_subtitle_tsim'].first).to eq descriptive.title.other.first.subtitle
+      end
+    end
+  end
+end

--- a/spec/indexers/curator/collection_indexer_spec.rb
+++ b/spec/indexers/curator/collection_indexer_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Curator::CollectionIndexer do
     end
 
     it 'sets the physical location and institution fields' do
-      pi_fields = %w(physical_location_ssim physical_location_tsim institution_name_ssi institution_name_tsi)
+      pi_fields = %w(physical_location_ssim physical_location_tim institution_name_ssi institution_name_ti)
       pi_fields.each do |field|
         expect(indexed[field]).to eq [@collection.institution.name]
       end

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Curator::DigitalObjectIndexer do
     end
 
     it 'sets the institution fields' do
-      %w(institution_name_ssi institution_name_tsi).each do |field|
+      %w(institution_name_ssi institution_name_ti).each do |field|
         expect(indexed[field]).to eq [digital_object.institution.name]
       end
       expect(indexed['institution_ark_id_ssi']).to eq [digital_object.institution.ark_id]
     end
 
     it 'sets the collection fields' do
-      %w(collection_name_ssim collection_name_tsim).each do |field|
+      %w(collection_name_ssim collection_name_tim).each do |field|
         expect(indexed[field]).to eq collections.map { |c| c.name }
       end
       expect(indexed['collection_ark_id_ssim']).to eq collections.map { |c| c.ark_id }

--- a/spec/models/curator/descriptives/field_sets/note_spec.rb
+++ b/spec/models/curator/descriptives/field_sets/note_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Curator::Descriptives::Note, type: :model do
     it { is_expected.to respond_to(:label, :type) }
 
     describe 'validations' do
-      it { is_expected.to validate_presence_of(:type) }
-
       it { is_expected.to validate_inclusion_of(:type).
                           in_array(Curator::Descriptives::NOTE_TYPES) }
     end

--- a/spec/models/curator/metastreams/descriptive_spec.rb
+++ b/spec/models/curator/metastreams/descriptive_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
     it { is_expected.to have_db_column(:subseries).
                         of_type(:string) }
 
+    it { is_expected.to have_db_column(:subsubseries).
+                        of_type(:string) }
+
     it { is_expected.to have_db_column(:rights).
                         of_type(:string) }
 

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -45,7 +45,8 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
       let(:simple_fields) do
         %w(abstract access_restrictions digital_origin frequency issuance origin_event extent
            physical_location_department physical_location_shelf_locator place_of_publication
-           publisher rights series subseries toc toc_url resource_type_manuscript text_direction)
+           publisher rights series subseries subsubseries toc toc_url resource_type_manuscript
+           text_direction)
       end
 
       it 'creates the descriptive object' do

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
 
         let(:notes) { descriptive.note }
         it 'sets notes' do
-          expect(notes.count).to eq 2
+          expect(notes.count).to eq 3
           expect(notes).to all(be_an_instance_of(Curator::Descriptives::Note))
           desc_json['note'].each do |note_json|
             expect(collection_as_json(notes, { only: %i(label type) })).to include(note_json)

--- a/spec/services/curator/filestreams/file_set_factory_service_spec.rb
+++ b/spec/services/curator/filestreams/file_set_factory_service_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Curator::Filestreams::FileSetFactoryService, type: :service do
     parent_col = create(:curator_collection)
     parent_obj = create(:curator_digital_object)
     parent_obj.workflow = create(:curator_metastreams_workflow)
+    @object_json['ark_id'] = "commonwealth:#{SecureRandom.hex(5)}"
     @object_json['file_set_of']['ark_id'] = parent_obj.ark_id
     @object_json['exemplary_image_of'][0]['ark_id'] = parent_obj.ark_id
     @object_json['exemplary_image_of'][1]['ark_id'] = parent_col.ark_id


### PR DESCRIPTION
In this PR:
* indexing for `Curator::Metastreams::Descriptive` properties and associated `ControlledTerms` (excluding subjects, this will come in a separate PR)
* add `subsubseries` property to `Metastreams::Descriptive`
* allow `Descriptives::Note` to have blank values for `type`
* specs for descriptive indexers
* modifications to factories
  * make some values more like what we expect from actual data
  * try to ensure uniqueness of `ark_id` to prevent spec failures due to uniqueness validation