### PR TITLE
sync JSON structures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -746,6 +746,7 @@ RSpec/MultipleExpectations:
   Max: 5
   Exclude:
     - 'spec/lib/curator/parsers/edtf_date_parser_spec.rb'
+    - 'spec/services/curator/digital_object_factory_service_spec.rb'
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -129,15 +129,17 @@ module Curator
 
     def publication(json_attrs = {})
       pub_hash = {}
+      pub_attrs = json_attrs.fetch(:publication, {})
       %i(edition_name edition_number volume issue_number).each do |k|
-        pub_hash[k] = json_attrs.fetch(k, nil)
+        pub_hash[k] = pub_attrs.fetch(k, nil)
       end
       Descriptives::Publication.new(pub_hash.compact)
     end
 
     def title(json_attrs = {})
-      primary = json_attrs.fetch(:title_primary, {})
-      other = json_attrs.fetch(:title_other, {}).map { |t_attrs| title_attr(t_attrs) }
+      titles = json_attrs.fetch(:title, {})
+      primary = titles.fetch(:primary, {})
+      other = titles.fetch(:other, {}).map { |t_attrs| title_attr(t_attrs) }
       Descriptives::TitleSet.new(primary: primary, other: other)
     end
 
@@ -150,14 +152,12 @@ module Curator
     end
 
     def related(json_attrs = {})
-      constituent = json_attrs.fetch(:related_constituent, nil)
-      referenced_by_url = json_attrs.fetch(:related_referenced_by_url, [])
-      references_url = json_attrs.fetch(:related_references_url, [])
-      other_format = json_attrs.fetch(:related_other_format, [])
-      review_url = json_attrs.fetch(:related_review_url, [])
-      Descriptives::Related.new(constituent: constituent, referenced_by_url: referenced_by_url,
-                                references_url: references_url, other_format: other_format,
-                                review_url: review_url)
+      related_hash = {}
+      related_attrs = json_attrs.fetch(:related, {})
+      %i(constituent referenced_by_url references_url other_format review_url).each do |k|
+        related_hash[k] = related_attrs.fetch(k, nil)
+      end
+      Descriptives::Related.new(related_hash)
     end
 
     def physical_location(json_attrs = {})
@@ -176,9 +176,10 @@ module Curator
     end
 
     def cartographics(json_attrs = {})
+      carto_attrs = json_attrs.fetch(:cartographic, {})
       Descriptives::Cartographic.new(
-        scale: json_attrs.fetch(:scale, []),
-        projection: json_attrs.fetch(:projection, nil)
+        scale: carto_attrs.fetch(:scale, []),
+        projection: carto_attrs.fetch(:projection, nil)
       )
     end
 

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -27,31 +27,33 @@
             "invalid": true
           }
         ],
-        "title_primary": {
-          "label": "The wintermind",
-          "subtitle": "William Bonk and American letters",
-          "display": "primary",
-          "usage": "primary",
-          "supplied": true,
-          "language": "eng",
-          "authority_code": "naf",
-          "id_from_auth": "n00020514",
-          "part_number": "Vol. 1",
-          "part_name": "Being the third book"
-        },
-        "title_other": [
-          {
-            "label": "The man who would be king",
-            "type": "alternative",
-            "display": "Below map:"
-          },
-          {
-            "label": "Bible",
-            "type": "uniform",
+        "title": {
+          "primary": {
+            "label": "The wintermind",
+            "subtitle": "William Bonk and American letters",
+            "display": "primary",
+            "usage": "primary",
+            "supplied": true,
+            "language": "eng",
             "authority_code": "naf",
-            "id_from_auth": "n00020514"
-          }
-        ],
+            "id_from_auth": "n00020514",
+            "part_number": "Vol. 1",
+            "part_name": "Being the third book"
+          },
+          "other": [
+            {
+              "label": "The man who would be king",
+              "type": "alternative",
+              "display": "Below map:"
+            },
+            {
+              "label": "Bible",
+              "type": "uniform",
+              "authority_code": "naf",
+              "id_from_auth": "n00020514"
+            }
+          ]
+        },
         "name_roles": [
           {
             "name": {
@@ -114,10 +116,12 @@
         "date": {
           "created": "1495~"
         },
-        "edition_name": "First edition",
-        "edition_number": "1",
-        "volume": "Vol. III",
-        "issue_number": "20",
+        "publication": {
+          "edition_name": "First edition",
+          "edition_number": "1",
+          "volume": "Vol. III",
+          "issue_number": "20"
+        },
         "issuance": "monographic",
         "frequency": "annual",
         "languages": [
@@ -209,11 +213,13 @@
             "1900/"
           ]
         },
-        "scale": [
-          "Scale [ca. 1:18,000]",
-          "Scale [ca. 1:1,200,000]"
-        ],
-        "projection": "azimuthal equal-area proj.",
+        "cartographic": {
+          "scale": [
+            "Scale [ca. 1:18,000]",
+            "Scale [ca. 1:1,200,000]"
+          ],
+          "projection": "azimuthal equal-area proj."
+        },
         "host_collections": [
           "Medieval and Early Renaissance Manuscripts (Collection of Distinction)",
           "Colonial and Revolutionary Boston"
@@ -229,11 +235,25 @@
         },
         "physical_location_department": "Rare Books Department",
         "physical_location_shelf_locator": "Box 27, Folder 3",
-        "related_referenced_by_url": [
-          "http://nrs.harvard.edu/urn-3:HLS.Libr:law00030",
-          "http://abcd.efg"
-        ],
-        "related_constituent": "Constituency",
+        "related": {
+          "referenced_by_url": [
+            "http://nrs.harvard.edu/urn-3:HLS.Libr:law00030",
+            "http://abcd.efg"
+          ],
+          "constituent": "Constituency",
+          "references_url": [
+            "http://references.edu/123456",
+            "http://hijk.lmn"
+          ],
+          "other_format": [
+            "http://other_format.org/foo",
+            "http://opqr.stu"
+          ],
+          "review_url": [
+            "http://review.net/bar",
+            "http://vwx.yz"
+          ]
+        },
         "rights": "Copyright (c) Leslie Jones.",
         "licenses": [
           {

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
         end
 
         let(:primary_title) { titles.primary }
+        let(:title_json) { desc_json['title'] }
         let(:title_attributes) do
           %w(label usage display language subtitle supplied part_name part_number
              id_from_auth authority_code type)
@@ -84,7 +85,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
         it 'sets primary title values' do
           expect(primary_title).to be_an_instance_of(Curator::Descriptives::Title)
           title_attributes.each do |attr|
-            expect(primary_title.public_send(attr)).to eq desc_json['title_primary'][attr]
+            expect(primary_title.public_send(attr)).to eq title_json['primary'][attr]
           end
         end
 
@@ -93,7 +94,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
           expect(other_titles.count).to eq 2
           expect(other_titles).to all(be_an_instance_of(Curator::Descriptives::Title))
 
-          desc_json['title_other'].each do |title_other_json|
+          title_json['other'].each do |title_other_json|
             expect(collection_as_json(other_titles, { only: title_attributes })).to include(title_other_json)
           end
         end
@@ -113,25 +114,31 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
         end
 
         let(:publication) { descriptive.publication }
+        let(:pub_json) { desc_json['publication'] }
         it 'sets publication data' do
           expect(publication).to be_an_instance_of(Curator::Descriptives::Publication)
           %w(volume edition_name edition_number issue_number).each do |attr|
-            expect(publication.send(attr)).to eq desc_json[attr]
+            expect(publication.send(attr)).to eq pub_json[attr]
           end
         end
 
         let(:cartographic) { descriptive.cartographic }
+        let(:carto_json) { desc_json['cartographic'] }
         it 'sets cartographic data' do
           expect(cartographic).to be_an_instance_of(Curator::Descriptives::Cartographic)
-          expect(cartographic.scale).to eq desc_json['scale']
-          expect(cartographic.projection).to eq desc_json['projection']
+          expect(cartographic.scale).to eq carto_json['scale']
+          expect(cartographic.projection).to eq carto_json['projection']
         end
 
         let(:related) { descriptive.related }
+        let(:related_json) { desc_json['related'] }
         it 'sets related data' do
           expect(related).to be_an_instance_of(Curator::Descriptives::Related)
-          expect(related.referenced_by_url).to eq desc_json['related_referenced_by_url']
-          expect(related.constituent).to eq desc_json['related_constituent']
+          expect(related.referenced_by_url).to eq related_json['referenced_by_url']
+          expect(related.constituent).to eq related_json['constituent']
+          expect(related.references_url).to eq related_json['references_url']
+          expect(related.other_format).to eq related_json['other_format']
+          expect(related.review_url).to eq related_json['review_url']
         end
       end
 


### PR DESCRIPTION
This PR brings the incoming JSON structure of `['metastreams']['descriptive']` expected by `DigitalObjectFactoryService` in line with the output from `DescriptiveSerializer`.