### PR TITLE
Serializer integration

### DIFF
--- a/app/decorators/curator/desc_subject_decorator.rb
+++ b/app/decorators/curator/desc_subject_decorator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Curator
+  class DescSubjectDecorator < Decorators::BaseDecorator
+    attr_reader :topics, :name, :geos, :other
+
+    def initialize(descriptive)
+      super(descriptive)
+      @topics = descriptive.subject_topics if descriptive.respond_to?(:subject_topics)
+      @names = descriptive.subject_names if descriptive.respond_to?(:subject_names)
+      @geos = descriptive.workflow if descriptive.respond_to?(:subject_geos)
+      @other = descriptive.subject_other if descriptive.respond_to?(:subject_other)
+    end
+
+    def titles
+      other.titles if other
+    end
+
+    def temporals
+      other.temporals if other
+    end
+
+    def dates
+      other.dates if dates
+    end
+  end
+end

--- a/app/decorators/curator/metastream_decorator.rb
+++ b/app/decorators/curator/metastream_decorator.rb
@@ -4,10 +4,13 @@ module Curator
   class MetastreamDecorator < Decorators::BaseDecorator
     attr_reader :administrative, :descriptive, :workflow
     def initialize(metastreamable_object)
-      super(metastreamable_object)
       @administrative = metastreamable_object.administrative if metastreamable_object.respond_to?(:administrative)
       @descriptive = metastreamable_object.descriptive if metastreamable_object.respond_to?(:descriptive)
       @workflow = metastreamable_object.workflow if metastreamable_object.respond_to?(:workflow)
+    end
+
+    def blank?
+      @administrative.blank? && @descriptive.blank? && @workflow.blank?
     end
   end
 end

--- a/app/decorators/curator/metastream_decorator.rb
+++ b/app/decorators/curator/metastream_decorator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Curator
+  class MetastreamDecorator < Decorators::BaseDecorator
+    attr_reader :administrative, :descriptive, :workflow
+    def initialize(metastreamable_object)
+      super(metastreamable_object)
+      @administrative = metastreamable_object.administrative if metastreamable_object.respond_to?(:administrative)
+      @descriptive = metastreamable_object.descriptive if metastreamable_object.respond_to?(:descriptive)
+      @workflow = metastreamable_object.workflow if metastreamable_object.respond_to?(:workflow)
+    end
+  end
+end

--- a/app/decorators/curator/metastreams/subject_decorator.rb
+++ b/app/decorators/curator/metastreams/subject_decorator.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 module Curator
-  class DescSubjectDecorator < Decorators::BaseDecorator
-    attr_reader :topics, :name, :geos, :other
+  class Metastreams::SubjectDecorator < Decorators::BaseDecorator
+    attr_reader :topics, :names, :geos, :other
 
     def initialize(descriptive)
-      super(descriptive)
       @topics = descriptive.subject_topics if descriptive.respond_to?(:subject_topics)
       @names = descriptive.subject_names if descriptive.respond_to?(:subject_names)
-      @geos = descriptive.workflow if descriptive.respond_to?(:subject_geos)
+      @geos = descriptive.subject_geos if descriptive.respond_to?(:subject_geos)
       @other = descriptive.subject_other if descriptive.respond_to?(:subject_other)
+    end
+
+    def blank?
+      @topics.blank? && @names.blank? && @geos.blank? && @other.blank?
     end
 
     def titles
@@ -21,7 +24,7 @@ module Curator
     end
 
     def dates
-      other.dates if dates
+      other.dates if other
     end
   end
 end

--- a/app/models/concerns/curator/metastreamable.rb
+++ b/app/models/concerns/curator/metastreamable.rb
@@ -3,13 +3,32 @@
 module Curator
   # includes all metastream concerns in one
   module Metastreamable
-    extend ActiveSupport::Concern
-    included do
-      include Metastreams::Administratable
-      include Metastreams::Workflowable
-      include Metastreams::Descriptable
+    module All
+      extend ActiveSupport::Concern
+      included do
+        include Metastreams::Administratable
+        include Metastreams::Workflowable
+        include Metastreams::Descriptable
+        include Metastreamable::InstanceMethods
 
-      scope :with_metastreams, -> { merge(with_workflow).merge(with_administrative).merge(with_descriptive) }
+        scope :with_metastreams, -> { merge(with_workflow).merge(with_administrative).merge(with_descriptive) }
+      end
+    end
+
+    module Basic
+      extend ActiveSupport::Concern
+      included do
+        include Metastreams::Administratable
+        include Metastreams::Workflowable
+        include Metastreamable::InstanceMethods
+        scope :with_metastreams, -> { merge(with_workflow).merge(with_administrative)}
+      end
+    end
+
+    module InstanceMethods
+      def metastreams
+        Curator::MetastreamDecorator.new(self)
+      end
     end
   end
 end

--- a/app/models/concerns/curator/metastreamable.rb
+++ b/app/models/concerns/curator/metastreamable.rb
@@ -21,7 +21,7 @@ module Curator
         include Metastreams::Administratable
         include Metastreams::Workflowable
         include Metastreamable::InstanceMethods
-        scope :with_metastreams, -> { merge(with_workflow).merge(with_administrative)}
+        scope :with_metastreams, -> { merge(with_workflow).merge(with_administrative) }
       end
     end
 

--- a/app/models/concerns/curator/metastreams/descriptable.rb
+++ b/app/models/concerns/curator/metastreams/descriptable.rb
@@ -6,7 +6,7 @@ module Curator
       extend ActiveSupport::Concern
       included do
         scope :with_descriptive, -> { includes(:descriptive) }
-        has_one :descriptive, as: :descriptable, inverse_of: :descriptable, class_name: 'Curator::Metastreams::Descriptive', dependent: :destroy
+        has_one :descriptive, -> { merge(for_serialization) }, as: :descriptable, inverse_of: :descriptable, class_name: 'Curator::Metastreams::Descriptive', dependent: :destroy
       end
     end
   end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -3,12 +3,12 @@
 module Curator
   class Collection < ApplicationRecord
     include Curator::Mintable
-    include Curator::Metastreams::Administratable
-    include Curator::Metastreams::Workflowable
+    include Curator::Metastreamable::Basic
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
 
-    scope :with_metastreams, -> { merge(with_administrative).with(with_workflow) }
+    self.curator_indexable_mapper = Curator::CollectionIndexer.new
+
     scope :for_serialization, -> { merge(with_metastreams) }
 
     belongs_to :institution, inverse_of: :collections, class_name: 'Curator::Institution'
@@ -16,7 +16,5 @@ module Curator
     has_many :admin_set_objects, inverse_of: :admin_set, class_name: 'Curator::DigitalObject', foreign_key: :admin_set_id, dependent: :destroy
 
     has_many :collection_members, inverse_of: :collection, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
-
-    self.curator_indexable_mapper = Curator::CollectionIndexer.new
   end
 end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -8,6 +8,9 @@ module Curator
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
 
+    scope :with_metastreams, -> { merge(with_administrative).with(with_workflow) }
+    scope :for_serialization, -> { merge(with_metastreams) }
+
     belongs_to :institution, inverse_of: :collections, class_name: 'Curator::Institution'
 
     has_many :admin_set_objects, inverse_of: :admin_set, class_name: 'Curator::DigitalObject', foreign_key: :admin_set_id, dependent: :destroy

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -12,7 +12,7 @@ module Curator
     scope :with_mappings, -> { includes(:exemplary_image_mapping, :collection_members, :file_set_member_mappings) }
     scope :for_serialization, -> { merge(with_metastreams).merge(with_mappings) }
 
-    validates :contained_by_id, exclusion: { in: ->(digital_object) { Array.wrap(digital_object.id) } }, uniqueness: { scope: :id }, unless: -> { contained_by.blank? }
+    validates :contained_by_id, exclusion: { in: -> (digital_object) { Array.wrap(digital_object.id) } }, uniqueness: { scope: :id }, unless: -> { contained_by.blank? }
 
     before_create :add_admin_set_to_members, if: -> { admin_set.present? } # Should Fail if admin set is not present
 
@@ -34,7 +34,7 @@ module Curator
 
     has_many :container_for, inverse_of: :contained_by, class_name: 'Curator::DigitalObject', foreign_key: :contained_by_id, dependent: :nullify
 
-    has_many :collection_members, ->{ includes(:collection) }, inverse_of: :digital_object, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
+    has_many :collection_members, -> { includes(:collection) }, inverse_of: :digital_object, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
     has_many :is_member_of_collection, through: :collection_members, source: :collection
 
     has_many :file_set_member_mappings, -> { includes(:file_set) }, inverse_of: :digital_object, class_name: 'Curator::Mappings::FileSetMember', dependent: :destroy
@@ -48,8 +48,6 @@ module Curator
       has_many :text_file_set_members, source_type: 'Curator::Filestreams::Text'
       has_many :video_file_set_members, source_type: 'Curator::Filestreams::Video'
     end
-
-
 
     private
 

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -7,6 +7,9 @@ module Curator
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
 
+    scope :with_mappings, -> { includes(:exemplary_image_mapping, :collection_members, :file_set_member_mappings) }
+    scope :for_serialization, -> { merge(with_metastreams).merge(with_mappings) }
+
     validates :contained_by_id, exclusion: { in: ->(digital_object) { Array.wrap(digital_object.id) } }, uniqueness: { scope: :id }, unless: -> { contained_by.blank? }
 
     before_create :add_admin_set_to_members, if: -> { admin_set.present? } # Should Fail if admin set is not present
@@ -29,7 +32,7 @@ module Curator
 
     has_many :container_for, inverse_of: :contained_by, class_name: 'Curator::DigitalObject', foreign_key: :contained_by_id, dependent: :nullify
 
-    has_many :collection_members, inverse_of: :digital_object, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
+    has_many :collection_members, ->{ includes(:collection) }, inverse_of: :digital_object, class_name: 'Curator::Mappings::CollectionMember', dependent: :destroy
     has_many :is_member_of_collection, through: :collection_members, source: :collection
 
     has_many :file_set_member_mappings, -> { includes(:file_set) }, inverse_of: :digital_object, class_name: 'Curator::Mappings::FileSetMember', dependent: :destroy

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -3,9 +3,11 @@
 module Curator
   class DigitalObject < ApplicationRecord
     include Curator::Mintable
-    include Curator::Metastreamable
+    include Curator::Metastreamable::All
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
+
+    self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
 
     scope :with_mappings, -> { includes(:exemplary_image_mapping, :collection_members, :file_set_member_mappings) }
     scope :for_serialization, -> { merge(with_metastreams).merge(with_mappings) }
@@ -47,7 +49,7 @@ module Curator
       has_many :video_file_set_members, source_type: 'Curator::Filestreams::Video'
     end
 
-    self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
+
 
     private
 

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -8,9 +8,10 @@ module Curator
     include Curator::Filestreams::MetadataFoxable
     include Curator::Mappings::Exemplary::FileSet
     include Curator::Mintable
-    include Curator::Metastreams::Workflowable
-    include Curator::Metastreams::Administratable
+    include Curator::Metastreamable::Basic
     include Curator::Indexable
+
+    self.curator_indexable_mapper = Curator::FileSetIndexer.new
 
     acts_as_list scope: [:file_set_of, :file_set_type], top_of_list: 0
 
@@ -24,8 +25,6 @@ module Curator
 
     validates :file_name_base, presence: true
     validates :file_set_type, presence: true, inclusion: { in: Filestreams.file_set_types.collect { |type| "Curator::Filestreams::#{type}" } }
-
-    self.curator_indexable_mapper = Curator::FileSetIndexer.new
 
     private
 

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -4,6 +4,9 @@ module Curator
   class Filestreams::FileSet < ApplicationRecord
     self.inheritance_column = :file_set_type
 
+    include AttrJson::Record
+    include AttrJson::Record::QueryScopes
+    include AttrJson::Record::Dirty
     include Curator::Filestreams::Characterizable
     include Curator::Filestreams::MetadataFoxable
     include Curator::Mappings::Exemplary::FileSet
@@ -12,6 +15,12 @@ module Curator
     include Curator::Indexable
 
     self.curator_indexable_mapper = Curator::FileSetIndexer.new
+
+    attr_json_config(default_container_attribute: :pagination)
+
+    attr_json :page_label, :string
+    attr_json :page_type, :string
+    attr_json :hand_side, :string
 
     acts_as_list scope: [:file_set_of, :file_set_type], top_of_list: 0
 

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -7,10 +7,14 @@ module Curator
     include Curator::Metastreams::Workflowable
     include Curator::Indexable
 
+    scope :with_location, -> { includes(:location) }
+    scope :with_metastreams, -> { merge(with_administrative).merge(with_workflow) }
+    scope :for_serialization, -> { merge(with_metastreams).merge(with_location) } 
+
     validates :url, format: { with: URI.regexp(%w(http https)), allow_blank: true }
     validates :abstract, presence: { allow_blank: true }
 
-    belongs_to :location, -> { includes(:authority) }, inverse_of: :institution_locations, class_name: 'Curator::ControlledTerms::Geographic', optional: true
+    belongs_to :location, -> { merge(with_authority) }, inverse_of: :institution_locations, class_name: 'Curator::ControlledTerms::Geographic', optional: true
 
     has_many :host_collections, inverse_of: :institution, class_name: 'Curator::Mappings::HostCollection', dependent: :destroy
     # host_collections is a mapping object not to be consfused with collections

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -3,13 +3,13 @@
 module Curator
   class Institution < ApplicationRecord
     include Curator::Mintable
-    include Curator::Metastreams::Administratable
-    include Curator::Metastreams::Workflowable
+    include Curator::Metastreamable::Basic
     include Curator::Indexable
 
+    self.curator_indexable_mapper = Curator::InstitutionIndexer.new
+
     scope :with_location, -> { includes(:location) }
-    scope :with_metastreams, -> { merge(with_administrative).merge(with_workflow) }
-    scope :for_serialization, -> { merge(with_metastreams).merge(with_location) } 
+    scope :for_serialization, -> { merge(with_metastreams).merge(with_location) }
 
     validates :url, format: { with: URI.regexp(%w(http https)), allow_blank: true }
     validates :abstract, presence: { allow_blank: true }
@@ -21,7 +21,5 @@ module Curator
     has_many :collections, inverse_of: :institution, class_name: 'Curator::Collection', dependent: :destroy
 
     has_many :collection_admin_set_objects, through: :collections, source: :admin_set_objects
-
-    self.curator_indexable_mapper = Curator::InstitutionIndexer.new
   end
 end

--- a/app/models/curator/metastreams/descriptive.rb
+++ b/app/models/curator/metastreams/descriptive.rb
@@ -12,8 +12,9 @@ module Curator
     enum text_direction: %w(ltr rtl).freeze
     # JSON ATTRS
 
-    scope :with_mappings, -> { includes(:term_mappings, :name_roles, :desc_host_collections) }
-
+    scope :with_mappings, -> { includes(:desc_terms, :name_roles, :desc_host_collections) }
+    scope :with_physical_location, -> { includes(:physical_location) }
+    scope :for_serialization, -> { merge(with_mappings).merge(with_physical_location) }
     # Identifier
     attr_json :identifier, Curator::Descriptives::Identifier.to_type, container_attribute: :identifier_json, array: true, default: []
 
@@ -41,7 +42,7 @@ module Curator
     # RELS
     # PARENTS
     belongs_to :descriptable, polymorphic: true, inverse_of: :descriptive
-    belongs_to :physical_location, inverse_of: :physical_locations_of, class_name: 'Curator::ControlledTerms::Name'
+    belongs_to :physical_location, -> { merge(with_authority) }, inverse_of: :physical_locations_of, class_name: 'Curator::ControlledTerms::Name'
 
     # MAPPING OBJECTS
     with_options inverse_of: :descriptive, dependent: :destroy do
@@ -62,6 +63,9 @@ module Curator
       has_many :subject_names, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Name'
       has_many :subject_geos, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Geographic'
     end
+    alias :topics :subject_topics
+    alias :names :subject_names
+    alias :geos :subject_geos
 
     # VALIDATIONS
     validates :descriptable_id, uniqueness: { scope: :descriptable_type }

--- a/app/serializers/curator/collection_serializer.rb
+++ b/app/serializers/curator/collection_serializer.rb
@@ -3,15 +3,17 @@
 module Curator
   class CollectionSerializer < CuratorSerializer
     schema_as_json root: :collection do
-      attributes :ark_id, :abstract, :name, :metastreams
-    end
+      attributes :abstract, :name
 
-    # def metastreams
-    #   {}.merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.administrative, serializer: Metastreams::AdministrativeSerializer, root: 'administrative').as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.workflow, serializer: Metastreams::WorkflowSerializer, root: 'workflow').as_json
-    #   )
-    # end
+      #TODO: Add ability to configure fields for relationships whne defining schema rathe than passing them in as #serializer_params
+      node :institution, target: :key do
+        attribute :ark_id
+      end
+
+      node :metastreams do
+        has_one :administrative, serializer: 'Curator::Metastreams::AdministrativeSerializer'
+        has_one :workflow, serializer: 'Curator::Metastreams::WorkflowSerializer'
+      end
+    end
   end
 end

--- a/app/serializers/curator/collection_serializer.rb
+++ b/app/serializers/curator/collection_serializer.rb
@@ -10,7 +10,7 @@ module Curator
         attribute :ark_id
       end
 
-      node :metastreams do
+      node :metastreams, target: :key do
         has_one :administrative, serializer: 'Curator::Metastreams::AdministrativeSerializer'
         has_one :workflow, serializer: 'Curator::Metastreams::WorkflowSerializer'
       end

--- a/app/serializers/curator/collection_serializer.rb
+++ b/app/serializers/curator/collection_serializer.rb
@@ -5,7 +5,7 @@ module Curator
     schema_as_json root: :collection do
       attributes :abstract, :name
 
-      #TODO: Add ability to configure fields for relationships whne defining schema rathe than passing them in as #serializer_params
+      # TODO: Add ability to configure fields for relationships whne defining schema rathe than passing them in as #serializer_params
       node :institution, target: :key do
         attribute :ark_id
       end

--- a/app/serializers/curator/controlled_terms/authority_serializer.rb
+++ b/app/serializers/curator/controlled_terms/authority_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class ControlledTerms::AuthoritySerializer < CuratorSerializer
+  class ControlledTerms::AuthoritySerializer < Curator::Serializers::AbstractSerializer
     schema_as_json :authority do
       attributes :name, :code, :base_url
     end

--- a/app/serializers/curator/controlled_terms/authority_serializer.rb
+++ b/app/serializers/curator/controlled_terms/authority_serializer.rb
@@ -2,7 +2,7 @@
 
 module Curator
   class ControlledTerms::AuthoritySerializer < Curator::Serializers::AbstractSerializer
-    schema_as_json :authority do
+    schema_as_json root: :authority do
       attributes :name, :code, :base_url
     end
   end

--- a/app/serializers/curator/controlled_terms/name_serializer.rb
+++ b/app/serializers/curator/controlled_terms/name_serializer.rb
@@ -3,8 +3,7 @@
 module Curator
   class ControlledTerms::NameSerializer < ControlledTerms::NomenclatureSerializer
     schema_as_json root: :name do
-      attributes :affiliation, :authority_code
-      attribute(:type) { |record| record.name_type }
+      attributes :affiliation, :authority_code, :name_type
     end
   end
 end

--- a/app/serializers/curator/controlled_terms/nomenclature_serializer.rb
+++ b/app/serializers/curator/controlled_terms/nomenclature_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class ControlledTerms::NomenclatureSerializer < CuratorSerializer
+  class ControlledTerms::NomenclatureSerializer < Curator::Serializers::AbstractSerializer
     schema_as_json do
       attributes :label, :id_from_auth
     end

--- a/app/serializers/curator/curator_serializer.rb
+++ b/app/serializers/curator/curator_serializer.rb
@@ -3,27 +3,7 @@
 module Curator
   class CuratorSerializer < Curator::Serializers::AbstractSerializer
     schema_as_json do
-      attributes :id, :created_at, :updated_at
+      attributes :ark_id, :created_at, :updated_at
     end
-
-    # def serializable_hash(adapter_options = nil, options = {}, adapter_instance = self.class.serialization_adapter_instance)
-    #   hash = deep_reject_nil_vals(super)
-    #   hash
-    # end
-    #
-    # private
-    #
-    # def deep_reject_nil_vals(hash = {})
-    #   hash.each do |key, value|
-    #     if value.blank?
-    #       hash.delete(key)
-    #     elsif value.is_a?(Hash)
-    #       deep_reject_nil_vals(value)
-    #     elsif value.is_a?(Array) && value.all? { |el| el.is_a?(Hash) }
-    #       value.each { |el| deep_reject_nil_vals(el) }
-    #     end
-    #   end
-    #   hash
-    # end
   end
 end

--- a/app/serializers/curator/digital_object_serializer.rb
+++ b/app/serializers/curator/digital_object_serializer.rb
@@ -3,7 +3,6 @@
 module Curator
   class DigitalObjectSerializer < CuratorSerializer
     schema_as_json root: :digital_object do
-
       node :admin_set, target: :key do
         attribute :ark_id
       end

--- a/app/serializers/curator/digital_object_serializer.rb
+++ b/app/serializers/curator/digital_object_serializer.rb
@@ -15,7 +15,7 @@ module Curator
         attribute :ark_id
       end
 
-      node :metastreams do
+      node :metastreams, target: :key do
         has_one :administrative, serializer: Curator::Metastreams::AdministrativeSerializer
         has_one :descriptive, serializer: Curator::Metastreams::DescriptiveSerializer
         has_one :workflow, serializer: Curator::Metastreams::WorkflowSerializer

--- a/app/serializers/curator/digital_object_serializer.rb
+++ b/app/serializers/curator/digital_object_serializer.rb
@@ -3,7 +3,6 @@
 module Curator
   class DigitalObjectSerializer < CuratorSerializer
     schema_as_json root: :digital_object do
-      attributes :ark_id
     end
     # def metastreams
     #   {}.merge(

--- a/app/serializers/curator/digital_object_serializer.rb
+++ b/app/serializers/curator/digital_object_serializer.rb
@@ -3,15 +3,24 @@
 module Curator
   class DigitalObjectSerializer < CuratorSerializer
     schema_as_json root: :digital_object do
+
+      node :admin_set, target: :key do
+        attribute :ark_id
+      end
+
+      node :contained_by, target: :key do
+        attribute :ark_id
+      end
+
+      node :is_member_of_collection, target: :key do
+        attribute :ark_id
+      end
+
+      node :metastreams do
+        has_one :administrative, serializer: Curator::Metastreams::AdministrativeSerializer
+        has_one :descriptive, serializer: Curator::Metastreams::DescriptiveSerializer
+        has_one :workflow, serializer: Curator::Metastreams::WorkflowSerializer
+      end
     end
-    # def metastreams
-    #   {}.merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.administrative, serializer: Metastreams::AdministrativeSerializer, root: 'administrative').as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.descriptive, serializer: Metastreams::DescriptiveSerializer, root: 'descriptive').as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.workflow, serializer: Metastreams::WorkflowSerializer, root: 'workflow').as_json
-    #   )
-    # end
   end
 end

--- a/app/serializers/curator/filestreams/audio_serializer.rb
+++ b/app/serializers/curator/filestreams/audio_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::AudioSerializer < Filestreams::FileSetSerializer
+  end
+end

--- a/app/serializers/curator/filestreams/document_serializer.rb
+++ b/app/serializers/curator/filestreams/document_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Filestreams::ImageSerializer < Filestreams::FileSetSerializer
+  class Filestreams::DocumentSerializer < Filestreams::FileSetSerializer
     schema_as_json do
       node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
         attribute(:ark_id) { |record| record.exemplary_object.ark_id }

--- a/app/serializers/curator/filestreams/ereader_serializer.rb
+++ b/app/serializers/curator/filestreams/ereader_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::EreaderSerializer < Filestreams::FileSetSerializer
+  end
+end

--- a/app/serializers/curator/filestreams/file_set_serializer.rb
+++ b/app/serializers/curator/filestreams/file_set_serializer.rb
@@ -3,7 +3,7 @@
 module Curator
   class Filestreams::FileSetSerializer < CuratorSerializer
     schema_as_json do
-      attributes :ark_id
+      attributes :file_name_base
     end
   end
 end

--- a/app/serializers/curator/filestreams/file_set_serializer.rb
+++ b/app/serializers/curator/filestreams/file_set_serializer.rb
@@ -2,14 +2,15 @@
 
 module Curator
   class Filestreams::FileSetSerializer < CuratorSerializer
-    schema_as_json do
+    schema_as_json root: :file_set do
       attributes :file_name_base, :position
+      attribute(:file_set_type) { |record| record.file_set_type.demodulize.downcase }
 
       node :file_set_of, target: :key do
         attributes :ark_id
       end
 
-      node :pagination do
+      node :pagination, if: ->(record, _serializer_params) { record.pagination.present? } do
         attributes :page_label, :page_type, :hand_side
       end
 

--- a/app/serializers/curator/filestreams/file_set_serializer.rb
+++ b/app/serializers/curator/filestreams/file_set_serializer.rb
@@ -3,7 +3,20 @@
 module Curator
   class Filestreams::FileSetSerializer < CuratorSerializer
     schema_as_json do
-      attributes :file_name_base
+      attributes :file_name_base, :position
+
+      node :file_set_of, target: :key do
+        attributes :ark_id
+      end
+
+      node :pagination do
+        attributes :page_label, :page_type, :hand_side
+      end
+
+      node :metastreams, target: :key do
+        has_one :administrative, serializer: 'Curator::Metastreams::AdministrativeSerializer'
+        has_one :workflow, serializer: 'Curator::Metastreams::WorkflowSerializer'
+      end
     end
   end
 end

--- a/app/serializers/curator/filestreams/image_serializer.rb
+++ b/app/serializers/curator/filestreams/image_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::ImageSerializer < Filestreams::FileSetSerializer
+    schema_as_json root: :image do
+      node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
+        attribute(:ark_id) { |record| record.exemplary_object.ark_id }
+      end
+    end
+  end
+end

--- a/app/serializers/curator/filestreams/metadata_serializer.rb
+++ b/app/serializers/curator/filestreams/metadata_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::MetadataSerializer < Filestreams::FileSetSerializer
+  end
+end

--- a/app/serializers/curator/filestreams/text_serializer.rb
+++ b/app/serializers/curator/filestreams/text_serializer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::TextSerializer < Filestreams::FileSetSerializer
+  end
+end

--- a/app/serializers/curator/filestreams/video_serializer.rb
+++ b/app/serializers/curator/filestreams/video_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Filestreams::ImageSerializer < Filestreams::FileSetSerializer
+  class Filestreams::VideoSerializer < Filestreams::FileSetSerializer
     schema_as_json do
       node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
         attribute(:ark_id) { |record| record.exemplary_object.ark_id }

--- a/app/serializers/curator/institution_serializer.rb
+++ b/app/serializers/curator/institution_serializer.rb
@@ -7,7 +7,7 @@ module Curator
 
       belongs_to :location, serializer: Curator::ControlledTerms::GeographicSerializer
 
-      node :metastreams do
+      node :metastreams, target: :key do
         has_one :administrative, serializer: Curator::Metastreams::AdministrativeSerializer
         has_one :workflow, serializer: Curator::Metastreams::WorkflowSerializer
       end

--- a/app/serializers/curator/institution_serializer.rb
+++ b/app/serializers/curator/institution_serializer.rb
@@ -2,7 +2,7 @@
 
 module Curator
   class InstitutionSerializer < CuratorSerializer
-    schema_as_json do
+    schema_as_json root: :institution do
       attributes :abstract, :name, :url
 
       belongs_to :location, serializer: Curator::ControlledTerms::GeographicSerializer

--- a/app/serializers/curator/institution_serializer.rb
+++ b/app/serializers/curator/institution_serializer.rb
@@ -3,15 +3,12 @@
 module Curator
   class InstitutionSerializer < CuratorSerializer
     schema_as_json do
-      attributes :ark_id, :abstract, :name, :metastreams
+      attributes :abstract, :name, :url
+      belongs_to :location, serializer: Curator::ControlledTerms::GeographicSerializer
+      node :metastreams do
+        has_one :administrative, serializer: Curator::Metastreams::AdministrativeSerializer
+        has_one :workflow, serializer: Curator::Metastreams::WorkflowSerializer
+      end
     end
-
-    # def metastreams
-    #   {}.merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.administrative, serializer: Metastreams::AdministrativeSerializer, root: 'administrative').as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.workflow, serializer: Metastreams::WorkflowSerializer, root: 'workflow').as_json
-    #   )
-    # end
   end
 end

--- a/app/serializers/curator/institution_serializer.rb
+++ b/app/serializers/curator/institution_serializer.rb
@@ -4,7 +4,9 @@ module Curator
   class InstitutionSerializer < CuratorSerializer
     schema_as_json do
       attributes :abstract, :name, :url
+
       belongs_to :location, serializer: Curator::ControlledTerms::GeographicSerializer
+
       node :metastreams do
         has_one :administrative, serializer: Curator::Metastreams::AdministrativeSerializer
         has_one :workflow, serializer: Curator::Metastreams::WorkflowSerializer

--- a/app/serializers/curator/metastreams/administrative_serializer.rb
+++ b/app/serializers/curator/metastreams/administrative_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Metastreams::AdministrativeSerializer < CuratorSerializer
+  class Metastreams::AdministrativeSerializer < Curator::Serializers::AbstractSerializer
     schema_as_json root: :administrative do
       attributes :description_standard, :flagged, :harvestable, :destination_site
     end

--- a/app/serializers/curator/metastreams/descriptive_serializer.rb
+++ b/app/serializers/curator/metastreams/descriptive_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Metastreams::DescriptiveSerializer < CuratorSerializer
+  class Metastreams::DescriptiveSerializer < Curator::Serializers::AbstractSerializer
     # CONTROLLED_TERMS_FIELDS = %i(label id_from_auth authority_code).freeze
     #
     # class DescriptiveNameRoleSerializer < ActiveModel::Serializer

--- a/app/serializers/curator/metastreams/descriptive_serializer.rb
+++ b/app/serializers/curator/metastreams/descriptive_serializer.rb
@@ -5,7 +5,7 @@ module Curator
     schema_as_json root: :descriptive do
       attributes :abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url
 
-      attribute(:host_collections) { |record| record.host_collections.pluck(:name) }
+      attribute(:host_collections) { |record| record.host_collections.names }
 
       belongs_to :physical_location, serializer: Curator::ControlledTerms::NameSerializer
 
@@ -53,79 +53,17 @@ module Curator
         belongs_to :role, serializer: Curator::ControlledTerms::RoleSerializer
       end
 
-      node :subject do
+      node :subject, target: :key do
+        attributes :dates, :temporals
+
         has_many :topics, serializer: Curator::ControlledTerms::SubjectSerializer
         has_many :names, serializer: Curator::ControlledTerms::NameSerializer
         has_many :geos, serializer: Curator::ControlledTerms::GeographicSerializer
 
-        node :titles, target: -> (record) { record.subject_other.titles }, if: -> (record, _) { record.subject_other.present? } do
+        node :titles, target: :key do
           attributes :label, :subtitle, :display, :display_label, :usage, :supplied, :language, :type, :authority_code, :id_from_auth, :part_name, :part_number
         end
-        attribute(:temporals, if: -> (record, _) { record.subject_other.present? }) { |record| record.subject_other.temporals }
-        attribute(:dates, if: -> (record, _) { record.subject_other.present? }) { |record| record.subject_other.dates }
       end
     end
-    # attribute :cartographic do
-    #   object.cartographic.as_json
-    # end
-    #
-    # attribute :date do
-    #   object.date.as_json
-    # end
-    #
-    # attribute :related do
-    #   object.related.as_json
-    # end
-    #
-    # attribute :title do
-    #   object.title.as_json
-    # end
-    #
-    # attribute :identifier do
-    #   object.identifier.as_json
-    # end
-    #
-    # attribute :note do
-    #   object.note.as_json
-    # end
-    #
-    # attribute :subject do |serializer|
-    #   serializer.subject.as_json
-    # end
-    #
-    # # TODO: Cache these methods #see https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/general/serializers.md#associations
-    # def subject
-    #   {}.merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.subject_topics, each_serializer: Curator::ControlledTerms::SubjectSerializer, root: 'topic', fields: CONTROLLED_TERMS_FIELDS).as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.subject_names, each_serializer: Curator::ControlledTerms::NameSerializer, root: 'name', fields: CONTROLLED_TERMS_FIELDS + %i(affiliation type)).as_json
-    #   ).merge(
-    #     ActiveModelSerializers::SerializableResource.new(object.subject_geos, each_serializer: Curator::ControlledTerms::GeographicSerializer, root: 'geo', fields: CONTROLLED_TERMS_FIELDS + %i(coordinates bounding_box)).as_json
-    #   ).merge(object.subject_other.as_json)
-    # end
-    #
-    # def name_role
-    #   object.name_roles.map { |name_role| DescriptiveNameRoleSerializer.new(name_role).attributes }
-    # end
-    #
-    # def genre
-    #   object.genres.map { |genre| Curator::ControlledTerms::GenreSerializer.new(genre).attributes(CONTROLLED_TERMS_FIELDS + %i(basic)) }
-    # end
-    #
-    # def language
-    #   object.languages.map { |language| Curator::ControlledTerms::LanguageSerializer.new(language).attributes(CONTROLLED_TERMS_FIELDS) }
-    # end
-    #
-    # def resource_type
-    #   object.resource_types.map { |resource_type| Curator::ControlledTerms::ResourceTypeSerializer.new(resource_type).attributes(CONTROLLED_TERMS_FIELDS) }
-    # end
-    #
-    # def license
-    #   object.licenses.map { |license| Curator::ControlledTerms::LicenseSerializer.new(license).attributes(%i(label uri)) }
-    # end
-    #
-    # def physical_location
-    #   Curator::ControlledTerms::NameSerializer.new(object.physical_location).attributes(CONTROLLED_TERMS_FIELDS + %i(affiliation type))
-    # end
   end
 end

--- a/app/serializers/curator/metastreams/workflow_serializer.rb
+++ b/app/serializers/curator/metastreams/workflow_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Curator
-  class Metastreams::WorkflowSerializer < CuratorSerializer
+  class Metastreams::WorkflowSerializer < Curator::Serializers::AbstractSerializer
     schema_as_json root: :workflow do
       attributes :publishing_state, :processing_state, :ingest_origin
     end

--- a/lib/curator.rb
+++ b/lib/curator.rb
@@ -11,6 +11,7 @@ module Curator
   class CuratorError < StandardError; end
 
   eager_autoload do
+    autoload :Decorators
     autoload :Descriptives
     autoload :Services
     autoload :Parsers
@@ -20,6 +21,7 @@ module Curator
   def self.eager_load!
     super
     Curator::Descriptives.eager_load!
+    Curator::Decorators.eager_load!
     Curator::Parsers.eager_load!
     Curator::Services.eager_load!
     Curator::Serializers.eager_load!

--- a/lib/curator/decorators.rb
+++ b/lib/curator/decorators.rb
@@ -3,7 +3,24 @@
 module Curator
   module Decorators
     extend ActiveSupport::Autoload
-    class BaseDecorator < SimpleDelegator; end
+    class BaseDecorator < SimpleDelegator
+      include ActiveModel::Serialization
+
+      # NOTE: Because of how the serializer current works records are checked with .blank? before being read_for_serialization
+      # Due to the fact the SimplmeDelegator class does not include active support core extensions this will fail on that check with the following NameError
+      # NameError: undefined method `blank?' for module `Kernel'
+      # Due to this I am adding making the .blank? method be required by classes that inherit from this(BaseDecorator) class
+      def blank?
+        raise 'I need to be implemented in the class'
+      end
+
+      # NOTE: this is needed for ActiveModel::Serialization to work
+      # Can override as needed
+      def attributes
+        {}
+      end
+    end
+
     eager_autoload do
       autoload :MetastreamDecorator
       autoload :DescSubjectDecorator

--- a/lib/curator/decorators.rb
+++ b/lib/curator/decorators.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Curator
+  module Decorators
+    extend ActiveSupport::Autoload
+    class BaseDecorator < SimpleDelegator; end
+    eager_autoload do
+      autoload :MetastreamDecorator
+      autoload :DescSubjectDecorator
+    end
+  end
+end

--- a/lib/curator/engine.rb
+++ b/lib/curator/engine.rb
@@ -3,6 +3,7 @@
 module Curator
   class Engine < ::Rails::Engine
     require 'concurrent'
+    require 'delegate'
     require 'forwardable'
     require 'faraday'
     require 'faraday_middleware'

--- a/lib/curator/serializers/abstract_serializer.rb
+++ b/lib/curator/serializers/abstract_serializer.rb
@@ -13,6 +13,7 @@ module Curator
 
       def initialize(record, adapter_key, serializer_params = {})
         @record = record
+        adapter_key = :null if record.blank?
         @adapter = self.class.send(:_schema_for_adapter, adapter_key)
         # NOTE: The reason we reverse_merge the adapter key into the serializer params is so any relationships serialized will know which apater they are serializing for
         @serializer_params = serializer_params.dup.merge(adapter_key: adapter_key)

--- a/lib/curator/serializers/adapter_base.rb
+++ b/lib/curator/serializers/adapter_base.rb
@@ -21,8 +21,8 @@ module Curator
         raise 'Not Implemented'
       end
 
-      def initialize_copy(source)
-        @schema = source.schema.clone
+      def initialize_dup(source)
+        @schema = source.schema.deep_dup
         super
       end
 

--- a/lib/curator/serializers/adapter_base.rb
+++ b/lib/curator/serializers/adapter_base.rb
@@ -21,10 +21,6 @@ module Curator
         raise 'Not Implemented'
       end
 
-      def serializable_hash_for_reationship(_record = nil, _serializer_params = {})
-        raise 'Not Implemented'
-      end
-
       def initialize_dup(source)
         @schema = source.schema.deep_dup
         super

--- a/lib/curator/serializers/adapter_base.rb
+++ b/lib/curator/serializers/adapter_base.rb
@@ -21,6 +21,10 @@ module Curator
         raise 'Not Implemented'
       end
 
+      def serializable_hash_for_reationship(_record = nil, _serializer_params = {})
+        raise 'Not Implemented'
+      end
+
       def initialize_dup(source)
         @schema = source.schema.deep_dup
         super

--- a/lib/curator/serializers/adapters/json_adapter.rb
+++ b/lib/curator/serializers/adapters/json_adapter.rb
@@ -4,7 +4,7 @@ module Curator
   module Serializers
     class JSONAdapter < AdapterBase
       def serializable_hash(record, serializer_params = {})
-        serialized_result = schema.serialize(record, serializer_params.dup.reverse_merge!(adapter_key: :json))
+        serialized_result = schema.serialize(record, serializer_params.dup.merge(adapter_key: :json))
 
         # NOTE: Needed a way to return the base serialize  result from the schema for the relatiosn before formatting
         # This option is passed in for the relation facet class on read_for_serialization

--- a/lib/curator/serializers/schema.rb
+++ b/lib/curator/serializers/schema.rb
@@ -24,6 +24,10 @@ module Curator
         def to_h
           Concurrent::Hash[type, schema_attribute]
         end
+
+        def deep_dup
+          super.freeze
+        end
       end
 
       attr_reader :root, :facets, :options
@@ -37,8 +41,13 @@ module Curator
       def update_root!(root = nil)
         @root = root
       end
-      # DSL METHODS
 
+      def initialize_dup(source)
+        @facets = source.facets.inject(Concurrent::Array.new) { |res, facet| res << facet.deep_dup }
+        super
+      end
+
+      # DSL METHODS
       def attribute(key, **opts, &block)
         add_facet(type: :attributes, schema_attribute: Attribute.new(key: key, method: block || key, options: opts))
       end

--- a/lib/curator/serializers/schema/node.rb
+++ b/lib/curator/serializers/schema/node.rb
@@ -4,9 +4,9 @@ module Curator
   module Serializers
     class Node < Attribute
       extend Forwardable
-      attr_reader :schema
+      attr_reader :node_schema
 
-      def_delegators :schema, :root, :attribute, :attributes, :node, :has_one, :belongs_to, :has_many
+      def_delegators :node_schema, :root, :attribute, :attributes, :node, :has_one, :belongs_to, :has_many
 
       def initialize(key:, options: {}, &block)
         super(key: key, options: options.dup)
@@ -14,7 +14,7 @@ module Curator
 
         aquire_target_method!(options.fetch(:target, nil), key)
 
-        @schema = Schema.new(root: key, options: options.dup.slice(:key_transform_method, :cache_enabled, :cache_options))
+        @node_schema = Schema.new(root: key, options: options.dup.slice(:key_transform_method, :cache_enabled, :cache_options))
         instance_eval(&block)
       end
 
@@ -22,7 +22,7 @@ module Curator
         target_val = super(record, serializer_params.dup) if method
         target_val = record if target_val.blank?
 
-        schema.serialize(target_val, serializer_params.dup)
+        node_schema.serialize(target_val, serializer_params.dup)
       end
 
       def include_value?(record, serializer_params = {})

--- a/lib/curator/serializers/schema/node.rb
+++ b/lib/curator/serializers/schema/node.rb
@@ -20,7 +20,7 @@ module Curator
 
       def read_for_serialization(record, serializer_params = {})
         target_val = method.present? ? super(record, serializer_params.dup) : record
-        
+
         node_schema.serialize(target_val, serializer_params.dup)
       end
 

--- a/lib/curator/serializers/schema/node.rb
+++ b/lib/curator/serializers/schema/node.rb
@@ -19,9 +19,8 @@ module Curator
       end
 
       def read_for_serialization(record, serializer_params = {})
-        target_val = super(record, serializer_params.dup) if method
-        target_val = record if target_val.blank?
-
+        target_val = method.present? ? super(record, serializer_params.dup) : record
+        
         node_schema.serialize(target_val, serializer_params.dup)
       end
 

--- a/lib/curator/serializers/schema/relation.rb
+++ b/lib/curator/serializers/schema/relation.rb
@@ -11,7 +11,7 @@ module Curator
         @serializer = serializer_klass_for(serializer_klass)
       end
       # You can only add links in this case. everything else is delegated to the relations serializer
-
+      # TODO: Add ability to pass custom root in options
       def read_for_serialization(record, serializer_params = {})
         return if record.blank?
 

--- a/lib/curator/serializers/schema/relation.rb
+++ b/lib/curator/serializers/schema/relation.rb
@@ -11,6 +11,7 @@ module Curator
         @serializer = serializer_klass_for(serializer_klass)
       end
       # You can only add links in this case. everything else is delegated to the relations serializer
+
       # TODO: Add ability to pass custom root in options
       def read_for_serialization(record, serializer_params = {})
         return if record.blank?
@@ -19,12 +20,12 @@ module Curator
         adapter_key = serializer_params.dup.fetch(:adapter_key, :null)
         adapter_key = :null if relation_record.blank?
 
-        serializer_instance = build_serializer_instance(relation_record, adapter_key, serializer_params)
+        serializer_instance = build_serializer_instance(relation_record, adapter_key, serializer_params.dup)
         serializer_instance.serializable_hash
       end
 
       def include_value?(record, serializer_params = {})
-        super(record, serializer_params.dup.except(:fields)) && include_relation?(serializer_params.dup)
+        include_relation?(serializer_params.dup) && super(record, serializer_params.dup.except(:fields))
       end
 
       def include_relation?(serializer_params = {})
@@ -34,6 +35,11 @@ module Curator
       end
 
       private
+
+      def parse_fields(serializer_params = {})
+        return if serializer_params.dup.dig(:fields, key).blank?
+
+      end
 
       def build_serializer_instance(relation_record, adapter_key, serializer_params = {})
         serializer.new(relation_record, adapter_key, serializer_params.dup.merge(adapter_key: adapter_key, for_relation: true))

--- a/lib/curator/serializers/serialization_dsl.rb
+++ b/lib/curator/serializers/serialization_dsl.rb
@@ -64,7 +64,7 @@ module Curator
 
           if _has_schema_adapter?(adapter_key.to_sym)
             adapter_instance = _schema_for_adapter(adapter_key)
-            adapter_instance.schema.update_root!(schema_options.dup.fetch(:root, nil))
+            adapter_instance.schema.update_root!(schema_options.dup.fetch(:root)) if schema_options.dup.fetch(:root, nil)
             adapter_instance.schema.options.merge!(schema_options.dup.except(:root))
             adapter_instance.instance_eval(&block)
           else

--- a/lib/curator/serializers/serialization_dsl.rb
+++ b/lib/curator/serializers/serialization_dsl.rb
@@ -54,7 +54,6 @@ module Curator
         # NOTE: redefining a schema for an adapter on an inherited class will create a new one
         def _define_adapter_schema(adapter_key:, root: nil, options: {}, &block)
           raise 'NullAdapter cant be used this way' if adapter_key.to_sym == :null
-
           # TODO: Think of more options to set up at the schema level.
           schema_options = options.dup.slice(:key_transform_method)
           schema_options[:cache_enabled] = cache_enabled?
@@ -93,7 +92,7 @@ module Curator
 
         def _inherit_schemas!(parent_adapter_schemas)
           # NOTE: We want to make sure that the schema registered in the class is NOT the same instance of the parent class This ensures that it is a different object in memory but preserves the states of all the instance objects on the schema for the adapter
-          parent_adapter_schemas.each_pair { |k, v| _adapter_schemas.compute_if_absent(k) { v.clone } }
+          parent_adapter_schemas.each_pair { |k, v| _adapter_schemas.compute_if_absent(k) { v.deep_dup } }
         end
 
         def _reset_adapter_schemas!

--- a/spec/decorators/curator/metastream_decorator_spec.rb
+++ b/spec/decorators/curator/metastream_decorator_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/curator_decorator'
+
+RSpec.describe Curator::MetastreamDecorator, type: :decorators do
+  let!(:metastreamable_record) { create(:curator_institution, :with_metastreams) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'curator_decorator' do
+      let(:decorator) { described_class.new(metastreamable_record) }
+    end
+  end
+
+  describe 'Decorator instance' do
+    subject { described_class.new(metastreamable_record) }
+
+    let(:expected_blank_condition) { subject.administrative.blank? && subject.descriptive.blank? && subject.workflow.blank? }
+
+    it { is_expected.to respond_to(:administrative, :descriptive, :workflow) }
+
+    it 'is expected to return #blank? based on the :expected_blank_condition' do
+      expect(subject.blank?).to eq(expected_blank_condition)
+    end
+  end
+end

--- a/spec/decorators/curator/metastreams/subject_decorator_spec.rb
+++ b/spec/decorators/curator/metastreams/subject_decorator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/curator_decorator'
+
+RSpec.describe Curator::Metastreams::SubjectDecorator, type: :decorators do
+  let!(:desc_term_counts) { 3 }
+  let!(:subject_record) { create(:curator_metastreams_descriptive, :with_all_desc_terms, desc_term_count: desc_term_counts) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'curator_decorator' do
+      let(:decorator) { described_class.new(subject_record) }
+    end
+  end
+
+  describe 'Decorator instance' do
+    subject { described_class.new(subject_record) }
+
+    let(:expected_blank_condition) { subject.topics.blank? && subject.names.blank? && subject.titles.blank? && subject.other.blank? }
+
+    it { is_expected.to respond_to(:topics, :names, :geos, :other, :titles, :temporals, :dates) }
+
+    it 'is expected to return #blank? based on the :expected_blank_condition' do
+      expect(subject.blank?).to eq(expected_blank_condition)
+    end
+  end
+end

--- a/spec/decorators/curator/shared/curator_decorator.rb
+++ b/spec/decorators/curator/shared/curator_decorator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'curator_decorator', type: :decorators do
+  describe 'Curator::Decorators::BaseDecorator' do
+    subject { decorator }
+
+    it { is_expected.to be_a_kind_of(Curator::Decorators::BaseDecorator) }
+    it { is_expected.to respond_to(:blank?, :attributes, :serializable_hash) }
+
+    it 'expects #blank? to return true or false' do
+      expect(subject.blank?).to be(true).or be(false)
+    end
+
+    it 'expects #attributes to be a kind of Hash' do
+      expect(subject.attributes).to be_a_kind_of(Hash)
+    end
+  end
+end

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     archived_at { nil }
 
     trait :with_metastreams do
-      after :create do |collection, options|
+      after :create do |collection, _options|
         create(:curator_metastreams_administrative, administratable: collection)
         create(:curator_metastreams_workflow, workflowable: collection)
       end

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :curator_collection, class: 'Curator::Collection' do
+    ark_id
     association :institution, factory: :curator_institution
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     name { "#{Faker::FunnyName.four_word_name} Collection" }
     abstract { Faker::Lorem.paragraph }
     archived_at { nil }

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -7,5 +7,12 @@ FactoryBot.define do
     name { "#{Faker::FunnyName.four_word_name} Collection" }
     abstract { Faker::Lorem.paragraph }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |collection, options|
+        create(:curator_metastreams_administrative, administratable: collection)
+        create(:curator_metastreams_workflow, workflowable: collection)
+      end
+    end
   end
 end

--- a/spec/factories/curator/controlled_terms/genres.rb
+++ b/spec/factories/curator/controlled_terms/genres.rb
@@ -3,11 +3,9 @@
 FactoryBot.define do
   factory :curator_controlled_terms_genre, class: 'Curator::ControlledTerms::Genre' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence,
-        id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10),
-        basic: [true, false].sample }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
+    basic { [true, false].sample }
     type { 'Curator::ControlledTerms::Genre' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/geographics.rb
+++ b/spec/factories/curator/controlled_terms/geographics.rb
@@ -4,7 +4,11 @@ FactoryBot.define do
   factory :curator_controlled_terms_geographic, class: 'Curator::ControlledTerms::Geographic' do
     association :authority, factory: :curator_controlled_terms_authority
     sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
+      {
+        label: Faker::Lorem.sentence,
+        id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10),
+        coordinates: [Faker::Address.latitude, Faker::Address.longitude].join(',')
+      }
     end
     type { 'Curator::ControlledTerms::Geographic' }
     archived_at { nil }

--- a/spec/factories/curator/controlled_terms/geographics.rb
+++ b/spec/factories/curator/controlled_terms/geographics.rb
@@ -3,13 +3,11 @@
 FactoryBot.define do
   factory :curator_controlled_terms_geographic, class: 'Curator::ControlledTerms::Geographic' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      {
-        label: Faker::Lorem.sentence,
-        id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10),
-        coordinates: [Faker::Address.latitude, Faker::Address.longitude].join(',')
-      }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
+    coordinates { [Faker::Address.latitude, Faker::Address.longitude].join(',') }
+    bounding_box { (0..100).to_a.sample(4).join(' ') }
+    area_type { Faker::Address.city_prefix }
     type { 'Curator::ControlledTerms::Geographic' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/languages.rb
+++ b/spec/factories/curator/controlled_terms/languages.rb
@@ -3,9 +3,8 @@
 FactoryBot.define do
   factory :curator_controlled_terms_language, class: 'Curator::ControlledTerms::Language' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
     type { 'Curator::ControlledTerms::Language' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/licenses.rb
+++ b/spec/factories/curator/controlled_terms/licenses.rb
@@ -2,7 +2,8 @@
 
 FactoryBot.define do
   factory :curator_controlled_terms_license, class: 'Curator::ControlledTerms::License' do
-    sequence(:term_data) { |_n| { label: Faker::Lorem.sentence, uri: Faker::Internet.url } }
+    label { Faker::Lorem.sentence }
+    uri { Faker::Internet.url }
     type { 'Curator::ControlledTerms::License' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/names.rb
+++ b/spec/factories/curator/controlled_terms/names.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     label { Faker::Lorem.sentence }
     id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
     affiliation { Faker::University.name }
-    name_type { Faker::Company.buzzword } # NOTE: Should we validate name_types by list? 
+    name_type { Faker::Company.buzzword } # NOTE: Should we validate name_types by list?
     type { 'Curator::ControlledTerms::Name' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/names.rb
+++ b/spec/factories/curator/controlled_terms/names.rb
@@ -3,9 +3,10 @@
 FactoryBot.define do
   factory :curator_controlled_terms_name, class: 'Curator::ControlledTerms::Name' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
+    affiliation { Faker::University.name }
+    name_type { Faker::Company.buzzword } # NOTE: Should we validate name_types by list? 
     type { 'Curator::ControlledTerms::Name' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/resource_types.rb
+++ b/spec/factories/curator/controlled_terms/resource_types.rb
@@ -3,9 +3,8 @@
 FactoryBot.define do
   factory :curator_controlled_terms_resource_type, class: 'Curator::ControlledTerms::ResourceType' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
     type { 'Curator::ControlledTerms::ResourceType' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/roles.rb
+++ b/spec/factories/curator/controlled_terms/roles.rb
@@ -3,9 +3,8 @@
 FactoryBot.define do
   factory :curator_controlled_terms_role, class: 'Curator::ControlledTerms::Role' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
     type { 'Curator::ControlledTerms::Role' }
     archived_at { nil }
   end

--- a/spec/factories/curator/controlled_terms/subjects.rb
+++ b/spec/factories/curator/controlled_terms/subjects.rb
@@ -3,9 +3,8 @@
 FactoryBot.define do
   factory :curator_controlled_terms_subject, class: 'Curator::ControlledTerms::Subject' do
     association :authority, factory: :curator_controlled_terms_authority
-    sequence(:term_data) do |_n|
-      { label: Faker::Lorem.sentence, id_from_auth: Faker::Alphanumeric.alphanumeric(number: 10) }
-    end
+    label { Faker::Lorem.sentence }
+    id_from_auth { Faker::Alphanumeric.alphanumeric(number: 10) }
     type { 'Curator::ControlledTerms::Subject' }
     archived_at { nil }
   end

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -12,9 +12,13 @@ FactoryBot.define do
     end
 
     trait :with_metastreams do
-      after :create do |digital_object|
+      transient do
+        desc_term_count { nil }
+      end
+
+      after :create do |digital_object, options|
         create(:curator_metastreams_administrative, administratable: digital_object)
-        create(:curator_metastreams_descriptive, descriptable: digital_object)
+        create(:curator_metastreams_descriptive, :with_descriptive_fields, descriptable: digital_object, genre_count: options.desc_term_count, name_role_count: options.desc_term_count, resource_type_count: options.desc_term_count, language_count: options.desc_term_count, license_count: options.desc_term_count, subject_count: options.desc_term_count)
         create(:curator_metastreams_workflow, workflowable: digital_object)
       end
     end

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
 
       after :create do |digital_object, options|
         create(:curator_metastreams_administrative, administratable: digital_object)
-        create(:curator_metastreams_descriptive, :with_descriptive_fields, descriptable: digital_object, genre_count: options.desc_term_count, name_role_count: options.desc_term_count, resource_type_count: options.desc_term_count, language_count: options.desc_term_count, license_count: options.desc_term_count, subject_count: options.desc_term_count)
+        create(:curator_metastreams_descriptive, descriptable: digital_object, genre_count: options.desc_term_count, name_role_count: options.desc_term_count, resource_type_count: options.desc_term_count, language_count: options.desc_term_count, license_count: options.desc_term_count, subject_count: options.desc_term_count)
         create(:curator_metastreams_workflow, workflowable: digital_object)
       end
     end

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :curator_digital_object, class: 'Curator::DigitalObject' do
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
+    ark_id
     association :admin_set, factory: :curator_collection
     contained_by_id { nil }
     archived_at { nil }

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -13,12 +13,12 @@ FactoryBot.define do
 
     trait :with_metastreams do
       transient do
-        desc_term_count { nil }
+        desc_term_count { 1 }
       end
 
       after :create do |digital_object, options|
         create(:curator_metastreams_administrative, administratable: digital_object)
-        create(:curator_metastreams_descriptive, descriptable: digital_object, genre_count: options.desc_term_count, name_role_count: options.desc_term_count, resource_type_count: options.desc_term_count, language_count: options.desc_term_count, license_count: options.desc_term_count, subject_count: options.desc_term_count)
+        create(:curator_metastreams_descriptive, :with_all_desc_terms, descriptable: digital_object, desc_term_count: options.desc_term_count)
         create(:curator_metastreams_workflow, workflowable: digital_object)
       end
     end

--- a/spec/factories/curator/filestreams/audios.rb
+++ b/spec/factories/curator/filestreams/audios.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :curator_filestreams_audio, class: 'Curator::Filestreams::Audio' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Audio' }
     file_name_base { Faker::Music.album }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/filestreams/audios.rb
+++ b/spec/factories/curator/filestreams/audios.rb
@@ -8,5 +8,12 @@ FactoryBot.define do
     file_name_base { Faker::Music.album }
     position { 1 }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |audio_file_set|
+        create(:curator_metastreams_administrative, administratable: audio_file_set)
+        create(:curator_metastreams_workflow, workflowable: audio_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/documents.rb
+++ b/spec/factories/curator/filestreams/documents.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :curator_filestreams_document, class: 'Curator::Filestreams::Document' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Document' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/documents.rb
+++ b/spec/factories/curator/filestreams/documents.rb
@@ -7,7 +7,13 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Document' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |document_file_set|
+        create(:curator_metastreams_administrative, administratable: document_file_set)
+        create(:curator_metastreams_workflow, workflowable: document_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/ereaders.rb
+++ b/spec/factories/curator/filestreams/ereaders.rb
@@ -7,6 +7,16 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Ereader' }
     file_name_base { Faker::Book.publisher }
     position { 1 }
+    hand_side { 'left' }
+    page_type { 'TOC' }
+    page_label { '3' }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |ereader_file_set|
+        create(:curator_metastreams_administrative, administratable: ereader_file_set)
+        create(:curator_metastreams_workflow, workflowable: ereader_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/ereaders.rb
+++ b/spec/factories/curator/filestreams/ereaders.rb
@@ -7,9 +7,6 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Ereader' }
     file_name_base { Faker::Book.publisher }
     position { 1 }
-    hand_side { 'left' }
-    page_type { 'TOC' }
-    page_label { '3' }
     archived_at { nil }
 
     trait :with_metastreams do

--- a/spec/factories/curator/filestreams/ereaders.rb
+++ b/spec/factories/curator/filestreams/ereaders.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :curator_filestreams_ereader, class: 'Curator::Filestreams::Ereader' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Ereader' }
     file_name_base { Faker::Book.publisher }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/filestreams/file_set.rb
+++ b/spec/factories/curator/filestreams/file_set.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :curator_filestreams_file_set, class: 'Curator::Filestreams::FileSet' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(n)}" }
-    file_set_type { 'Curator::Filestreams::Audio' }
+    file_set_type { Curator::Filestreams.file_set_types.map { |type| "Curator::Filestreams::#{type}" }.sample }
     file_name_base { Faker::Music.album }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/filestreams/images.rb
+++ b/spec/factories/curator/filestreams/images.rb
@@ -2,12 +2,21 @@
 
 FactoryBot.define do
   factory :curator_filestreams_image, class: 'Curator::Filestreams::Image' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Image' }
     file_name_base { Faker::Artist.name }
     position { 1 }
-    pagination { { 'hand_side' => 'left', 'page_type' => 'TOC', 'page_label' => '3' } }
+    hand_side { 'left' }
+    page_type { 'TOC' }
+    page_label { '3' }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |image_file_set|
+        create(:curator_metastreams_administrative, administratable: image_file_set)
+        create(:curator_metastreams_workflow, workflowable: image_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/metadata.rb
+++ b/spec/factories/curator/filestreams/metadata.rb
@@ -7,6 +7,16 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Metadata' }
     file_name_base { Faker::Internet.uuid }
     position { 1 }
+    hand_side { 'left' }
+    page_type { 'TOC' }
+    page_label { 'OAI HARVEST META' }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |metadata_file_set|
+        create(:curator_metastreams_administrative, administratable: metadata_file_set)
+        create(:curator_metastreams_workflow, workflowable: metadata_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/metadata.rb
+++ b/spec/factories/curator/filestreams/metadata.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :curator_filestreams_metadata, class: 'Curator::Filestreams::Metadata' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Metadata' }
     file_name_base { Faker::Internet.uuid }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/filestreams/metadata.rb
+++ b/spec/factories/curator/filestreams/metadata.rb
@@ -7,9 +7,6 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Metadata' }
     file_name_base { Faker::Internet.uuid }
     position { 1 }
-    hand_side { 'left' }
-    page_type { 'TOC' }
-    page_label { 'OAI HARVEST META' }
     archived_at { nil }
 
     trait :with_metastreams do

--- a/spec/factories/curator/filestreams/texts.rb
+++ b/spec/factories/curator/filestreams/texts.rb
@@ -7,9 +7,6 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Text' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }
-    hand_side { 'left' }
-    page_type { 'TOC' }
-    page_label { 'My OCR' }
     archived_at { nil }
 
     trait :with_metastreams do

--- a/spec/factories/curator/filestreams/texts.rb
+++ b/spec/factories/curator/filestreams/texts.rb
@@ -7,7 +7,16 @@ FactoryBot.define do
     file_set_type { 'Curator::Filestreams::Text' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }
-    pagination { {} }
+    hand_side { 'left' }
+    page_type { 'TOC' }
+    page_label { 'My OCR' }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |text_file_set|
+        create(:curator_metastreams_administrative, administratable: text_file_set)
+        create(:curator_metastreams_workflow, workflowable: text_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/filestreams/texts.rb
+++ b/spec/factories/curator/filestreams/texts.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :curator_filestreams_text, class: 'Curator::Filestreams::Text' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Text' }
     file_name_base { Faker::Books::Lovecraft.tome }
     position { 1 }

--- a/spec/factories/curator/filestreams/videos.rb
+++ b/spec/factories/curator/filestreams/videos.rb
@@ -2,12 +2,11 @@
 
 FactoryBot.define do
   factory :curator_filestreams_video, class: 'Curator::Filestreams::Video' do
+    ark_id
     association :file_set_of, factory: :curator_digital_object
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     file_set_type { 'Curator::Filestreams::Video' }
     file_name_base { Faker::TvShows::Simpsons.character }
     position { 1 }
-    pagination { {} }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/filestreams/videos.rb
+++ b/spec/factories/curator/filestreams/videos.rb
@@ -8,5 +8,12 @@ FactoryBot.define do
     file_name_base { Faker::TvShows::Simpsons.character }
     position { 1 }
     archived_at { nil }
+
+    trait :with_metastreams do
+      after :create do |video_file_set|
+        create(:curator_metastreams_administrative, administratable: video_file_set)
+        create(:curator_metastreams_workflow, workflowable: video_file_set)
+      end
+    end
   end
 end

--- a/spec/factories/curator/institutions.rb
+++ b/spec/factories/curator/institutions.rb
@@ -11,14 +11,26 @@ FactoryBot.define do
 
     transient do
       collection_count { nil }
+      with_collection_metastreams { false }
     end
 
     trait :with_location do
       location { create(:curator_controlled_terms_geographic) }
     end
 
+    trait :with_metastreams do
+      after :create do |institution|
+        create(:curator_metastreams_administrative, administratable: institution)
+        create(:curator_metastreams_workflow, workflowable: institution)
+      end
+    end
+
     after :create do |institution, options|
-      create_list(:curator_collection, options.collection_count, institution: institution) if options.collection_count
+      if options.collection_count
+        create_list(:curator_collection, options.collection_count, :with_metastreams, institution: institution) if options.with_collection_metastreams
+
+        create_list(:curator_collection, options.collection_count, institution: institution) unless options.with_collection_metastreams
+      end
     end
   end
 end

--- a/spec/factories/curator/institutions.rb
+++ b/spec/factories/curator/institutions.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :curator_institution, class: 'Curator::Institution' do
+    ark_id
     association :location, factory: :curator_controlled_terms_geographic
-    sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].max..[n, 32].max))}" }
     name { Faker::University.name }
     abstract { Faker::Lorem.paragraph(sentence_count: 12) }
     url { Faker::Internet.unique.url(host: 'example-institution.org') }

--- a/spec/factories/curator/mappings/desc_terms.rb
+++ b/spec/factories/curator/mappings/desc_terms.rb
@@ -4,5 +4,37 @@ FactoryBot.define do
   factory :curator_mappings_desc_term, class: 'Curator::Mappings::DescTerm' do
     association :descriptive, factory: :curator_metastreams_descriptive
     association :mapped_term, factory: :curator_controlled_terms_genre
+
+    trait :specific_genre do
+      mapped_term { create(:curator_controlled_terms_genre, basic: false) }
+    end
+
+    trait :basic_genre do
+      mapped_term { create(:curator_controlled_terms_genre, basic: true) }
+    end
+
+    trait :resource_type do
+      mapped_term { create(:curator_controlled_terms_resource_type) }
+    end
+
+    trait :language do
+      mapped_term { create(:curator_controlled_terms_language) }
+    end
+
+    trait :license do
+      mapped_term { create(:curator_controlled_terms_license) }
+    end
+
+    trait :subject_topic do
+      mapped_term { create(:curator_controlled_terms_subject) }
+    end
+
+    trait :subject_name do
+      mapped_term { create(:curator_controlled_terms_name) }
+    end
+
+    trait :subject_geo do
+      mapped_term { create(:curator_controlled_terms_geographic) }
+    end
   end
 end

--- a/spec/factories/curator/metastreams/administratives.rb
+++ b/spec/factories/curator/metastreams/administratives.rb
@@ -3,7 +3,8 @@
 FactoryBot.define do
   factory :curator_metastreams_administrative, class: 'Curator::Metastreams::Administrative' do
     association :administratable, factory: :curator_digital_object
-    description_standard { 1 }
+    description_standard { Curator::Metastreams::Administrative.description_standards.keys.sample }
+    flagged { [true, false].sample }
     archived_at { nil }
   end
 end

--- a/spec/factories/curator/metastreams/administratives.rb
+++ b/spec/factories/curator/metastreams/administratives.rb
@@ -4,7 +4,14 @@ FactoryBot.define do
   factory :curator_metastreams_administrative, class: 'Curator::Metastreams::Administrative' do
     association :administratable, factory: :curator_digital_object
     description_standard { Curator::Metastreams::Administrative.description_standards.keys.sample }
-    flagged { [true, false].sample }
     archived_at { nil }
+
+    trait :is_flagged do
+      flagged { true }
+    end
+
+    trait :non_havestable do
+      harvestable { false }
+    end
   end
 end

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -54,7 +54,6 @@ FactoryBot.define do
       end
     end
 
-
     transient do
       genre_count { nil }
       name_role_count { nil }

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -37,6 +37,24 @@ FactoryBot.define do
       resource_type_manuscript { true }
     end
 
+    trait :with_all_desc_terms do
+      transient do
+        desc_term_count { nil }
+      end
+
+      after :create do |descriptive, options|
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :specific_genre, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :language, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :resource_type, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :license, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_topic, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_name, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_geo, descriptive: descriptive) if options.desc_term_count
+        create_list(:curator_mappings_desc_name_role, options.desc_term_count, descriptive: descriptive) if options.desc_term_count
+      end
+    end
+
+
     transient do
       genre_count { nil }
       name_role_count { nil }
@@ -44,6 +62,7 @@ FactoryBot.define do
       resource_type_count { nil }
       license_count { nil }
       subject_count { nil }
+      host_collection_count { 1 }
     end
 
     after :create do |descriptive, options|
@@ -55,6 +74,7 @@ FactoryBot.define do
       create_list(:curator_mappings_desc_term, options.subject_count, :subject_name, descriptive: descriptive) if options.subject_count
       create_list(:curator_mappings_desc_term, options.subject_count, :subject_geo, descriptive: descriptive) if options.subject_count
       create_list(:curator_mappings_desc_name_role, options.name_role_count, descriptive: descriptive) if options.name_role_count
+      create_list(:curator_mappings_desc_host_collection, options.host_collection_count, descriptive: descriptive) if options.host_collection_count
     end
   end
 end

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -35,18 +35,33 @@ FactoryBot.define do
 
     transient do
       genre_count { nil }
+      name_role_count { nil }
+      language_count { nil }
+      resource_type_count { nil }
+      license_count { nil }
+      subject_count { nil }
+    end
+
+    trait :with_descriptive_fields do
+      identifier { create_list(:curator_descriptives_identifier, 3) }
+      date { create(:curator_descriptives_date) }
+      note { create_list(:curator_descriptives_note, 3) }
+      cartographic { create(:curator_descriptives_cartographic) }
+      publication { create(:curator_descriptives_publication) }
+      related { create(:curator_descriptives_related) }
+      title { create(:curator_descriptives_title_set) }
+      subject_other { create(:curator_descriptives_subject) }
     end
 
     after :create do |descriptive, options|
-      descriptive.identifier = create_list(:curator_descriptives_identifier, 3)
-      descriptive.date = create(:curator_descriptives_date)
-      descriptive.note = create_list(:curator_descriptives_note, 3)
-      descriptive.cartographic = create(:curator_descriptives_cartographic)
-      descriptive.publication = create(:curator_descriptives_publication)
-      descriptive.related = create(:curator_descriptives_related)
-      descriptive.title = create(:curator_descriptives_title_set)
-      descriptive.subject_other = create(:curator_descriptives_subject)
-      create_list(:curator_mappings_desc_term, options.genre_count, descriptive: descriptive) if options.genre_count
+      create_list(:curator_mappings_desc_term, options.genre_count, :specific_genre, descriptive: descriptive) if options.genre_count
+      create_list(:curator_mappings_desc_term, options.language_count, :language, descriptive: descriptive) if options.language_count
+      create_list(:curator_mappings_desc_term, options.resource_type_count, :resource_type, descriptive: descriptive) if options.resource_type_count
+      create_list(:curator_mappings_desc_term, options.license_count, :license, descriptive: descriptive) if options.license_count
+      create_list(:curator_mappings_desc_term, options.subject_count, :subject_topic, descriptive: descriptive) if options.subject_count
+      create_list(:curator_mappings_desc_term, options.subject_count, :subject_name, descriptive: descriptive) if options.subject_count
+      create_list(:curator_mappings_desc_term, options.subject_count, :subject_geo, descriptive: descriptive) if options.subject_count
+      create_list(:curator_mappings_desc_name_role, options.name_role_count, descriptive: descriptive) if options.name_role_count
     end
   end
 end

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -4,14 +4,14 @@ FactoryBot.define do
   factory :curator_metastreams_descriptive, class: 'Curator::Metastreams::Descriptive' do
     association :descriptable, factory: :curator_digital_object
     association :physical_location, factory: :curator_controlled_terms_name
-    identifier_json { {} }
-    title_json { {} }
-    date_json { {} }
-    note_json { {} }
-    subject_json { {} }
-    related_json { {} }
-    cartographics_json { {} }
-    publication_json { {} }
+    identifier { create_list(:curator_descriptives_identifier, 3) }
+    date { create(:curator_descriptives_date) }
+    note { create_list(:curator_descriptives_note, 3) }
+    cartographic { create(:curator_descriptives_cartographic) }
+    publication { create(:curator_descriptives_publication) }
+    related { create(:curator_descriptives_related) }
+    title { create(:curator_descriptives_title_set) }
+    subject_other { create(:curator_descriptives_subject) }
     digital_origin { 1 }
     origin_event { 1 }
     text_direction { 1 }
@@ -40,17 +40,6 @@ FactoryBot.define do
       resource_type_count { nil }
       license_count { nil }
       subject_count { nil }
-    end
-
-    trait :with_descriptive_fields do
-      identifier { create_list(:curator_descriptives_identifier, 3) }
-      date { create(:curator_descriptives_date) }
-      note { create_list(:curator_descriptives_note, 3) }
-      cartographic { create(:curator_descriptives_cartographic) }
-      publication { create(:curator_descriptives_publication) }
-      related { create(:curator_descriptives_related) }
-      title { create(:curator_descriptives_title_set) }
-      subject_other { create(:curator_descriptives_subject) }
     end
 
     after :create do |descriptive, options|

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -43,13 +43,9 @@ FactoryBot.define do
       end
 
       after :create do |descriptive, options|
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :specific_genre, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :language, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :resource_type, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :license, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_topic, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_name, descriptive: descriptive) if options.desc_term_count
-        create_list(:curator_mappings_desc_term, options.desc_term_count, :subject_geo, descriptive: descriptive) if options.desc_term_count
+        %i(specific_genre language resource_type license subject_topic subject_name subject_geo).each do |desc_term_type|
+          create_list(:curator_mappings_desc_term, options.desc_term_count, desc_term_type, descriptive: descriptive) if options.desc_term_count
+        end
         create_list(:curator_mappings_desc_name_role, options.desc_term_count, descriptive: descriptive) if options.desc_term_count
       end
     end
@@ -66,12 +62,12 @@ FactoryBot.define do
 
     after :create do |descriptive, options|
       create_list(:curator_mappings_desc_term, options.genre_count, :specific_genre, descriptive: descriptive) if options.genre_count
-      create_list(:curator_mappings_desc_term, options.language_count, :language, descriptive: descriptive) if options.language_count
-      create_list(:curator_mappings_desc_term, options.resource_type_count, :resource_type, descriptive: descriptive) if options.resource_type_count
-      create_list(:curator_mappings_desc_term, options.license_count, :license, descriptive: descriptive) if options.license_count
-      create_list(:curator_mappings_desc_term, options.subject_count, :subject_topic, descriptive: descriptive) if options.subject_count
-      create_list(:curator_mappings_desc_term, options.subject_count, :subject_name, descriptive: descriptive) if options.subject_count
-      create_list(:curator_mappings_desc_term, options.subject_count, :subject_geo, descriptive: descriptive) if options.subject_count
+      %i(subject_topic subject_name subject_other).each do |subject_type|
+        create_list(:curator_mappings_desc_term, options.subject_count, subject_type, descriptive: descriptive) if options.subject_count
+      end
+      %i(language resource_type license).each do |desc_term_type|
+        create_list(:curator_mappings_desc_term, options.send("#{desc_term_type}_count"), :language, descriptive: descriptive) if options.send("#{desc_term_type}_count")
+      end
       create_list(:curator_mappings_desc_name_role, options.name_role_count, descriptive: descriptive) if options.name_role_count
       create_list(:curator_mappings_desc_host_collection, options.host_collection_count, descriptive: descriptive) if options.host_collection_count
     end

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -33,6 +33,10 @@ FactoryBot.define do
     abstract { Faker::Lorem.paragraph }
     archived_at { nil }
 
+    trait :manuscript? do
+      resource_type_manuscript { true }
+    end
+
     transient do
       genre_count { nil }
       name_role_count { nil }

--- a/spec/factories/curator/metastreams/workflows.rb
+++ b/spec/factories/curator/metastreams/workflows.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :curator_metastreams_workflow, class: 'Curator::Metastreams::Workflow' do
     association :workflowable, factory: :curator_digital_object
-    publishing_state { 1 }
-    processing_state { 1 }
+    publishing_state { Curator::Metastreams::Workflow.publishing_states.keys.sample }
+    processing_state { Curator::Metastreams::Workflow.processing_states.keys.sample }
     ingest_origin { Faker::Internet.uuid }
     archived_at { nil }
   end

--- a/spec/factories/curator/mintables.rb
+++ b/spec/factories/curator/mintables.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# SEQUENCE GENERATOR FOR ARK_IDS
+
+FactoryBot.define do
+  sequence(:ark_id) { |n| "commonwealth:#{SecureRandom.hex(rand([n, 8].min..[n, 32].min))}" }
+end

--- a/spec/lib/curator/serializers/schema/node_spec.rb
+++ b/spec/lib/curator/serializers/schema/node_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Curator::Serializers::Node, type: :lib_serializers do
   let!(:descriptive) { create(:curator_metastreams_descriptive, genre_count: 5) }
   let!(:delegated_schema_methods) { %i(root attribute attributes node has_one has_many belongs_to) }
 
-  it { is_expected.to respond_to(:schema, :serialize, :include_value?, :read_for_serialization) }
+  it { is_expected.to respond_to(:node_schema, :serialize, :include_value?, :read_for_serialization) }
   it { is_expected.to respond_to(*delegated_schema_methods) }
 
   it 'is expected to raise error without a block' do
@@ -18,7 +18,7 @@ RSpec.describe Curator::Serializers::Node, type: :lib_serializers do
 
   it 'expects certain methods to be delegated to schema' do
     delegated_schema_methods.each do |schema_method|
-      expect(subject).to delegate_method(schema_method).to(:schema)
+      expect(subject).to delegate_method(schema_method).to(:node_schema)
     end
   end
 

--- a/spec/lib/curator/serializers/schema_spec.rb
+++ b/spec/lib/curator/serializers/schema_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Curator::Serializers::Schema, type: :lib_serializers do
     let!(:custom_attr) { :abstract_trunc }
     let!(:custom_link_attr) { :https_url }
     let!(:meta_attr) { :collection_count }
-    let(:node_attr) { :ark_attributes }
+    let!(:node_attr) { :ark_attributes }
     let!(:collection_serializer) do
       Class.new(Curator::Serializers::AbstractSerializer) do
         schema_as_json root: :collection do

--- a/spec/lib/curator/serializers/schema_spec.rb
+++ b/spec/lib/curator/serializers/schema_spec.rb
@@ -35,9 +35,11 @@ RSpec.describe Curator::Serializers::Schema, type: :lib_serializers do
 
     let!(:schema_facets) { %i(attribute attributes link meta node relation has_one has_many belongs_to) }
 
-    it { is_expected.to respond_to(:root, :facets, :options) }
+    it { is_expected.to respond_to(:root, :facets, :options, :facet_groups, :cache_enabled?, :cache_options, :key_transform_method) }
     it { is_expected.to respond_to(*schema_facets) }
-    it { is_expected.to respond_to(:is_collection?, :facet_groups, :serialize, :serialize_each) }
+    it { is_expected.to respond_to(:is_collection?).with(1).argument }
+    it { is_expected.to respond_to(:key_in_group?).with(2).arguments }
+    it { is_expected.to respond_to(:serialize, :serialize_each).with(1..2).arguments }
 
     describe 'schema configuration' do
       it 'is expected to store attribute facets' do

--- a/spec/lib/curator/serializers/serialization_dsl_spec.rb
+++ b/spec/lib/curator/serializers/serialization_dsl_spec.rb
@@ -112,12 +112,13 @@ RSpec.describe Curator::Serializers::SerializationDSL, type: :lib_serializer do
         end
 
         it 'expects duplicates of @_adapter_schemas values of parent to be mapped to the child serializer' do
-          expect(subject.values.map(&:object_id).compact).not_to match_array(child_class_adapter_schemas.values.map(&:object_id).compact) #Adapter Object ids
-          expect(subject.values.flat_map(&schema_object_ids_proc).compact).not_to match_array(child_class_adapter_schemas.values.flat_map(&schema_object_ids_proc).compact)
-          expect(subject.values.flat_map(&schema_facets_object_ids_proc).compact).not_to match_array(child_class_adapter_schemas.values.flat_map(&schema_facets_object_ids_proc).compact)
+          expect(subject.values.map(&:object_id).compact).not_to match_array(child_class_adapter_schemas.values.map(&:object_id).compact) # Adapter Object ids
+          expect(subject.values.flat_map(&schema_object_ids_proc).compact).not_to match_array(child_class_adapter_schemas.values.flat_map(&schema_object_ids_proc).compact) # Adapter Schema Object ids
+          expect(subject.values.flat_map(&schema_facets_object_ids_proc).compact).not_to match_array(child_class_adapter_schemas.values.flat_map(&schema_facets_object_ids_proc).compact) # Adapter Schema Facet Object Ids
         end
 
-        it "expects the each facet in the parent/child class @_adpater_schema to be frozen?" do
+        it 'expects the each facet in the parent/child class @_adpater_schema to be frozen?' do
+          # Note: Facets in Schema should ALWAYS be frozen
           expect(subject.values.flat_map(&schema_facets_frozen_proc).compact).to all(be_truthy)
           expect(child_class_adapter_schemas.values.flat_map(&schema_facets_frozen_proc).compact).to all(be_truthy)
         end

--- a/spec/models/curator/collection_spec.rb
+++ b/spec/models/curator/collection_spec.rb
@@ -7,6 +7,7 @@ require_relative './shared/optimistic_lockable'
 require_relative './shared/timestampable'
 require_relative './shared/archivable'
 require_relative './shared/mappings/has_exemplary_file_set'
+require_relative './shared/for_serialization'
 
 RSpec.describe Curator::Collection, type: :model do
   subject { create(:curator_collection) }
@@ -40,5 +41,11 @@ RSpec.describe Curator::Collection, type: :model do
     it { is_expected.to have_many(:collection_members).
         inverse_of(:collection).
         class_name('Curator::Mappings::CollectionMember').dependent(:destroy) }
+  end
+
+  describe 'Scopes' do
+    it_behaves_like 'for_serialization' do
+      let(:expected_scope_sql) { described_class.merge(described_class.with_metastreams).to_sql }
+    end
   end
 end

--- a/spec/models/curator/collection_spec.rb
+++ b/spec/models/curator/collection_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe Curator::Collection, type: :model do
   end
 
   describe 'Associations' do
-    it_behaves_like 'administratable'
-    it_behaves_like 'workflowable'
+    it_behaves_like 'metastreamable_basic'
     it_behaves_like 'has_exemplary_file_set'
 
     it { is_expected.to belong_to(:institution).

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -142,4 +142,22 @@ RSpec.describe Curator::DigitalObject, type: :model do
       end
     end
   end
+
+  describe 'Scopes' do
+    describe '.with_mappings' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.includes(:exemplary_image_mapping, :collection_members, :file_set_member_mappings).to_sql }
+
+      it { is_expected.to respond_to(:with_mappings) }
+
+      it 'expects the scope sql to match the expected_scope_sql' do
+        expect(subject.with_mappings.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
+    it_behaves_like 'for_serialization' do
+      let(:expected_scope_sql) { described_class.merge(described_class.with_metastreams).merge(described_class.with_mappings).to_sql }
+    end
+  end
 end

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Curator::DigitalObject, type: :model do
   end
 
   describe 'Associations' do
-    it_behaves_like 'metastreamable'
+    it_behaves_like 'metastreamable_all'
     it_behaves_like 'has_exemplary_file_set'
 
     let!(:file_sets_class_map) do

--- a/spec/models/curator/institution_spec.rb
+++ b/spec/models/curator/institution_spec.rb
@@ -6,6 +6,7 @@ require_relative './shared/metastreamable'
 require_relative './shared/optimistic_lockable'
 require_relative './shared/timestampable'
 require_relative './shared/archivable'
+require_relative './shared/for_serialization'
 
 RSpec.describe Curator::Institution, type: :model do
   subject { create(:curator_institution) }
@@ -42,5 +43,23 @@ RSpec.describe Curator::Institution, type: :model do
 
     it { is_expected.to have_many(:collection_admin_set_objects).
       through(:collections).source(:admin_set_objects) }
+  end
+
+  describe 'Scopes' do
+    describe '.with_location' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.includes(:location).to_sql }
+
+      it { is_expected.to respond_to(:with_location) }
+
+      it 'expects the scope sql to match the :expected_scope_sql' do
+        expect(subject.with_location.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
+    it_behaves_like 'for_serialization' do
+      let(:expected_scope_sql) { described_class.merge(described_class.with_metastreams).merge(described_class.with_location).to_sql }
+    end
   end
 end

--- a/spec/models/curator/institution_spec.rb
+++ b/spec/models/curator/institution_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe Curator::Institution, type: :model do
   end
 
   describe 'Associations' do
-    it_behaves_like 'administratable'
-    it_behaves_like 'workflowable'
+    it_behaves_like 'metastreamable_basic'
 
     it { is_expected.to belong_to(:location).
       inverse_of(:institution_locations).

--- a/spec/models/curator/metastreams/descriptive_spec.rb
+++ b/spec/models/curator/metastreams/descriptive_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 require_relative '../shared/optimistic_lockable'
 require_relative '../shared/timestampable'
 require_relative '../shared/archivable'
+require_relative '../shared/for_serialization'
 
 RSpec.describe Curator::Metastreams::Descriptive, type: :model do
   subject { create(:curator_metastreams_descriptive) }
@@ -264,6 +265,36 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
                            source(:mapped_term).
                            class_name(relation_class)
       end
+    end
+  end
+
+  describe 'Scopes' do
+    describe '.with_mappings' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.includes(:desc_terms, :name_roles, :desc_host_collections).to_sql }
+
+      it { is_expected.to respond_to(:with_mappings) }
+
+      it 'expects the scope sql to match the :expected_scope_sql' do
+        expect(subject.with_mappings.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
+    describe '.with_physical_location' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.includes(:physical_location).to_sql }
+
+      it { is_expected.to respond_to(:with_physical_location) }
+
+      it 'expects the scope sql to match the :expected_scope_sql' do
+        expect(subject.with_physical_location.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
+    it_behaves_like 'for_serialization' do
+      let(:expected_scope_sql) { described_class.merge(described_class.with_mappings).merge(described_class.with_physical_location).to_sql }
     end
   end
 end

--- a/spec/models/curator/shared/for_serialization.rb
+++ b/spec/models/curator/shared/for_serialization.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'for_serialization', type: :model do
-  #Requires query stub in block when including
+  # Requires query stub in block when including
   describe '#for_serialization scope' do
     subject { described_class }
 

--- a/spec/models/curator/shared/for_serialization.rb
+++ b/spec/models/curator/shared/for_serialization.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'for_serialization', type: :model do
-  # Requires query stub in block when including
+  # Requires expected_scope_sql stub in block when including
   describe '#for_serialization scope' do
     subject { described_class }
 
     it { is_expected.to respond_to(:for_serialization) }
 
-    it 'expects the the scope as sql to match :expected_sql' do
-      expect(subject.for_serialization.to_sql).to match(expected_sql)
+    it 'expects the the scope as sql to match :expected_scope_sql' do
+      expect(subject.for_serialization.to_sql).to match(expected_scope_sql)
     end
   end
 end

--- a/spec/models/curator/shared/for_serialization.rb
+++ b/spec/models/curator/shared/for_serialization.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'for_serialization', type: :model do
+  #Requires query stub in block when including
+  describe '#for_serialization scope' do
+    subject { described_class }
+
+    it { is_expected.to respond_to(:for_serialization) }
+
+    it 'expects the the scope as sql to match :expected_sql' do
+      expect(subject.for_serialization.to_sql).to match(expected_sql)
+    end
+  end
+end

--- a/spec/models/curator/shared/metastreamable.rb
+++ b/spec/models/curator/shared/metastreamable.rb
@@ -42,7 +42,7 @@ RSpec.shared_examples 'workflowable', type: :model do
   end
 end
 
-RSpec.shared_examples 'metastreamable', type: :model do
+RSpec.shared_examples 'metastreamable_all', type: :model do
   it_behaves_like 'administratable'
   it_behaves_like 'descriptable'
   it_behaves_like 'workflowable'
@@ -50,8 +50,29 @@ RSpec.shared_examples 'metastreamable', type: :model do
   describe '#with_metastreams' do
     subject { described_class }
 
-    it 'is expected to respond_to #with_metastreams' do
-      expect(subject).to respond_to(:with_metastreams)
+    let(:expected_sql) { described_class.includes(:administratable, :descriptable, :workflowable).to_sql }
+
+    it { is_expected.to respond_to(:with_metastreams) }
+
+    it 'expects the sql for #with_metastreams to match the :expected_sql' do
+      expect(subject.with_metastreams.to_sql).to match(expected_sql)
+    end
+  end
+end
+
+RSpec.shared_examples 'metastreamable_basic', type: :model do
+  it_behaves_like 'administratable'
+  it_behaves_like 'workflowable'
+
+  describe '#with_metastreams' do
+    subject { described_class }
+
+    let(:expected_sql) { described_class.includes(:administratable, :workflowable).to_sql }
+
+    it { is_expected.to respond_to(:with_metastreams) }
+
+    it 'expects the sql for #with_metastreams to match the :expected_sql' do
+      expect(subject.with_metastreams.to_sql).to match(expected_sql)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -127,6 +127,10 @@ RSpec.configure do |config|
     metadata[:type] = :lib_serializers
   end
 
+  config.define_derived_metadata(file_path: Regexp.new('/spec/serializers/curator')) do |metadata|
+    metadata[:type] = :serializers
+  end
+
   # TODO: Create derived metadata for serializers once we switch to blueprinter
 
   config.infer_spec_type_from_file_location!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -127,10 +127,13 @@ RSpec.configure do |config|
     metadata[:type] = :lib_serializers
   end
 
-  config.define_derived_metadata(file_path: Regexp.new('/spec/serializers/curator')) do |metadata|
+  config.define_derived_metadata(file_path: Regexp.new('/spec/serializers/')) do |metadata|
     metadata[:type] = :serializers
   end
 
+  config.define_derived_metadata(file_path: Regexp.new('/spec/decorators/')) do |metadata|
+    metadata[:type] = :decorators
+  end
   # TODO: Create derived metadata for serializers once we switch to blueprinter
 
   config.infer_spec_type_from_file_location!

--- a/spec/serializers/curator/collection_serializer_spec.rb
+++ b/spec/serializers/curator/collection_serializer_spec.rb
@@ -2,19 +2,40 @@
 
 require 'rails_helper'
 require_relative './shared/inherited_serializers'
+require_relative './shared/json_serialization'
 
 RSpec.describe Curator::CollectionSerializer, type: :serializers do
-  pending
-  let(:record) { create(:curator_collection, :with_metastreams) }
   let!(:collection_count) { 3 }
-  let!(:records) { create_list(:curator_collection, collection_count, :with_metastreams) }
-  let!(:expected_as_json_options) do
-    {
-
-    }
-  end
+  let!(:record) { create(:curator_collection, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_collection, collection_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'curator_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:ark_id, :created_at, :updated_at, :abstract, :name],
+          include: {
+            institution: {
+              only: [:ark_id]
+            }
+          },
+          administrative: {
+            root: true,
+            only: [:description_standard, :harvestable, :flagged, :destination_site]
+          },
+          workflow: {
+            root: true,
+            only: [:publishing_state, :processing_state, :ingest_origin]
+          }
+        }
+      end
+    end
   end
 end

--- a/spec/serializers/curator/collection_serializer_spec.rb
+++ b/spec/serializers/curator/collection_serializer_spec.rb
@@ -4,12 +4,17 @@ require 'rails_helper'
 require_relative './shared/inherited_serializers'
 
 RSpec.describe Curator::CollectionSerializer, type: :serializers do
-  let!(:record) { create(:curator_collection, :with_metastreams) }
-  let!(:adapter_key) { :json }
+  pending
+  let(:record) { create(:curator_collection, :with_metastreams) }
+  let!(:collection_count) { 3 }
+  let!(:records) { create_list(:curator_collection, collection_count, :with_metastreams) }
+  let!(:expected_as_json_options) do
+    {
 
-  it_behaves_like 'curator_serializer'
+    }
+  end
 
-  describe 'Serializing Collection' do
-    let!(:records) { create_list(:curator_institution, 3, :with_location, :with_metastreams) }
+  describe 'Base Behavior' do
+    it_behaves_like 'curator_serializer'
   end
 end

--- a/spec/serializers/curator/collection_serializer_spec.rb
+++ b/spec/serializers/curator/collection_serializer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/inherited_serializers'
+
+RSpec.describe Curator::CollectionSerializer, type: :serializers do
+  let!(:record) { create(:curator_collection, :with_metastreams) }
+  let!(:adapter_key) { :json }
+
+  it_behaves_like 'curator_serializer'
+
+  describe 'Serializing Collection' do
+    let!(:records) { create_list(:curator_institution, 3, :with_location, :with_metastreams) }
+  end
+end

--- a/spec/serializers/curator/controlled_terms/authority_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/authority_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::AuthoritySerializer, type: :serializers do
+  let!(:authority_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_authority) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_authority, authority_count) }
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:name, :code, :base_url]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/genre_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/genre_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::GenreSerializer, type: :serializers do
+  let!(:genre_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_genre) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_genre, genre_count) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :id_from_auth, :basic, :authority_code],
+          methods: [:label, :id_from_auth, :basic, :authority_code]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/geographic_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/geographic_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::GeographicSerializer, type: :serializers do
+  let!(:geographic_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_geographic) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_geographic, geographic_count) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :id_from_auth, :authority_code, :bounding_box, :area_type, :coordinates],
+          methods: [:label, :id_from_auth, :authority_code, :bounding_box, :area_type, :coordinates]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/language_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/language_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::LanguageSerializer, type: :serializers do
+  let!(:language_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_language) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_language, language_count) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :id_from_auth, :authority_code],
+          methods: [:label, :id_from_auth, :authority_code]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/license_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/license_serializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::LicenseSerializer, type: :serializers do
+  let!(:license_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_license) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_license, license_count) }
+
+  skip 'Base Behavior' do
+    # NOTE: Since Licenses don't have an id_from_auth this will fail need to figure out a way to skip that final check in shared example
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :uri],
+          methods: [:label, :uri]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/license_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/license_serializer_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe Curator::ControlledTerms::LicenseSerializer, type: :serializers d
   let!(:record) { create(:curator_controlled_terms_license) }
   let!(:record_collection) { create_list(:curator_controlled_terms_license, license_count) }
 
-  skip 'Base Behavior' do
-    # NOTE: Since Licenses don't have an id_from_auth this will fail need to figure out a way to skip that final check in shared example
-    it_behaves_like 'nomenclature_serializer'
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer', has_id_from_auth: false
   end
 
   describe 'Serialization' do

--- a/spec/serializers/curator/controlled_terms/name_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/name_serializer_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-
-
 RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
   let!(:name_count) { 3 }
   let!(:record) { create(:curator_controlled_terms_name) }

--- a/spec/serializers/curator/controlled_terms/name_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/name_serializer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
+  let!(:name_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_name) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_name, name_count) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  skip 'Serialization' do
+    # TODO: Figure out a way to allow message for json_array
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :id_from_auth, :authority_code, :affiliation, :type],
+          methods: [:label, :id_from_auth, :authority_code, :bounding_box, :affiliation, :type]
+        }
+
+        before(:each) { allow(record).to recieve(:type) { record.name_type } }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/resource_type_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/resource_type_serializer_spec.rb
@@ -4,12 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-
-
-RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
-  let!(:name_count) { 3 }
-  let!(:record) { create(:curator_controlled_terms_name) }
-  let!(:record_collection) { create_list(:curator_controlled_terms_name, name_count) }
+RSpec.describe Curator::ControlledTerms::ResourceTypeSerializer, type: :serializers do
+  let!(:resource_type_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_resource_type) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_resource_type, resource_type_count) }
 
   describe 'Base Behavior' do
     it_behaves_like 'nomenclature_serializer'
@@ -22,8 +20,8 @@ RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
       let(:expected_as_json_options) do
         {
           root: true,
-          only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
-          methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+          only: [:label, :id_from_auth, :authority_code],
+          methods: [:label, :id_from_auth, :authority_code]
         }
       end
     end

--- a/spec/serializers/curator/controlled_terms/role_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/role_serializer_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::ControlledTerms::RoleSerializer, type: :serializers do
+  let!(:role_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_role) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_role, role_count) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'nomenclature_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:label, :id_from_auth, :authority_code],
+          methods: [:label, :id_from_auth, :authority_code]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/controlled_terms/subject_serializer_spec.rb
+++ b/spec/serializers/curator/controlled_terms/subject_serializer_spec.rb
@@ -4,12 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-
-
-RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
-  let!(:name_count) { 3 }
-  let!(:record) { create(:curator_controlled_terms_name) }
-  let!(:record_collection) { create_list(:curator_controlled_terms_name, name_count) }
+RSpec.describe Curator::ControlledTerms::SubjectSerializer, type: :serializers do
+  let!(:subject_count) { 3 }
+  let!(:record) { create(:curator_controlled_terms_subject) }
+  let!(:record_collection) { create_list(:curator_controlled_terms_subject, subject_count) }
 
   describe 'Base Behavior' do
     it_behaves_like 'nomenclature_serializer'
@@ -22,8 +20,8 @@ RSpec.describe Curator::ControlledTerms::NameSerializer, type: :serializers do
       let(:expected_as_json_options) do
         {
           root: true,
-          only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
-          methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+          only: [:label, :id_from_auth, :authority_code],
+          methods: [:label, :id_from_auth, :authority_code]
         }
       end
     end

--- a/spec/serializers/curator/digital_object_serializer_spec.rb
+++ b/spec/serializers/curator/digital_object_serializer_spec.rb
@@ -37,13 +37,7 @@ RSpec.describe Curator::DigitalObjectSerializer, type: :serializers do
             root: true,
             only: [:description_standard, :harvestable, :flagged, :destination_site]
           },
-          descriptive: {
-            root: true
-            # only: [:],
-            # included: {
-            #
-            # }
-          },
+          descriptive: descriptive_as_json_options,
           workflow: {
             root: true,
             only: [:publishing_state, :processing_state, :ingest_origin]

--- a/spec/serializers/curator/digital_object_serializer_spec.rb
+++ b/spec/serializers/curator/digital_object_serializer_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/inherited_serializers'
+require_relative './shared/json_serialization'
+
+RSpec.describe Curator::DigitalObjectSerializer, type: :serializers do
+  let!(:digital_object_count) { 3 }
+  let!(:descriptive_term_counts) { 2 }
+  let!(:record) { create(:curator_digital_object, :with_metastreams, :with_contained_by, desc_term_count: descriptive_term_counts) }
+  let!(:record_collection) { create_list(:curator_digital_object, digital_object_count, :with_contained_by, :with_metastreams, desc_term_count: descriptive_term_counts) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'curator_serializer'
+  end
+
+  skip 'Serialization(Pending)' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:ark_id, :created_at, :updated_at],
+          include: {
+            admin_set: {
+              only: :ark_id
+            },
+            contained_by: {
+              only: :ark_id
+            },
+            is_member_of_collection: {
+              only: :ark_id
+            }
+          },
+          administrative: {
+            root: true,
+            only: [:description_standard, :harvestable, :flagged, :destination_site]
+          },
+          descriptive: {
+            root: true
+            # only: [:],
+            # included: {
+            #
+            # }
+          },
+          workflow: {
+            root: true,
+            only: [:publishing_state, :processing_state, :ingest_origin]
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/digital_object_serializer_spec.rb
+++ b/spec/serializers/curator/digital_object_serializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Curator::DigitalObjectSerializer, type: :serializers do
     it_behaves_like 'curator_serializer'
   end
 
-  skip 'Serialization(Pending)' do
+  describe 'Serialization' do
     it_behaves_like 'json_serialization' do
       let(:json_record) { record }
       let(:json_array) { record_collection }

--- a/spec/serializers/curator/filestreams/audio_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/audio_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::AudioSerializer, type: :serializers do
+  let!(:audio_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_audio, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_audio, audio_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/filestreams/document_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/document_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::DocumentSerializer, type: :serializers do
+  let!(:document_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_document, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_document, document_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/filestreams/ereader_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/ereader_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::EreaderSerializer, type: :serializers do
+  let!(:ereader_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_ereader, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_ereader, ereader_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/filestreams/image_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/image_serializer_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/inherited_serializers'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
+  let!(:image_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+
+  describe 'Base Behavior' do
+    it_behaves_like 'file_set_serializer'
+  end
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:ark_id, :created_at, :updated_at, :file_name_base, :position, :pagination],
+          include: {
+            file_set_of: {
+              only: [:ark_id]
+            }
+          },
+          administrative: {
+            root: true,
+            only: [:description_standard, :harvestable, :flagged, :destination_site]
+          },
+          workflow: {
+            root: true,
+            only: [:publishing_state, :processing_state, :ingest_origin]
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/filestreams/metadata_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/metadata_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::MetadataSerializer, type: :serializers do
+  let!(:metadata_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_metadata, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_ereader, metadata_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/filestreams/text_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/text_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::TextSerializer, type: :serializers do
+  let!(:text_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_text, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_text, text_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/filestreams/video_serializer_spec.rb
+++ b/spec/serializers/curator/filestreams/video_serializer_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 require_relative '../shared/inherited_serializers'
 require_relative '../shared/json_serialization'
 
-RSpec.describe Curator::Filestreams::ImageSerializer, type: :serializers do
-  let!(:image_file_set_count) { 3 }
-  let!(:record) { create(:curator_filestreams_image, :with_metastreams) }
-  let!(:record_collection) { create_list(:curator_filestreams_image, image_file_set_count, :with_metastreams) }
+RSpec.describe Curator::Filestreams::VideoSerializer, type: :serializers do
+  let!(:video_file_set_count) { 3 }
+  let!(:record) { create(:curator_filestreams_video, :with_metastreams) }
+  let!(:record_collection) { create_list(:curator_filestreams_ereader, video_file_set_count, :with_metastreams) }
 
   describe 'Base Behavior' do
     it_behaves_like 'file_set_serializer'

--- a/spec/serializers/curator/institution_serializer_spec.rb
+++ b/spec/serializers/curator/institution_serializer_spec.rb
@@ -13,12 +13,13 @@ RSpec.describe Curator::InstitutionSerializer, type: :serializers do
   end
 
   describe 'Serialization' do
-
     it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
       let(:expected_as_json_options) do
         {
           root: true,
-          only: [:ark_id, :created_at, :updated_at, :abstract, :url],
+          only: [:ark_id, :created_at, :updated_at, :name, :abstract, :url],
           include: {
             location: {
               methods: [:area_type, :coordinates, :bounding_box, :authority_code, :label, :id_from_auth],
@@ -35,9 +36,6 @@ RSpec.describe Curator::InstitutionSerializer, type: :serializers do
           }
         }
       end
-      let(:json_record) { record }
-      let(:json_array) { record_collection }
     end
   end
-
 end

--- a/spec/serializers/curator/institution_serializer_spec.rb
+++ b/spec/serializers/curator/institution_serializer_spec.rb
@@ -2,14 +2,42 @@
 
 require 'rails_helper'
 require_relative './shared/inherited_serializers'
-
+require_relative './shared/json_serialization'
 RSpec.describe Curator::InstitutionSerializer, type: :serializers do
+  let!(:institution_count) { 3 }
   let!(:record) { create(:curator_institution, :with_location, :with_metastreams) }
-  let!(:adapter_key) { :json }
+  let!(:record_collection) { create_list(:curator_institution, institution_count, :with_location, :with_metastreams) }
 
-  it_behaves_like 'curator_serializer'
-
-  describe 'Serializing Collection' do
-    let!(:records) { create_list(:curator_institution, 3, :with_location, :with_metastreams) }
+  describe 'Base Behavior' do
+    it_behaves_like 'curator_serializer'
   end
+
+  describe 'Serialization' do
+
+    it_behaves_like 'json_serialization' do
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:ark_id, :created_at, :updated_at, :abstract, :url],
+          include: {
+            location: {
+              methods: [:area_type, :coordinates, :bounding_box, :authority_code, :label, :id_from_auth],
+              only: [:area_type, :coordinates, :bounding_box, :authority_code, :label, :id_from_auth]
+            }
+          },
+          administrative: {
+            root: true,
+            only: [:description_standard, :harvestable, :flagged, :destination_site]
+          },
+          workflow: {
+            root: true,
+            only: [:publishing_state, :processing_state, :ingest_origin]
+          }
+        }
+      end
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+    end
+  end
+
 end

--- a/spec/serializers/curator/institution_serializer_spec.rb
+++ b/spec/serializers/curator/institution_serializer_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/inherited_serializers'
+
+RSpec.describe Curator::InstitutionSerializer, type: :serializers do
+  let!(:record) { create(:curator_institution, :with_location, :with_metastreams) }
+  let!(:adapter_key) { :json }
+
+  it_behaves_like 'curator_serializer'
+
+  describe 'Serializing Collection' do
+    let!(:records) { create_list(:curator_institution, 3, :with_location, :with_metastreams) }
+  end
+end

--- a/spec/serializers/curator/metastreams/administrative_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/administrative_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::Metastreams::AdministrativeSerializer, type: :serializers do
+  let!(:administrative_count) { 3 }
+  let!(:record) { create(:curator_metastreams_administrative) }
+  let!(:record_collection) { create_list(:curator_metastreams_administrative, administrative_count) }
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:description_standard, :flagged, :harvestable, :destination_site]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
@@ -4,5 +4,35 @@ require 'rails_helper'
 require_relative '../shared/json_serialization'
 
 RSpec.describe Curator::Metastreams::DescriptiveSerializer, type: :serializers do
-  pending 'spec pending'
+  let!(:descriptive_count) { 3 }
+  let!(:desc_term_counts) { 3 }
+  let!(:record) { create(:curator_metastreams_descriptive) }
+  let!(:record_collection) { create_list(:curator_metastreams_descriptive, descriptive_count) }
+
+  skip 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url],
+          include: {
+            physical_location: {
+              only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
+              methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+            },
+            identifier: {
+              only: [:label, :type, :invalid],
+              methods: [:label, :type, :invalid]
+            },
+            title: {
+              only: [:primary, :other],
+              methods: [:primary, :other]
+            }
+          }
+        }
+      end
+    end
+  end
 end

--- a/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
@@ -6,33 +6,14 @@ require_relative '../shared/json_serialization'
 RSpec.describe Curator::Metastreams::DescriptiveSerializer, type: :serializers do
   let!(:descriptive_count) { 3 }
   let!(:desc_term_counts) { 3 }
-  let!(:record) { create(:curator_metastreams_descriptive) }
-  let!(:record_collection) { create_list(:curator_metastreams_descriptive, descriptive_count) }
+  let!(:record) { create(:curator_metastreams_descriptive, :with_all_desc_terms, desc_term_count: desc_term_counts) }
+  let!(:record_collection) { create_list(:curator_metastreams_descriptive, descriptive_count, :with_all_desc_terms, desc_term_count: desc_term_counts) }
 
-  skip 'Serialization' do
+  describe 'Serialization' do
     it_behaves_like 'json_serialization' do
       let(:json_record) { record }
       let(:json_array) { record_collection }
-      let(:expected_as_json_options) do
-        {
-          root: true,
-          only: [:abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url],
-          include: {
-            physical_location: {
-              only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
-              methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
-            },
-            identifier: {
-              only: [:label, :type, :invalid],
-              methods: [:label, :type, :invalid]
-            },
-            title: {
-              only: [:primary, :other],
-              methods: [:primary, :other]
-            }
-          }
-        }
-      end
+      let(:expected_as_json_options) { descriptive_as_json_options }
     end
   end
 end

--- a/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/descriptive_serializer_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::Metastreams::DescriptiveSerializer, type: :serializers do
+  pending 'spec pending'
+end

--- a/spec/serializers/curator/metastreams/workflow_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/workflow_serializer_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/json_serialization'
+
+RSpec.describe Curator::Metastreams::WorkflowSerializer, type: :serializers do
+  let!(:workflow_count) { 3 }
+  let!(:record) { create(:curator_metastreams_workflow) }
+  let!(:record_collection) { create_list(:curator_metastreams_workflow, workflow_count) }
+
+  describe 'Serialization' do
+    it_behaves_like 'json_serialization' do
+      let(:json_record) { record }
+      let(:json_array) { record_collection }
+      let(:expected_as_json_options) do
+        {
+          root: true,
+          only: [:publishing_state, :processing_state, :ingest_origin]
+        }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/shared/inherited_serializers.rb
+++ b/spec/serializers/curator/shared/inherited_serializers.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples_for 'curator_serializer', type: :serializers do
-  describe 'CuratorSerializer' do
+  describe 'Curator::CuratorSerializer' do
     let(:adapter_key) { :json }
     let(:base_attribute_keys) { serializer_adapter_schema_attributes(Curator::CuratorSerializer, adapter_key, :attributes) }
     let(:described_class_attribute_keys) { serializer_adapter_schema_attributes(described_class, adapter_key, :attributes) }
     let(:described_class_instance) { described_class.new(record, adapter_key) }
 
-    it 'is expected to be a kind of Curator::CuartorSerializer'do
+    it 'is expected to be a kind of Curator::CuratorSerializer'do
       expect(described_class_instance).to be_a_kind_of(Curator::CuratorSerializer)
     end
 
@@ -29,7 +29,29 @@ RSpec.shared_examples_for 'curator_serializer', type: :serializers do
 end
 
 RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do
-  describe 'ControlledTerms::NomenclatureSerializer' do
-    pending
+  describe 'Curator::ControlledTerms::NomenclatureSerializer' do
+    let(:adapter_key) { :json }
+    let(:base_attribute_keys) { serializer_adapter_schema_attributes(Curator::ControlledTerms::NomenclatureSerializer, adapter_key, :attributes) }
+    let(:described_class_attribute_keys) { serializer_adapter_schema_attributes(described_class, adapter_key, :attributes) }
+    let(:described_class_instance) { described_class.new(record, adapter_key) }
+
+    it 'is expected to be a kind of Curator::CuratorSerializer'do
+      expect(described_class_instance).to be_a_kind_of(Curator::ControlledTerms::NomenclatureSerializer)
+    end
+
+    it 'expects the base attribute keys to be in the described class attriubute keys' do
+      expect(described_class_attribute_keys).to include(*base_attribute_keys)
+    end
+
+    describe 'inherited serializer attributes' do
+      subject { described_class_instance.serializable_hash }
+
+      let(:root_key) { fetch_transformed_root_key(described_class_instance) }
+
+      it 'is expected to have base attributes in serializable_hash' do
+        expect(subject).to have_key(root_key)
+        expect(subject[root_key].keys).to include(*base_attribute_keys)
+      end
+    end
   end
 end

--- a/spec/serializers/curator/shared/inherited_serializers.rb
+++ b/spec/serializers/curator/shared/inherited_serializers.rb
@@ -28,10 +28,11 @@ RSpec.shared_examples_for 'curator_serializer', type: :serializers do
   end
 end
 
-RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do
+RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do |has_id_from_auth: true|
   describe 'Curator::ControlledTerms::NomenclatureSerializer' do
     let(:adapter_key) { :json }
     let(:base_attribute_keys) { serializer_adapter_schema_attributes(Curator::ControlledTerms::NomenclatureSerializer, adapter_key, :attributes) }
+    let(:attribute_keys_proc) { -> (use_id_from_auth) { use_id_from_auth ? base_attribute_keys : base_attribute_keys.reject { |a| a == 'id_from_auth' } } }
     let(:described_class_attribute_keys) { serializer_adapter_schema_attributes(described_class, adapter_key, :attributes) }
     let(:described_class_instance) { described_class.new(record, adapter_key) }
 
@@ -47,10 +48,11 @@ RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do
       subject { described_class_instance.serializable_hash }
 
       let(:root_key) { fetch_transformed_root_key(described_class_instance) }
+      let(:attribute_keys) { attribute_keys_proc.call(has_id_from_auth) }
 
       it 'is expected to have base attributes in serializable_hash' do
         expect(subject).to have_key(root_key)
-        expect(subject[root_key].keys).to include(*base_attribute_keys)
+        expect(subject[root_key].keys).to include(*attribute_keys)
       end
     end
   end

--- a/spec/serializers/curator/shared/inherited_serializers.rb
+++ b/spec/serializers/curator/shared/inherited_serializers.rb
@@ -55,3 +55,7 @@ RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do
     end
   end
 end
+
+RSpec.shared_examples_for 'file_set_serializer', type: :serializers do
+  pending "File Set serializer shared group not active yet.."
+end

--- a/spec/serializers/curator/shared/inherited_serializers.rb
+++ b/spec/serializers/curator/shared/inherited_serializers.rb
@@ -59,5 +59,31 @@ RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do |has_
 end
 
 RSpec.shared_examples_for 'file_set_serializer', type: :serializers do
-  pending "File Set serializer shared group not active yet.."
+  it_behaves_like 'curator_serializer'
+  describe 'Curator::Filestreams::FileSetSerializer' do
+    let(:adapter_key) { :json }
+    let(:base_attribute_keys) { serializer_adapter_schema_attributes(Curator::Filestreams::FileSetSerializer, adapter_key, :attributes) }
+    let(:described_class_attribute_keys) { serializer_adapter_schema_attributes(described_class, adapter_key, :attributes) }
+    let(:described_class_instance) { described_class.new(record, adapter_key) }
+
+    it 'is expected to be a kind of Curator::CuratorSerializer'do
+      expect(described_class_instance).to be_a_kind_of(Curator::Filestreams::FileSetSerializer)
+    end
+
+    it 'expects the base attribute keys to be in the described class attriubute keys' do
+      expect(described_class_attribute_keys).to include(*base_attribute_keys)
+    end
+
+    describe 'inherited serializer attributes' do
+      subject { described_class_instance.serializable_hash }
+
+      let(:root_key) { fetch_transformed_root_key(described_class_instance) }
+      let(:attribute_keys) { base_attribute_keys }
+
+      it 'is expected to have base attributes in serializable_hash' do
+        expect(subject).to have_key(root_key)
+        expect(subject[root_key].keys).to include(*attribute_keys)
+      end
+    end
+  end
 end

--- a/spec/serializers/curator/shared/inherited_serializers.rb
+++ b/spec/serializers/curator/shared/inherited_serializers.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for 'curator_serializer', type: :serializers do
+  describe 'CuratorSerializer' do
+    let(:adapter_key) { :json }
+    let(:base_attribute_keys) { serializer_adapter_schema_attributes(Curator::CuratorSerializer, adapter_key, :attributes) }
+    let(:described_class_attribute_keys) { serializer_adapter_schema_attributes(described_class, adapter_key, :attributes) }
+    let(:described_class_instance) { described_class.new(record, adapter_key) }
+
+    it 'is expected to be a kind of Curator::CuartorSerializer'do
+      expect(described_class_instance).to be_a_kind_of(Curator::CuratorSerializer)
+    end
+
+    it 'expects the base attribute keys to be in the described class attriubute keys' do
+      expect(described_class_attribute_keys).to include(*base_attribute_keys)
+    end
+
+    describe 'inherited serializer attributes' do
+      subject { described_class_instance.serializable_hash }
+
+      let(:root_key) { fetch_transformed_root_key(described_class_instance) }
+
+      it 'is expected to have base attributes in serializable_hash' do
+        expect(subject).to have_key(root_key)
+        expect(subject[root_key].keys).to include(*base_attribute_keys)
+      end
+    end
+  end
+end
+
+RSpec.shared_examples_for 'nomenclature_serializer', type: :serializers do
+  describe 'ControlledTerms::NomenclatureSerializer' do
+    pending
+  end
+end

--- a/spec/serializers/curator/shared/json_serialization.rb
+++ b/spec/serializers/curator/shared/json_serialization.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples 'json_serialization', type: :serializers do
   let!(:adapter_key) { :json }
-  let!(:json_regex) { /\{.*\:\{.*\:.*\}\}/ }
+  let!(:json_regex) { /[{\[]{1}([,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t]|".*?")+[}\]]{1}/ }
   let!(:recurse_keys_to_json_map) do
     proc do |val|
       case val

--- a/spec/serializers/curator/shared/json_serialization.rb
+++ b/spec/serializers/curator/shared/json_serialization.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'json_serialization', type: :serializers do
+  let(:adapter_key) { :json }
+  let(:json_regex) { /\{.*\:\{.*\:.*\}\}/ }
+
+  describe 'JSON serialization behavior' do
+    describe 'For single record' do
+      let(:serializer_for_one) { described_class.new(json_record, adapter_key) }
+      let(:expected_json_hash) { record_as_json(json_record, expected_as_json_options) }
+      let(:json_root_key) { record_root_key(json_record) }
+
+      describe '#serializable_hash' do
+        subject { serializer_for_one.serializable_hash }
+
+        it { is_expected.to be_a_kind_of(Hash).and have_key(json_root_key) }
+
+        it 'expects subject to match :expected_json_hash' do
+          expect(subject).to match(json_root_key => a_hash_including(expected_json_hash[json_root_key]))
+        end
+      end
+
+      describe '#render' do
+        subject { serializer_for_one.render }
+
+        let(:expected_json_matchers) do
+          recurse_to_json_map = proc do |val|
+            case val
+            when Hash
+              val.keys.map(&:to_json) + recurse_to_json_map.call(val.values)
+            when Array
+              awesome_print val
+            else
+              val.to_json
+            end
+          end
+          recurse_to_json_map.call(expected_json_hash[json_root_key])
+        end
+
+        it { is_expected.to be_a_kind_of(String).and match(json_regex).and match(json_root_key) }
+
+        it 'expects subject to match all of the expected_json_matchers' do
+          expected_json_matchers.each do |json_matcher|
+            awesome_print json_matcher
+            awesome_print subject.match(json_matcher)
+            expect(subject).to match(json_matcher)
+          end
+        end
+      end
+    end
+
+    describe 'For collection of records' do
+      let(:serializer_for_many) { described_class.new(json_array, adapter_key) }
+      let(:expected_json_array) { json_array.map { |json_record| record_as_json(json_record, expected_as_json_options.merge(root: false)) }}
+
+      describe '#serializable_hash' do
+        subject { serializer_for_many.serializable_hash }
+
+        let(:json_root_key) { record_root_key(json_array) }
+
+        it { is_expected.to be_a_kind_of(Hash).and have_key(json_root_key) }
+
+        it 'expects the root key to contain an array' do
+          expect(subject[json_root_key]).to be_a_kind_of(Array).and all(be_a_kind_of(Hash))
+        end
+
+        it 'expects each element of the hash to match the :expected_json_array' do
+          expect(subject[json_root_key].count).to eql(expected_json_array.count)
+          expected_json_array.each do |json_record|
+            expect(subject).to match(json_root_key => array_including(a_hash_including(json_record)))
+          end
+        end
+      end
+
+      describe '#render' do
+        subject { serializer_for_many.render }
+
+        let(:json_root_key) { record_root_key(json_array) }
+
+        it { is_expected.to be_a_kind_of(String).and match(json_root_key) }
+      end
+    end
+  end
+end

--- a/spec/serializers/curator/shared/json_serialization.rb
+++ b/spec/serializers/curator/shared/json_serialization.rb
@@ -7,9 +7,9 @@ RSpec.shared_examples 'json_serialization', type: :serializers do
     proc do |val|
       case val
       when Hash
-        val.keys.map(&:to_json).concat(recurse_keys_to_json_map.call(val.values.select { |v| Hash === v }))
+        val.keys.map(&:to_json).concat(recurse_keys_to_json_map.call(val.values.select { |v| v.is_a?(Hash) }))
       when Array
-        val.flat_map { |v| recurse_keys_to_json_map.call(v) }
+        val.flat_map { |v| recurse_keys_to_json_map.call(v) if v.is_a?(Hash) }.compact
       end
     end
   end
@@ -21,6 +21,8 @@ RSpec.shared_examples 'json_serialization', type: :serializers do
         val.inject([]) do |ret, (_k, v)|
           ret << recurse_vals_to_json_map.call(v)
         end.flatten
+      when Array
+        val.flat_map { |v| recurse_vals_to_json_map.call(v) }
       else
         val.to_json
       end
@@ -117,14 +119,14 @@ RSpec.shared_examples 'json_serialization', type: :serializers do
         it 'expects the subject to match the key, val times in the :json_key_tally' do
           json_key_tally.each do |key, val|
             expect(subject).to match(key)
-            expect(subject.scan(key).count).to eq(val)
+            expect(subject.scan(key).count).to eq(val), "failed on #{key}"
           end
         end
 
         it 'expects the subject to match the key, val times in the :json_val_tally' do
           json_val_tally.each do |key, val|
             expect(subject).to match(key)
-            expect(subject.scan(key).count).to eq(val)
+            expect(subject.scan(key).count).to eq(val), "failed on #{key}"
           end
         end
       end

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -29,8 +29,30 @@ module SerializerHelper
       record.as_json(opts.dup.slice(:only, :include))
     end
   end
+
+  module IntegrationHelper
+    def record_as_json(record, options = {})
+      record.as_json(options.slice(:only, :include, :root, :except, :method))
+    end
+
+    def fetch_transformed_root_key(serializer_instance)
+      serializer_instance.adapter.send(:run_root_key_transform, serializer_instance.record)
+    end
+
+    def serializer_adapter_schema_attributes(serializer_class, adapter_key, facet_group_key)
+      return [] if adapter_key == :null
+
+      serializer_class.send(:_schema_for_adapter, adapter_key)&.
+                                                                schema&.
+                                                                facet_groups&.
+                                                                fetch(facet_group_key, [])&.
+                                                                map(&:key)&.
+                                                                map(&:to_s)
+    end
+  end
 end
 
 RSpec.configure do |config|
   config.include SerializerHelper::FacetHelper, type: :lib_serializers
+  config.include SerializerHelper::IntegrationHelper, type: :serializers
 end

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -6,7 +6,7 @@ module SerializerHelper
     # This is only required when stubbing out an expected value for as json in the descriptive class
     def descriptive_as_json_options
       {
-        after_as_json: -> (json_record) { json_record['host_collections'] = json_record['host_collections'].flat_map(&:values) if json_record.key?('host_collections') },
+        after_as_json: -> (json_record) { json_record['host_collections'] = json_record['host_collections'].flat_map(&:values) if json_record.key?('host_collections'); json_record },
         root: true,
         only: [:abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url],
         include: {
@@ -198,9 +198,12 @@ module SerializerHelper
     end
 
     protected
+
+    # helper method for running after_as_json procs to clean up otherwise difficult as json
+    # See host_collection proc in descriptive_as_json_options to see what I mean
     def post_process_as_json(as_json_record, root_key, options = {})
       if options.key?(:after_as_json) && options[:after_as_json].respond_to?(:call)
-        if root_key && as_json_record.key(root_key)
+        if root_key && as_json_record.key?(root_key)
           as_json_record[root_key] = options[:after_as_json].call(as_json_record[root_key].dup)
         else
           as_json_record = options[:after_as_json].call(as_json_record.dup)

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -53,10 +53,10 @@ module SerializerHelper
       record.model_name.element
     end
 
-     #use record.metastreams for decorator object
+    # NOTE: Use record.metastreams for decorator object
     def metastreams_json(record_metastreams, meta_json_opts = {})
       metastreams = %i(administrative descriptive workflow).inject({}) do |ret, metastream|
-        next ret unless record_metastreams.respond_to?(metastream) &&   record_metastreams.public_send(metastream).present?
+        next ret unless record_metastreams.respond_to?(metastream) && record_metastreams.public_send(metastream).present?
 
         as_json_opts = meta_json_opts.fetch(metastream.to_sym, {}).slice(:root, :only, :include, :methods)
         ret.merge(record_metastreams.public_send(metastream).as_json(as_json_opts))
@@ -79,11 +79,13 @@ module SerializerHelper
                                                                 map(&:key)&.
                                                                 map(&:to_s)
     end
+
     protected
-    #Removes nils from hash
+
+    # NOTE: Helper method that recursivley removes blank, nil, and false values hash
     def crush_as_json(json_data)
       json_data.each_with_object({}) do |(k, v), new_hash|
-        unless v.blank?
+        if v.present?
           v.is_a?(Hash) ? new_hash[k] = crush_as_json(v) : new_hash[k] = v
         end
       end

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -11,7 +11,7 @@ module SerializerHelper
     def schema_attribute_group_keys(schema = nil, facet_group_key = nil)
       return {} if schema.blank?
 
-      return [] if facet_group.blank?
+      return [] if facet_group_key.blank?
 
       schema.facet_groups.fetch(facet_group_key, []).map { |f| f.key.to_s }
     end
@@ -92,7 +92,7 @@ module SerializerHelper
 
       schema = serializer_class.send(:_schema_for_adapter, adapter_key)&.schema
 
-      schema_attribute_group_keys(schema, facet_group)
+      schema_attribute_group_keys(schema, facet_group_key)
     end
 
     protected

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -10,7 +10,7 @@ module SerializerHelper
         root: true,
         only: [:abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url],
         include: {
-          host_collections: { only: [:name]},
+          host_collections: { only: [:name] },
           physical_location: {
             only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
             methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
@@ -213,7 +213,6 @@ module SerializerHelper
       return crush_as_json(as_json_record)
     end
 
-
     # NOTE: Helper method that recursivley removes blank, nil, and false values hash
     def crush_as_json(hash)
       hash.each_with_object({}) do |(k, v), new_hash|
@@ -221,7 +220,7 @@ module SerializerHelper
           if v.is_a?(Hash)
             new_hash[k] = crush_as_json(v)
           elsif v.is_a?(Array)
-             new_hash[k] = v.map { |ve|  ve.is_a?(Hash) ? crush_as_json(ve) : ve }
+            new_hash[k] = v.map { |ve| ve.is_a?(Hash) ? crush_as_json(ve) : ve }
           else
             new_hash[k] = v
           end

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -1,6 +1,103 @@
 # frozen_string_literal: true
 
 module SerializerHelper
+  module AsJsonHelper
+    # NOTE: This method return the long list of options userf for when #as_json on a descriptive is called of the descriptive as json
+    # This is only required when stubbing out an expected value for as json in the descriptive class
+    def descriptive_as_json_options
+      {
+        after_as_json: -> (json_record) { json_record['host_collections'] = json_record['host_collections'].flat_map(&:values) if json_record.key?('host_collections') },
+        root: true,
+        only: [:abstract, :digital_origin, :origin_event, :text_direction, :resource_type_manuscript, :place_of_publication, :publisher, :issuance, :frequency, :extent, :physical_location_department, :physical_location_shelf_locator, :series, :subseries, :subsubseries, :rights, :access_restrictions, :toc, :toc_url],
+        include: {
+          host_collections: { only: [:name]},
+          physical_location: {
+            only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
+            methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+          },
+          identifier: {
+            only: [:label, :type, :invalid],
+            methods: [:label, :type, :invalid]
+          },
+          title: {
+            only: [:primary, :other],
+            methods: [:primary, :other]
+          },
+          note: {
+            only: [:label, :type],
+            methods: [:label, :type]
+          },
+          cartographic: {
+            only: [:scale, :projection],
+            methods: [:scale, :projection]
+          },
+          date: {
+            only: [:created, :issued, :copyright],
+            methods: [:created, :issued, :copyright]
+          },
+          related: {
+            only: [:constituent, :other_format, :referenced_by_url, :references_url, :review_url],
+            methods: [:constituent, :other_format, :referenced_by_url, :references_url, :review_url]
+          },
+          publication: {
+            only: [:edition_name, :edition_number, :volume, :issue_number],
+            methods: [:edition_name, :edition_number, :volume, :issue_number]
+          },
+          resource_types: {
+            only: [:label, :id_from_auth, :authority_code],
+            methods: [:label, :id_from_auth, :authority_code]
+          },
+          genres: {
+            only: [:label, :id_from_auth, :basic, :authority_code],
+            methods: [:label, :id_from_auth, :basic, :authority_code]
+          },
+          languages: {
+            only: [:label, :id_from_auth, :authority_code],
+            methods: [:label, :id_from_auth, :authority_code]
+          },
+          licenses: {
+            only: [:label, :uri],
+            methods: [:label, :uri]
+          },
+          subject: {
+            methods: [:dates, :temporals],
+            include: {
+              titles: {
+                only: [:label, :subtitle, :display, :display_label, :usage, :supplied, :language, :type, :authority_code, :id_from_auth, :part_name, :part_number],
+                methods: [:label, :subtitle, :display, :display_label, :usage, :supplied, :language, :type, :authority_code, :id_from_auth, :part_name, :part_number]
+              },
+              topics: {
+                only: [:label, :id_from_auth, :authority_code],
+                methods: [:label, :id_from_auth, :authority_code]
+              },
+              names: {
+                only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
+                methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+              },
+              geos: {
+                only: [:label, :id_from_auth, :authority_code, :bounding_box, :area_type, :coordinates],
+                methods: [:label, :id_from_auth, :authority_code, :bounding_box, :area_type, :coordinates]
+              }
+            }
+          },
+          name_roles: {
+            except: [:id, :descriptive_id, :name_id, :role_id],
+            include: {
+              name: {
+                only: [:label, :id_from_auth, :authority_code, :affiliation, :name_type],
+                methods: [:label, :id_from_auth, :authority_code, :affiliation, :name_type]
+              },
+              role: {
+                only: [:label, :id_from_auth, :authority_code],
+                methods: [:label, :id_from_auth, :authority_code]
+              }
+            }
+          }
+        }
+      }
+    end
+  end
+
   module SchemaHelper
     def schema_attribute_keys(schema = nil)
       return [] if schema.blank?
@@ -49,20 +146,22 @@ module SerializerHelper
 
   module IntegrationHelper
     include SchemaHelper
+    include AsJsonHelper
     def record_as_json(record, options = {})
-      return crush_as_json(record.as_json(options.slice(:root, :include, :only, :methods))) unless record.respond_to?(:metastreams)
+      record_root_key = record_root_key(record)
+      return post_process_as_json(record.as_json(options.dup.slice(:root, :include, :only, :methods)), record_root_key, options) unless record.respond_to?(:metastreams)
 
       rec_as_json = record.as_json(options.slice(:root, :include, :only, :methods))
+
       meta_as_json = metastreams_json(record.metastreams, options)
 
-      record_root_key = record_root_key(record)
       if rec_as_json.key?(record_root_key)
         rec_as_json[record_root_key] = rec_as_json[record_root_key].dup.merge(meta_as_json)
-        return crush_as_json(rec_as_json)
+        return post_process_as_json(rec_as_json, record_root_key, options)
       end
 
       rec_as_json = rec_as_json.merge(meta_as_json)
-      crush_as_json(rec_as_json)
+      post_process_as_json(rec_as_json, record_root_key, options)
     end
 
     def record_root_key(record)
@@ -76,8 +175,11 @@ module SerializerHelper
       metastreams = %i(administrative descriptive workflow).inject({}) do |ret, metastream|
         next ret unless record_metastreams.respond_to?(metastream) && record_metastreams.public_send(metastream).present?
 
-        as_json_opts = meta_json_opts.fetch(metastream.to_sym, {}).slice(:root, :only, :include, :methods)
-        ret.merge(record_metastreams.public_send(metastream).as_json(as_json_opts))
+        meta_opts = meta_json_opts.fetch(metastream.to_sym, {})
+        as_json_opts = meta_opts.dup.slice(:root, :only, :include, :methods)
+        record_as_json = record_metastreams.public_send(metastream).as_json(as_json_opts)
+        record_as_json = post_process_as_json(record_as_json, metastream.to_s, meta_opts)
+        ret.merge(record_as_json)
       end
 
       Hash['metastreams', metastreams]
@@ -96,12 +198,30 @@ module SerializerHelper
     end
 
     protected
+    def post_process_as_json(as_json_record, root_key, options = {})
+      if options.key?(:after_as_json) && options[:after_as_json].respond_to?(:call)
+        if root_key && as_json_record.key(root_key)
+          as_json_record[root_key] = options[:after_as_json].call(as_json_record[root_key].dup)
+        else
+          as_json_record = options[:after_as_json].call(as_json_record.dup)
+        end
+      end
+
+      return crush_as_json(as_json_record)
+    end
+
 
     # NOTE: Helper method that recursivley removes blank, nil, and false values hash
-    def crush_as_json(json_data)
-      json_data.each_with_object({}) do |(k, v), new_hash|
+    def crush_as_json(hash)
+      hash.each_with_object({}) do |(k, v), new_hash|
         if v.present?
-          v.is_a?(Hash) ? new_hash[k] = crush_as_json(v) : new_hash[k] = v
+          if v.is_a?(Hash)
+            new_hash[k] = crush_as_json(v)
+          elsif v.is_a?(Array)
+             new_hash[k] = v.map { |ve|  ve.is_a?(Hash) ? crush_as_json(ve) : ve }
+          else
+            new_hash[k] = v
+          end
         end
       end
     end


### PR DESCRIPTION
closes #59 
- Integrated Serializer DSL into `app/serializers`
- Added Decorator Class to wrap certain elements of a model into one instance(For use with nodes in DSL)
- Added Scope `for_serialization` to `digital_objects`, `collections`, `institutions` `metastreams/descriptives` to use when querying models in controller and avoid N+1 queries

- DRYed out the `metastreamables` concern for partial/all `metastreams` 
- Fixed a inheritance bug regarding the Serializer DSL and updated tests to reflect fixes.

- Also added `attr_json` for the `pagination` attribute in `file_sets`