### PR TITLE
Misc fixes or changes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -470,14 +470,8 @@ Rails/ActionFilter:
 Rails/CreateTableWithTimestamps:
   Enabled: true
   Exclude:
-    - 'db/migrate/20190920170759_create_curator_mapping_desc_terms.rb'
-    - 'db/migrate/20190920170814_create_curator_mapping_desc_name_roles.rb'
-    - 'db/migrate/20190923145916_create_curator_mappings_host_collections.rb'
-    - 'db/migrate/20190923155026_create_curator_mappings_exemplary_images.rb'
-    - 'db/migrate/20190923160316_create_curator_mappings_desc_host_collections.rb'
-    - 'db/migrate/20190923164102_create_curator_mappings_collection_members.rb'
-    - 'db/migrate/20191016182158_create_curator_mappings_issues.rb'
-    - 'db/migrate/20200115181909_create_curator_mappings_file_set_members.rb'
+    - 'db/migrate/*_mapping*.rb'
+
 Rails/ActiveSupportAliases:
   Enabled: true
 

--- a/app/indexers/concerns/curator/indexer/administrative_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/administrative_indexer.rb
@@ -7,6 +7,7 @@ module Curator
       included do
         configure do
           to_field 'destination_site_ssim', obj_extract('administrative', 'destination_site')
+          to_field 'hosting_status_ssi', obj_extract('administrative', 'hosting_status')
           to_field 'harvesting_status_bsi', obj_extract('administrative', 'harvestable')
           to_field('flagged_content_ssi') { |rec, acc| acc << true if rec.administrative&.flagged }
         end

--- a/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/rights_license_indexer.rb
@@ -9,26 +9,23 @@ module Curator
           to_field 'rights_ss', obj_extract('descriptive', 'rights')
           to_field 'restrictions_on_access_ss', obj_extract('descriptive', 'access_restrictions')
           each_record do |record, context|
-            next unless record.descriptive&.licenses
+            next unless record.descriptive&.license
 
-            license_fields = %w(license_ssm license_uri_ssm reuse_allowed_ssi)
-            license_fields.each { |field| context.output_hash[field] ||= [] }
-            record.descriptive.licenses.each do |license|
-              license_text = license.label
-              reuse = if license_text.downcase.include?('public domain') ||
-                         license_text.downcase.include?('no known restrictions')
-                        'no restrictions'
-                      elsif license_text.downcase.include?('creative commons')
-                        'creative commons'
-                      elsif license_text.downcase.include?('contact host')
-                        'contact host'
-                      elsif license_text.downcase.include?('all rights reserved')
-                        'all rights reserved'
-                      end
-              context.output_hash['license_ssm'] << license_text
-              context.output_hash['reuse_allowed_ssi'] << reuse
-              context.output_hash['license_uri_ssm'] << license.uri
-            end
+            license = record.descriptive.license
+            license_text = license.label.downcase
+            reuse = if license_text.include?('public domain') ||
+                       license_text.include?('no known restrictions')
+                      'no restrictions'
+                    elsif license_text.include?('creative commons')
+                      'creative commons'
+                    elsif license_text.include?('contact host')
+                      'contact host'
+                    elsif license_text.include?('all rights reserved')
+                      'all rights reserved'
+                    end
+            context.output_hash['license_ss'] = license_text
+            context.output_hash['reuse_allowed_ssi'] = reuse
+            context.output_hash['license_uri_ss'] = license.uri
           end
         end
       end

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -21,10 +21,7 @@ module Curator
     configure do
       to_field 'is_file_set_of_ssim', obj_extract('file_set_of', 'ark_id')
       to_field 'is_exemplary_image_of_ssim' do |rec, acc|
-        # NOTE: Changed the bottom two lines to .pluck(:ark_id) instead of .map(&:ark_id) as its more efficient
-        # Definetly review other indexers and change to .pluck method
-        acc.concat rec.exemplary_image_objects.pluck(:ark_id) if rec.respond_to?(:exemplary_image_objects)
-        acc.concat rec.exemplary_image_collections.pluck(:ark_id) if rec.respond_to?(:exemplary_image_collections)
+        acc.concat rec.exemplary_image_of.map(&:ark_id)
       end
       to_field 'filename_base_ssi', obj_extract('file_name_base')
       to_field 'position_isi', obj_extract('position')

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -21,7 +21,7 @@ module Curator
     configure do
       to_field 'is_file_set_of_ssim', obj_extract('file_set_of', 'ark_id')
       to_field 'is_exemplary_image_of_ssim' do |rec, acc|
-        acc.concat rec.exemplary_image_of.map(&:ark_id)
+        acc.concat rec.exemplary_image_of.pluck('ark_id')
       end
       to_field 'filename_base_ssi', obj_extract('file_name_base')
       to_field 'position_isi', obj_extract('position')

--- a/app/models/concerns/curator/filestreams/thumbnailable.rb
+++ b/app/models/concerns/curator/filestreams/thumbnailable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Curator
+  module Filestreams
+    module Thumbnailable
+      extend ActiveSupport::Concern
+
+      included do
+        has_one_attached :image_thumbnail_300
+      end
+    end
+  end
+end

--- a/app/models/concerns/curator/mappings/exemplary.rb
+++ b/app/models/concerns/curator/mappings/exemplary.rb
@@ -9,10 +9,10 @@ module Curator
         included do
           has_one :exemplary_image_mapping, -> { includes(:exemplary_file_set) }, as: :exemplary_object, inverse_of: :exemplary_object, class_name: 'Curator::Mappings::ExemplaryImage', dependent: :destroy
 
-          delegate :exemplary_file_set, to: :exemplary_image_mapping, allow_nil: true
+          # delegate :exemplary_file_set, to: :exemplary_image_mapping, allow_nil: true
 
           # NOTE: no idea why this doesn't work will add a delegator instead seeing how that still works
-          # has_one :exemplary_file_set, through: :exemplary_image_mapping, source: :exemplary_file_set, class_name: 'Curator::Filestreams::FileSet'
+          has_one :exemplary_file_set, through: :exemplary_image_mapping, source: :exemplary_file_set
         end
       end
       module FileSet
@@ -21,8 +21,12 @@ module Curator
           has_many :exemplary_image_of_mappings, -> { includes(:exemplary_object) }, inverse_of: :exemplary_file_set, class_name: 'Curator::Mappings::ExemplaryImage', foreign_key: :exemplary_file_set_id, dependent: :destroy
 
           with_options through: :exemplary_image_of_mappings, source: :exemplary_object do
-            has_many :exemplary_image_collections, source_type: 'Curator::Collection'
-            has_many :exemplary_image_objects, source_type: 'Curator::DigitalObject'
+            has_many :exemplary_image_of_collections, source_type: 'Curator::Collection'
+            has_many :exemplary_image_of_objects, source_type: 'Curator::DigitalObject'
+          end
+
+          def exemplary_image_of
+            exemplary_image_of_collections.select(:id, :ark_id) + exemplary_image_of_objects.select(:id, :ark_id)
           end
         end
       end

--- a/app/models/curator/controlled_terms/geographic.rb
+++ b/app/models/curator/controlled_terms/geographic.rb
@@ -8,7 +8,7 @@ module Curator
 
     belongs_to :authority, inverse_of: :geographics, class_name: 'Curator::ControlledTerms::Authority', optional: true
 
-    has_many :institution_locations, inverse_of: :location, class_name: 'Curator::Institution', foreign_key: :location_id, dependent: :nullify
+    has_many :institution_locations, inverse_of: :location, class_name: 'Curator::Institution', foreign_key: :location_id, dependent: :destroy
 
     attr_json :area_type, :string
     attr_json :coordinates, :string

--- a/app/models/curator/controlled_terms/license.rb
+++ b/app/models/curator/controlled_terms/license.rb
@@ -2,10 +2,12 @@
 
 module Curator
   class ControlledTerms::License < ControlledTerms::Nomenclature
-    include Mappings::MappedTerms
+    undef_method :desc_terms # Removed relation method since License is not a a valid Term to be mapped
     belongs_to :authority, class_name: 'Curator::ControlledTerms::Authority', optional: true
     # NOTE These dont really have authorities but this line is required so rails doesnt try to validate this relatonship
     # ALSO I did not specify an inverse_of on eiher relationship so these should be hidden from authorities
+
+    has_many :licensees, inverse_of: :license, class_name: 'Curator::Metastreams::Descriptive', foreign_key: :license_id, dependent: :destroy
 
     attr_json :uri, :string
 

--- a/app/models/curator/filestreams/document.rb
+++ b/app/models/curator/filestreams/document.rb
@@ -2,10 +2,11 @@
 
 module Curator
   class Filestreams::Document < Filestreams::FileSet
+    include Filestreams::Thumbnailable
+
     belongs_to :file_set_of, inverse_of: :document_file_sets, class_name: 'Curator::DigitalObject'
 
     has_one_attached :document_master
     has_one_attached :document_access
-    has_one_attached :image_thumbnail_300
   end
 end

--- a/app/models/curator/filestreams/ereader.rb
+++ b/app/models/curator/filestreams/ereader.rb
@@ -2,10 +2,10 @@
 
 module Curator
   class Filestreams::Ereader < Filestreams::FileSet
+    include Filestreams::Thumbnailable
+
     belongs_to :file_set_of, inverse_of: :ereader_file_sets, class_name: 'Curator::DigitalObject'
 
     has_many_attached :ebook_access
-
-    has_one_attached :image_thumbnail_300
   end
 end

--- a/app/models/curator/filestreams/image.rb
+++ b/app/models/curator/filestreams/image.rb
@@ -2,6 +2,7 @@
 
 module Curator
   class Filestreams::Image < Filestreams::FileSet
+    include Filestreams::Thumbnailable
     belongs_to :file_set_of, inverse_of: :image_file_sets, class_name: 'Curator::DigitalObject'
 
     has_one_attached :document_access
@@ -10,7 +11,6 @@ module Curator
     has_one_attached :image_georectified_master
     has_one_attached :image_access_800
     has_one_attached :image_service
-    has_one_attached :image_thumbnail_300
 
     has_one_attached :text_coordinates_master
     has_one_attached :text_coordinates_access

--- a/app/models/curator/filestreams/metadata.rb
+++ b/app/models/curator/filestreams/metadata.rb
@@ -2,6 +2,7 @@
 
 module Curator
   class Filestreams::Metadata < Filestreams::FileSet
+    include Filestreams::Thumbnailable
     belongs_to :file_set_of, inverse_of: :metadata_file_sets, class_name: 'Curator::DigitalObject'
 
     has_one_attached :metadata_ia
@@ -9,6 +10,5 @@ module Curator
     has_one_attached :metadata_marc_xml
     has_one_attached :metadata_mods
     has_one_attached :metadata_oai
-    has_one_attached :image_thumbnail_300
   end
 end

--- a/app/models/curator/filestreams/video.rb
+++ b/app/models/curator/filestreams/video.rb
@@ -2,12 +2,11 @@
 
 module Curator
   class Filestreams::Video < Filestreams::FileSet
+    include Filestreams::Thumbnailable
     belongs_to :file_set_of, inverse_of: :video_file_sets, class_name: 'Curator::DigitalObject'
 
     has_one_attached :document_access
     has_one_attached :document_master
-
-    has_one_attached :image_thumbnail_300
 
     has_one_attached :text_plain
 

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -2,9 +2,10 @@
 
 module Curator
   class Institution < ApplicationRecord
+    include Curator::Indexable
     include Curator::Mintable
     include Curator::Metastreamable::Basic
-    include Curator::Indexable
+    include Curator::Filestreams::Thumbnailable
 
     self.curator_indexable_mapper = Curator::InstitutionIndexer.new
 

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -13,7 +13,6 @@ module Curator
     scope :for_serialization, -> { merge(with_metastreams).merge(with_location) }
 
     validates :url, format: { with: URI.regexp(%w(http https)), allow_blank: true }
-    validates :abstract, presence: { allow_blank: true }
 
     belongs_to :location, -> { merge(with_authority) }, inverse_of: :institution_locations, class_name: 'Curator::ControlledTerms::Geographic', optional: true
 

--- a/app/models/curator/mappings/desc_term.rb
+++ b/app/models/curator/mappings/desc_term.rb
@@ -2,6 +2,8 @@
 
 module Curator
   class Mappings::DescTerm < ApplicationRecord
+    VALID_TERM_CLASSES = Curator::ControlledTerms.nomenclature_types.collect { |klass| "Curator::ControlledTerms::#{klass}" unless klass == 'License' }.compact.freeze
+
     belongs_to :descriptive, inverse_of: :desc_terms, class_name: 'Curator::Metastreams::Descriptive'
 
     belongs_to :mapped_term, inverse_of: :desc_terms, class_name: 'Curator::ControlledTerms::Nomenclature'
@@ -13,9 +15,8 @@ module Curator
     private
 
     def mapped_term_class_name_validator
-      valid_class_names = Curator::ControlledTerms.nomenclature_types.collect { |klass| "Curator::ControlledTerms::#{klass}" }
       term_class_name = mapped_term&.class&.name
-      errors.add(:mapped_term, "#{term_class_name} is not valid!") if !valid_class_names.include?(term_class_name)
+      errors.add(:mapped_term, "#{term_class_name} is not valid!") if !VALID_TERM_CLASSES.include?(term_class_name)
     end
   end
 end

--- a/app/models/curator/mappings/exemplary_image.rb
+++ b/app/models/curator/mappings/exemplary_image.rb
@@ -3,7 +3,7 @@
 module Curator
   class Mappings::ExemplaryImage < ApplicationRecord
     VALID_EXEMPLARY_OBJECT_TYPES = %w(Collection DigitalObject).freeze
-    VALID_EXEMPLARY_FILE_SET_TYPES = %w(Image Document Video).freeze
+    VALID_EXEMPLARY_FILE_SET_TYPES = %w(Image Document Video Metadata).freeze
 
     belongs_to :exemplary_object, inverse_of: :exemplary_image_mapping, polymorphic: true
 

--- a/app/models/curator/metastreams.rb
+++ b/app/models/curator/metastreams.rb
@@ -13,7 +13,7 @@ module Curator
     end
 
     def self.valid_filestream_types
-      Curator::Filestreams.file_set_types.collect { |fstream_type| "Curator::Filestreams::#{fstream_type}" }.freeze
+      Array.wrap('Curator::Filestreams::FileSet').freeze
     end
 
     namespace_klass_accessors :administrative, :descriptive, :workflow

--- a/app/models/curator/metastreams/administrative.rb
+++ b/app/models/curator/metastreams/administrative.rb
@@ -8,10 +8,5 @@ module Curator
 
     validates :administratable_id, uniqueness: { scope: :administratable_type }
     validates :administratable_type, inclusion: { in: Metastreams.valid_base_types + Metastreams.valid_filestream_types }
-
-    def administratable=(administratable)
-      super
-      self.administratable_type = administratable.class.to_s
-    end
   end
 end

--- a/app/models/curator/metastreams/administrative.rb
+++ b/app/models/curator/metastreams/administrative.rb
@@ -5,6 +5,7 @@ module Curator
     belongs_to :administratable, polymorphic: true, inverse_of: :administrative
 
     enum description_standard: { aacr: 0, cco: 1, dacs: 2, gihc: 3, local: 4, rda: 5, dcrmg: 6, amremm: 7, dcrmb: 8, dcrmc: 9, dcrmmss: 10, appm: 11 }.freeze
+    enum hosting_status: { hosted: 0, harvested: 1 }.freeze
 
     validates :administratable_id, uniqueness: { scope: :administratable_type }
     validates :administratable_type, inclusion: { in: Metastreams.valid_base_types + Metastreams.valid_filestream_types }

--- a/app/models/curator/metastreams/descriptive.rb
+++ b/app/models/curator/metastreams/descriptive.rb
@@ -64,7 +64,7 @@ module Curator
     # TERMS
     with_options through: :desc_terms, source: :mapped_term do
       has_one :license, class_name: 'Curator::ControlledTerms::License'
-      #This wont work through the ,map table. Think we should just map the license directly to the table instead
+      # This wont work through the, map table. Think we should just map the license directly to the table instead
 
       has_many :genres, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Genre'
       has_many :resource_types, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::ResourceType'

--- a/app/models/curator/metastreams/descriptive.rb
+++ b/app/models/curator/metastreams/descriptive.rb
@@ -53,9 +53,11 @@ module Curator
 
     # TERMS
     with_options through: :desc_terms, source: :mapped_term do
+      has_one :license, class_name: 'Curator::ControlledTerms::License'
+      #This wont work through the ,map table. Think we should just map the license directly to the table instead
+
       has_many :genres, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Genre'
       has_many :resource_types, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::ResourceType'
-      has_many :licenses, class_name: 'Curator::ControlledTerms::License'
       has_many :languages, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Language'
       has_many :subject_topics, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Subject'
       has_many :subject_names, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Name'

--- a/app/models/curator/metastreams/descriptive.rb
+++ b/app/models/curator/metastreams/descriptive.rb
@@ -13,7 +13,8 @@ module Curator
 
     scope :with_mappings, -> { includes(:desc_terms, :name_roles, :desc_host_collections) }
     scope :with_physical_location, -> { includes(:physical_location) }
-    scope :for_serialization, -> { merge(with_mappings).merge(with_physical_location) }
+    scope :with_license, -> { includes(:license) }
+    scope :for_serialization, -> { merge(with_mappings).merge(with_physical_location).merge(with_license) }
     # Identifier
     attr_json :identifier, Curator::Descriptives::Identifier.to_type, container_attribute: :identifier_json, array: true, default: []
 
@@ -41,8 +42,8 @@ module Curator
     # RELS
     # PARENTS
     belongs_to :descriptable, polymorphic: true, inverse_of: :descriptive
+    belongs_to :license, inverse_of: :licensees, class_name: 'Curator::ControlledTerms::License'
     belongs_to :physical_location, -> { merge(with_authority) }, inverse_of: :physical_locations_of, class_name: 'Curator::ControlledTerms::Name'
-
     # MAPPING OBJECTS
     with_options inverse_of: :descriptive, dependent: :destroy do
       has_many :desc_terms, -> { includes(:mapped_term) }, class_name: 'Curator::Mappings::DescTerm'
@@ -63,9 +64,6 @@ module Curator
 
     # TERMS
     with_options through: :desc_terms, source: :mapped_term do
-      has_one :license, class_name: 'Curator::ControlledTerms::License'
-      # This wont work through the, map table. Think we should just map the license directly to the table instead
-
       has_many :genres, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Genre'
       has_many :resource_types, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::ResourceType'
       has_many :languages, -> { merge(with_authority) }, class_name: 'Curator::ControlledTerms::Language'

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -10,10 +10,5 @@ module Curator
     validates :ingest_origin, presence: true
     validates :workflowable_id, uniqueness: { scope: :workflowable_type }, on: :create
     validates :workflowable_type, inclusion: { in: Metastreams.valid_base_types + Metastreams.valid_filestream_types }, on: :create
-
-    def workflowable=(workflowable)
-      super
-      self.workflowable_type = workflowable.class.to_s
-    end
   end
 end

--- a/app/serializers/curator/filestreams/document_serializer.rb
+++ b/app/serializers/curator/filestreams/document_serializer.rb
@@ -3,9 +3,7 @@
 module Curator
   class Filestreams::DocumentSerializer < Filestreams::FileSetSerializer
     schema_as_json do
-      node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
-        attribute(:ark_id) { |record| record.exemplary_object.ark_id }
-      end
+      attributes :exemplary_image_of
     end
   end
 end

--- a/app/serializers/curator/filestreams/image_serializer.rb
+++ b/app/serializers/curator/filestreams/image_serializer.rb
@@ -3,9 +3,7 @@
 module Curator
   class Filestreams::ImageSerializer < Filestreams::FileSetSerializer
     schema_as_json do
-      node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
-        attribute(:ark_id) { |record| record.exemplary_object.ark_id }
-      end
+      attributes :exemplary_image_of
     end
   end
 end

--- a/app/serializers/curator/filestreams/metadata_serializer.rb
+++ b/app/serializers/curator/filestreams/metadata_serializer.rb
@@ -2,5 +2,8 @@
 
 module Curator
   class Filestreams::MetadataSerializer < Filestreams::FileSetSerializer
+    schema_as_json do
+      attributes :exemplary_image_of
+    end
   end
 end

--- a/app/serializers/curator/filestreams/video_serializer.rb
+++ b/app/serializers/curator/filestreams/video_serializer.rb
@@ -3,9 +3,7 @@
 module Curator
   class Filestreams::VideoSerializer < Filestreams::FileSetSerializer
     schema_as_json do
-      node :exemplary_image_of, target: ->(record) { record.exemplary_image_of_mappings } do
-        attribute(:ark_id) { |record| record.exemplary_object.ark_id }
-      end
+      attributes :exemplary_image_of
     end
   end
 end

--- a/app/serializers/curator/metastreams/descriptive_serializer.rb
+++ b/app/serializers/curator/metastreams/descriptive_serializer.rb
@@ -8,11 +8,11 @@ module Curator
       attribute(:host_collections) { |record| record.host_collections.names }
 
       belongs_to :physical_location, serializer: Curator::ControlledTerms::NameSerializer
+      belongs_to :license, serializer: Curator::ControlledTerms::LicenseSerializer
 
       has_many :resource_types, serializer: Curator::ControlledTerms::ResourceTypeSerializer
       has_many :genres, serializer: Curator::ControlledTerms::GenreSerializer
       has_many :languages, serializer: Curator::ControlledTerms::LanguageSerializer
-      has_many :licenses, serializer: Curator::ControlledTerms::LicenseSerializer
 
       node :identifier, target: :key do
         attributes :label, :type, :invalid

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -33,7 +33,7 @@ module Curator
           end
 
           build_administrative(digital_object) do |admin|
-            [:description_standard, :flagged, :destination_site, :harvestable].each do |attr|
+            [:description_standard, :flagged, :destination_site, :hosting_status, :harvestable].each do |attr|
               admin.send("#{attr}=", @admin_json_attrs.fetch(attr, nil))
             end
           end

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -50,6 +50,7 @@ module Curator
             descriptive.resource_type_manuscript ||= false # nil not allowed for this attribute
             descriptive.identifier = identifier(@desc_json_attrs)
             descriptive.physical_location = physical_location(@desc_json_attrs)
+            descriptive.license = license(@desc_json_attrs)
             descriptive.date = date(@desc_json_attrs)
             descriptive.publication = publication(@desc_json_attrs)
             descriptive.title = title(@desc_json_attrs)
@@ -68,15 +69,6 @@ module Curator
               host = find_or_create_host_collection(host_col,
                                                     admin_set.institution.id)
               descriptive.desc_host_collections.build(host_collection: host)
-            end
-            licenses = @desc_json_attrs.fetch(:licenses, [])
-            licenses.each do |license_attrs|
-              descriptive.desc_terms.build(
-                mapped_term: term_for_mapping(
-                  license_attrs,
-                  nomenclature_class: Curator.controlled_terms.license_class
-                )
-              )
             end
             @desc_json_attrs.fetch(:subject, {}).each do |k, v|
               map_type = case k.to_s
@@ -168,6 +160,14 @@ module Curator
         nomenclature_class: Curator.controlled_terms.name_class,
         term_data: term_data,
         authority_code: authority_code
+      )
+    end
+
+    def license(json_attrs = {})
+      license_term_data = json_attrs.fetch(:license)
+      find_or_create_nomenclature(
+        nomenclature_class: Curator.controlled_terms.license_class,
+        term_data: license_term_data
       )
     end
 

--- a/db/migrate/20190919192434_create_curator_controlled_terms_nomenclatures.rb
+++ b/db/migrate/20190919192434_create_curator_controlled_terms_nomenclatures.rb
@@ -4,7 +4,7 @@ class CreateCuratorControlledTermsNomenclatures < ActiveRecord::Migration[5.2]
   def change
     create_table :curator_controlled_terms_nomenclatures do |t|
       t.belongs_to :authority, index: { using: :btree }, foreign_key: { to_table: :curator_controlled_terms_authorities, on_delete: :nullify }
-      t.jsonb :term_data, default: '{}', index: { using: :gin }, null: false
+      t.jsonb :term_data, default: '{}', index: { using: :gin }
       t.string :type, index: { using: :btree }, null: false
       t.integer :lock_version
       t.timestamps null: false

--- a/db/migrate/20190919202256_create_curator_metastreams_administratives.rb
+++ b/db/migrate/20190919202256_create_curator_metastreams_administratives.rb
@@ -4,10 +4,11 @@ class CreateCuratorMetastreamsAdministratives < ActiveRecord::Migration[5.2]
   def change
     create_table :curator_metastreams_administratives do |t|
       t.belongs_to :administratable, polymorphic: true, index: { unique: true, using: :btree, name: 'unique_idx_meta_admin_on_metastreamable_poly' }, null: false
-      t.integer :description_standard
-      t.boolean :harvestable, index: { using: :btree }, default: true, null: false
-      t.boolean :flagged, default: false, null: false
-      t.string :destination_site, index: { using: :gin }, array: true, null: false, default: ['commonwealth']
+      t.integer :description_standard, index: { using: :btree, where: 'description_standard is not null', name: 'idx_administrative_on_not_null_desc_standard' }
+      t.integer :hosting_status, index: { using: :btree }, default: 0
+      t.boolean :harvestable, index: { using: :btree }, default: true
+      t.boolean :flagged, default: false
+      t.string :destination_site, index: { using: :gin }, array: true, default: ['commonwealth']
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190919202305_create_curator_metastreams_workflows.rb
+++ b/db/migrate/20190919202305_create_curator_metastreams_workflows.rb
@@ -4,7 +4,7 @@ class CreateCuratorMetastreamsWorkflows < ActiveRecord::Migration[5.2]
   def change
     create_table :curator_metastreams_workflows do |t|
       t.belongs_to :workflowable, polymorphic: true, index: { unique: true, using: :btree, name: 'unique_idx_meta_workflows_on_metastreamable_poly' }, null: false
-      t.integer :publishing_state, index: { using: :btree }, null: false, default: 0
+      t.integer :publishing_state, index: { using: :btree }, default: 0
       t.integer :processing_state, index: { using: :btree, where: 'processing_state is not null' }
       t.string :ingest_origin, null: false
       t.integer :lock_version

--- a/db/migrate/20190919202311_create_curator_metastreams_descriptives.rb
+++ b/db/migrate/20190919202311_create_curator_metastreams_descriptives.rb
@@ -5,17 +5,18 @@ class CreateCuratorMetastreamsDescriptives < ActiveRecord::Migration[5.2]
     create_table :curator_metastreams_descriptives do |t|
       t.belongs_to :descriptable, polymorphic: true, index: { unique: true, using: :btree, name: 'unique_idx_meta_desc_on_metastreamable_poly' }, null: false
       t.belongs_to :physical_location, index: { using: :btree }, foreign_key: { to_table: :curator_controlled_terms_nomenclatures, on_delete: :cascade }, null: false
-      t.jsonb :identifier_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
-      t.jsonb :title_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
-      t.jsonb :date_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false # created/issued/copyright
-      t.jsonb :note_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
-      t.jsonb :subject_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false # uniform_title/temporal/date
-      t.jsonb :related_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
-      t.jsonb :cartographics_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
-      t.jsonb :publication_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
+      t.belongs_to :license, index: { using: :btree }, foreign_key: { to_table: :curator_controlled_terms_nomenclatures, on_delete: :cascade }, null: false
+      t.jsonb :identifier_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
+      t.jsonb :title_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
+      t.jsonb :date_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}' # created/issued/copyright
+      t.jsonb :note_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
+      t.jsonb :subject_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}' # uniform_title/temporal/date
+      t.jsonb :related_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
+      t.jsonb :cartographics_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
+      t.jsonb :publication_json, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
       t.integer :digital_origin, default: 1
       t.integer :text_direction
-      t.boolean :resource_type_manuscript, default: false, null: false
+      t.boolean :resource_type_manuscript, default: false
       t.string :origin_event
       t.string :place_of_publication
       t.string :publisher

--- a/db/migrate/20190919202344_create_curator_filestreams_file_sets.rb
+++ b/db/migrate/20190919202344_create_curator_filestreams_file_sets.rb
@@ -7,7 +7,7 @@ class CreateCuratorFilestreamsFileSets < ActiveRecord::Migration[5.2]
       t.string :file_set_type, index: { using: :btree }, null: false
       t.string :file_name_base, null: false
       t.integer :position, index: { using: :btree, order: 'asc' }, null: false # Alias as Sequenece
-      t.jsonb :pagination, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}', null: false
+      t.jsonb :pagination, index: { using: :gin, opclass: :jsonb_path_ops }, default: '{}'
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190919202609_create_curator_institutions.rb
+++ b/db/migrate/20190919202609_create_curator_institutions.rb
@@ -7,7 +7,7 @@ class CreateCuratorInstitutions < ActiveRecord::Migration[5.2]
       t.string :ark_id, index: { using: :btree, unique: true }, null: false
       t.string :name, null: false
       t.string :url
-      t.text :abstract, null: false
+      t.text :abstract, default: ''
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190919202609_create_curator_institutions.rb
+++ b/db/migrate/20190919202609_create_curator_institutions.rb
@@ -7,7 +7,7 @@ class CreateCuratorInstitutions < ActiveRecord::Migration[5.2]
       t.string :ark_id, index: { using: :btree, unique: true }, null: false
       t.string :name, null: false
       t.string :url
-      t.text :abstract, null: false, default: ''
+      t.text :abstract, null: false
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190919202618_create_curator_collections.rb
+++ b/db/migrate/20190919202618_create_curator_collections.rb
@@ -6,7 +6,7 @@ class CreateCuratorCollections < ActiveRecord::Migration[5.2]
       t.string :ark_id, index: { using: :btree, unique: true }, null: false
       t.belongs_to :institution, index: { using: :btree }, foreign_key: { to_table: :curator_institutions }, null: false
       t.string :name, null: false
-      t.text :abstract, default: '', null: false
+      t.text :abstract, null: false
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190919202618_create_curator_collections.rb
+++ b/db/migrate/20190919202618_create_curator_collections.rb
@@ -6,7 +6,7 @@ class CreateCuratorCollections < ActiveRecord::Migration[5.2]
       t.string :ark_id, index: { using: :btree, unique: true }, null: false
       t.belongs_to :institution, index: { using: :btree }, foreign_key: { to_table: :curator_institutions }, null: false
       t.string :name, null: false
-      t.text :abstract, null: false
+      t.text :abstract, default: ''
       t.integer :lock_version
       t.timestamps null: false
       t.datetime :archived_at, index: { using: :btree, where: 'archived_at is null' }

--- a/db/migrate/20190923155026_create_curator_mappings_exemplary_images.rb
+++ b/db/migrate/20190923155026_create_curator_mappings_exemplary_images.rb
@@ -5,7 +5,7 @@ class CreateCuratorMappingsExemplaryImages < ActiveRecord::Migration[5.2]
     create_table :curator_mappings_exemplary_images do |t|
       t.belongs_to :exemplary_object, polymorphic: true, index: { using: :btree, unique: true, name: 'unique_idx_map_exemp_img_on_exemp_obj_poly' }, null: false
       t.belongs_to :exemplary_file_set, index: { using: :btree, name: 'idx_map_exemp_on_exemp_file_set' }, foreign_key: { to_table: :curator_filestreams_file_sets, on_delete: :cascade }, null: false
-      t.index [:exemplary_file_set_id, :exemplary_object_id, :exemplary_object_type], name: 'uniq_idx_map_exemp_img_on_exemp_obj_poly_and_exemp_fse', unique: true, using: :btree
+      t.index [:exemplary_file_set_id, :exemplary_object_id, :exemplary_object_type], name: 'uniq_idx_map_exemp_img_on_exemp_obj_poly_and_exemp_fset', unique: true, using: :btree
     end
   end
 end

--- a/spec/factories/curator/mappings/desc_terms.rb
+++ b/spec/factories/curator/mappings/desc_terms.rb
@@ -21,10 +21,6 @@ FactoryBot.define do
       mapped_term { create(:curator_controlled_terms_language) }
     end
 
-    trait :license do
-      mapped_term { create(:curator_controlled_terms_license) }
-    end
-
     trait :subject_topic do
       mapped_term { create(:curator_controlled_terms_subject) }
     end

--- a/spec/factories/curator/metastreams/descriptives.rb
+++ b/spec/factories/curator/metastreams/descriptives.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :curator_metastreams_descriptive, class: 'Curator::Metastreams::Descriptive' do
     association :descriptable, factory: :curator_digital_object
     association :physical_location, factory: :curator_controlled_terms_name
+    association :license, factory: :curator_controlled_terms_license
     identifier { create_list(:curator_descriptives_identifier, 3) }
     date { create(:curator_descriptives_date) }
     note { create_list(:curator_descriptives_note, 3) }
@@ -43,7 +44,7 @@ FactoryBot.define do
       end
 
       after :create do |descriptive, options|
-        %i(specific_genre language resource_type license subject_topic subject_name subject_geo).each do |desc_term_type|
+        %i(specific_genre language resource_type subject_topic subject_name subject_geo).each do |desc_term_type|
           create_list(:curator_mappings_desc_term, options.desc_term_count, desc_term_type, descriptive: descriptive) if options.desc_term_count
         end
         create_list(:curator_mappings_desc_name_role, options.desc_term_count, descriptive: descriptive) if options.desc_term_count
@@ -55,7 +56,6 @@ FactoryBot.define do
       name_role_count { nil }
       language_count { nil }
       resource_type_count { nil }
-      license_count { nil }
       subject_count { nil }
       host_collection_count { 1 }
     end
@@ -65,7 +65,7 @@ FactoryBot.define do
       %i(subject_topic subject_name subject_other).each do |subject_type|
         create_list(:curator_mappings_desc_term, options.subject_count, subject_type, descriptive: descriptive) if options.subject_count
       end
-      %i(language resource_type license).each do |desc_term_type|
+      %i(language resource_type).each do |desc_term_type|
         create_list(:curator_mappings_desc_term, options.send("#{desc_term_type}_count"), :language, descriptive: descriptive) if options.send("#{desc_term_type}_count")
       end
       create_list(:curator_mappings_desc_name_role, options.name_role_count, descriptive: descriptive) if options.name_role_count

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -255,12 +255,10 @@
           ]
         },
         "rights": "Copyright (c) Leslie Jones.",
-        "licenses": [
-          {
+        "license": {
             "label": "This work is licensed for use under a Creative Commons Attribution Non-Commercial No Derivatives License (CC BY-NC-ND).",
             "uri": "https://creativecommons.org/licenses/by-nc-nd/2.0/"
-          }
-        ],
+        },
         "access_restrictions": "Access to physical copy/copies by appointment only."
       }
 ,

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -265,6 +265,7 @@
       "administrative": {
         "description_standard": "amremm",
         "flagged": false,
+        "hosting_status": "hosted",
         "destination_site": [
           "commonwealth",
           "bpl"

--- a/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Curator::Indexer::AdministrativeIndexer do
       expect(indexed['destination_site_ssim']).to eq administrative.destination_site
     end
 
+    it 'sets the hosting_status field' do
+      expect(indexed['hosting_status_ssi']).to eq [administrative.hosting_status]
+    end
+
     it 'sets the harvesting_status field' do
       expect(indexed['harvesting_status_bsi']).to eq [administrative.harvestable]
     end

--- a/spec/indexers/concerns/curator/indexer/rights_license_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/rights_license_indexer_spec.rb
@@ -9,11 +9,15 @@ RSpec.describe Curator::Indexer::RightsLicenseIndexer do
       end
     end
     let(:indexer) { indexer_test_class.new }
-    let(:descriptive) do
-      descriptive_ms = create(:curator_metastreams_descriptive)
-      descriptive_ms.licenses << create(:curator_controlled_terms_license)
-      descriptive_ms
+    let(:license) do
+      license = if Curator.controlled_terms.license_class.where(term_data: { label: 'No known restrictions on use' }).exists?
+                  Curator.controlled_terms.license_class.where(term_data: { label: 'No known restrictions on use' }).first
+                else
+                  create(:curator_controlled_terms_license, label: 'creative commons')
+                end
+      license
     end
+    let(:descriptive) { create(:curator_metastreams_descriptive, license: license) }
     let(:descriptable_object) { descriptive.descriptable }
     let(:indexed) { indexer.map_record(descriptable_object) }
 
@@ -26,11 +30,11 @@ RSpec.describe Curator::Indexer::RightsLicenseIndexer do
     end
 
     it 'sets the license field' do
-      expect(indexed['license_ssm']).to eq descriptive.licenses.map(&:label)
+      expect(indexed['license_ss']).to eq descriptive.license.label
     end
 
     it 'sets the license_uri field' do
-      expect(indexed['license_uri_ssm']).to eq descriptive.licenses.map(&:uri)
+      expect(indexed['license_uri_ss']).to eq descriptive.license.uri
     end
 
     it 'sets the reuse_allowed field' do

--- a/spec/indexers/curator/collection_indexer_spec.rb
+++ b/spec/indexers/curator/collection_indexer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Curator::CollectionIndexer do
     exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: @collection,
                                                               exemplary_file_set: exemplary_file_set)
     exemplary_mapping.save!
+    @collection = @collection.reload
   end
 
   describe 'indexing' do

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
     end
 
     describe 'exemplary image indexing' do
-      # UPDATE: Fixed!
-      # instantiate DigitalObject from :curator_mappings_exemplary_image factory
-      # otherwise exemplary_image indexing doesn't work in test env
-      # let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
-      # let(:file_set) { exemplary_image_mapping.exemplary_file_set }
-      # let(:digital_object) { exemplary_image_mapping.exemplary_object }
       let(:file_set) { digital_object.exemplary_file_set }
       before(:each) do
         digital_object.reload

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -3,7 +3,12 @@
 require 'rails_helper'
 RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
   describe 'indexing' do
-    let(:digital_object) { create(:curator_digital_object, :with_contained_by) }
+    let!(:digital_object) do
+      digital_obj = create(:curator_digital_object, :with_contained_by, :with_metastreams)
+      create(:curator_mappings_exemplary_image, exemplary_object: digital_obj)
+      digital_obj
+    end
+
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(digital_object) }
     let(:collections) { digital_object.is_member_of_collection }
@@ -28,14 +33,19 @@ RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
     end
 
     describe 'exemplary image indexing' do
+      # UPDATE: Fixed!
       # instantiate DigitalObject from :curator_mappings_exemplary_image factory
       # otherwise exemplary_image indexing doesn't work in test env
-      let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
-      let(:file_set) { exemplary_image_mapping.exemplary_file_set }
-      let(:digital_object) { exemplary_image_mapping.exemplary_object }
+      # let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
+      # let(:file_set) { exemplary_image_mapping.exemplary_file_set }
+      # let(:digital_object) { exemplary_image_mapping.exemplary_object }
+      let(:file_set) { digital_object.exemplary_file_set }
+      before(:each) do
+        digital_object.reload
+      end
 
       it 'sets the exemplary image field' do
-        expect(indexed['exemplary_image_ssi']).to eq [file_set.ark_id]
+        expect(indexed['exemplary_image_ssi']).to include(file_set.ark_id)
       end
     end
 

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Curator::FileSetIndexer, type: :indexer do
 
     it 'sets the exemplary image field' do
       expect(indexed['is_exemplary_image_of_ssim']).to eq(
-        file_set.exemplary_image_objects.map { |obj| obj.ark_id }
+        file_set.exemplary_image_of.map(&:ark_id)
       )
     end
 

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Curator::FileSetIndexer, type: :indexer do
 
     it 'sets the exemplary image field' do
       expect(indexed['is_exemplary_image_of_ssim']).to eq(
-        file_set.exemplary_image_of.map(&:ark_id)
+        file_set.exemplary_image_of.pluck('ark_id')
       )
     end
 

--- a/spec/indexers/curator/file_set_indexer_spec.rb
+++ b/spec/indexers/curator/file_set_indexer_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Curator::FileSetIndexer, type: :indexer do
     let(:exemplary_image_mapping) { create(:curator_mappings_exemplary_image) }
     let(:file_set) { exemplary_image_mapping.exemplary_file_set }
     let(:indexer) { described_class.new }
-    let(:indexed) { indexer.map_record(file_set) }
+    let(:indexed) { indexer.map_record(file_set.reload) }
 
     it 'sets the file_set_of field' do
       expect(indexed['is_file_set_of_ssim']).to eq [file_set.file_set_of.ark_id]

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -43,6 +43,6 @@ RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
                         inverse_of(:location).
                         class_name('Curator::Institution').
                         with_foreign_key(:location_id).
-                        dependent(:nullify) }
+                        dependent(:destroy) }
   end
 end

--- a/spec/models/curator/controlled_terms/license_spec.rb
+++ b/spec/models/curator/controlled_terms/license_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
-require_relative '../shared/mappings/mapped_terms'
 # NOTE: No authority delegations/ cannnicable shared examples in this class is by design
 
 RSpec.describe Curator::ControlledTerms::License, type: :model do
@@ -23,10 +22,18 @@ RSpec.describe Curator::ControlledTerms::License, type: :model do
   end
 
   describe 'Associations' do
-    it_behaves_like 'mapped_term'
+    describe 'Not mappable' do
+      it { is_expected.not_to respond_to(:desc_terms) }
+    end
 
     it { is_expected.to belong_to(:authority).
                         class_name('Curator::ControlledTerms::Authority').
                         optional }
+
+    it { is_expected.to have_many(:licensees).
+                        inverse_of(:license).
+                        class_name('Curator::Metastreams::Descriptive').
+                        with_foreign_key(:license_id).
+                        dependent(:destroy) }
   end
 end

--- a/spec/models/curator/filestreams/document_spec.rb
+++ b/spec/models/curator/filestreams/document_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 require_relative '../shared/filestreams/file_set'
 require_relative '../shared/filestreams/file_attachments'
+require_relative '../shared/filestreams/thumbnailable'
+
 RSpec.describe Curator::Filestreams::Document, type: :model do
   subject { create(:curator_filestreams_document) }
 
@@ -14,6 +16,7 @@ RSpec.describe Curator::Filestreams::Document, type: :model do
                         class_name('Curator::DigitalObject').
                         required }
 
+    it_behaves_like 'thumbnailable'
     it_behaves_like 'has_file_attachments' do
       let(:has_one_file_attachments) { %i(document_master document_access image_thumbnail_300) }
     end

--- a/spec/models/curator/filestreams/ereader_spec.rb
+++ b/spec/models/curator/filestreams/ereader_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 require_relative '../shared/filestreams/file_set'
 require_relative '../shared/filestreams/file_attachments'
+require_relative '../shared/filestreams/thumbnailable'
+
 RSpec.describe Curator::Filestreams::Ereader, type: :model do
   subject { create(:curator_filestreams_ereader) }
 
@@ -14,10 +16,10 @@ RSpec.describe Curator::Filestreams::Ereader, type: :model do
                         class_name('Curator::DigitalObject').
                         required }
 
-    it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(image_thumbnail_300) }
+    it_behaves_like 'thumbnailable'
+
+    it_behaves_like 'has_many_attached' do
       let(:has_many_file_attachments) { %i(ebook_access) }
-      it_behaves_like 'has_many_attached'
     end
   end
 end

--- a/spec/models/curator/filestreams/image_spec.rb
+++ b/spec/models/curator/filestreams/image_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require_relative '../shared/filestreams/file_set'
 require_relative '../shared/filestreams/file_attachments'
+require_relative '../shared/filestreams/thumbnailable'
 
 RSpec.describe Curator::Filestreams::Image, type: :model do
   subject { create(:curator_filestreams_image) }
@@ -15,8 +16,10 @@ RSpec.describe Curator::Filestreams::Image, type: :model do
                         class_name('Curator::DigitalObject').
                         required }
 
+    it_behaves_like 'thumbnailable'
+
     it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(document_access image_master image_negative_master image_georectified_master image_access_800 image_service image_thumbnail_300 text_coordinates_master text_coordinates_access text_plain) }
+      let(:has_one_file_attachments) { %i(document_access image_master image_negative_master image_georectified_master image_access_800 image_service text_coordinates_master text_coordinates_access text_plain) }
     end
   end
 end

--- a/spec/models/curator/filestreams/metadata_spec.rb
+++ b/spec/models/curator/filestreams/metadata_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require_relative '../shared/filestreams/file_set'
 require_relative '../shared/filestreams/file_attachments'
+require_relative '../shared/filestreams/thumbnailable'
 
 RSpec.describe Curator::Filestreams::Metadata, type: :model do
   subject { create(:curator_filestreams_metadata) }
@@ -15,8 +16,10 @@ RSpec.describe Curator::Filestreams::Metadata, type: :model do
                         class_name('Curator::DigitalObject').
                         required }
 
+    it_behaves_like 'thumbnailable'
+
     it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(metadata_ia metadata_ia_scan metadata_marc_xml metadata_mods metadata_oai image_thumbnail_300) }
+      let(:has_one_file_attachments) { %i(metadata_ia metadata_ia_scan metadata_marc_xml metadata_mods metadata_oai) }
     end
   end
 end

--- a/spec/models/curator/filestreams/video_spec.rb
+++ b/spec/models/curator/filestreams/video_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 require_relative '../shared/filestreams/file_set'
 require_relative '../shared/filestreams/file_attachments'
+require_relative '../shared/filestreams/thumbnailable'
 
 RSpec.describe Curator::Filestreams::Video, type: :model do
   subject { create(:curator_filestreams_video) }
@@ -15,8 +16,10 @@ RSpec.describe Curator::Filestreams::Video, type: :model do
                         class_name('Curator::DigitalObject').
                         required }
 
+    it_behaves_like 'thumbnailable'
+
     it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(document_master document_access image_thumbnail_300 text_plain video_master video_access) }
+      let(:has_one_file_attachments) { %i(document_master document_access text_plain video_master video_access) }
     end
   end
 end

--- a/spec/models/curator/institution_spec.rb
+++ b/spec/models/curator/institution_spec.rb
@@ -7,6 +7,7 @@ require_relative './shared/optimistic_lockable'
 require_relative './shared/timestampable'
 require_relative './shared/archivable'
 require_relative './shared/for_serialization'
+require_relative './shared/filestreams/thumbnailable'
 
 RSpec.describe Curator::Institution, type: :model do
   subject { create(:curator_institution) }
@@ -30,6 +31,7 @@ RSpec.describe Curator::Institution, type: :model do
 
   describe 'Associations' do
     it_behaves_like 'metastreamable_basic'
+    it_behaves_like 'thumbnailable'
 
     it { is_expected.to belong_to(:location).
       inverse_of(:institution_locations).

--- a/spec/models/curator/metastreams/administrative_spec.rb
+++ b/spec/models/curator/metastreams/administrative_spec.rb
@@ -24,24 +24,34 @@ RSpec.describe Curator::Metastreams::Administrative, type: :model do
     it { is_expected.to have_db_column(:description_standard).
                         of_type(:integer)}
 
+    it { is_expected.to have_db_column(:hosting_status).
+                        of_type(:integer).
+                        with_options(default: 'hosted') }
+
     it { is_expected.to have_db_column(:harvestable).
                         of_type(:boolean).
-                        with_options(default: true, null: false) }
+                        with_options(default: true) }
 
     it { is_expected.to have_db_column(:flagged).
                         of_type(:boolean).
-                        with_options(default: false, null: false) }
+                        with_options(default: false) }
 
     it { is_expected.to have_db_column(:destination_site).
                         of_type(:string).
-                        with_options(default: ['commonwealth'], null: false, array: true) }
+                        with_options(default: ['commonwealth'], array: true) }
 
     it { is_expected.to have_db_index([:administratable_type, :administratable_id]).unique(true) }
+    it { is_expected.to have_db_index(:description_standard) }
+    it { is_expected.to have_db_index(:hosting_status) }
     it { is_expected.to have_db_index(:destination_site) }
     it { is_expected.to have_db_index(:harvestable) }
 
     it { is_expected.to define_enum_for(:description_standard).
                         with_values(aacr: 0, cco: 1, dacs: 2, gihc: 3, local: 4, rda: 5, dcrmg: 6, amremm: 7, dcrmb: 8, dcrmc: 9, dcrmmss: 10, appm: 11).
+                        backed_by_column_of_type(:integer) }
+
+    it { is_expected.to define_enum_for(:hosting_status).
+                        with_values(hosted: 0, harvested: 1).
                         backed_by_column_of_type(:integer) }
   end
 
@@ -59,6 +69,7 @@ RSpec.describe Curator::Metastreams::Administrative, type: :model do
       expect(default_admin.harvestable).to be(true)
       expect(default_admin.flagged).to be(false)
       expect(default_admin.destination_site).to be_a_kind_of(Array).and include('commonwealth')
+      expect(default_admin.hosting_status).to eq('hosted')
     end
   end
 

--- a/spec/models/curator/metastreams/descriptive_spec.rb
+++ b/spec/models/curator/metastreams/descriptive_spec.rb
@@ -25,37 +25,41 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
                         of_type(:integer).
                         with_options(null: false) }
 
+    it { is_expected.to have_db_column(:license_id).
+                       of_type(:integer).
+                       with_options(null: false) }
+
     it { is_expected.to have_db_column(:identifier_json).
                         of_type(:jsonb).
-                        with_options(default: { 'identifier' => [] }, null: false) }
+                        with_options(default: { 'identifier' => [] }) }
 
     it { is_expected.to have_db_column(:title_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:date_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:note_json).
                         of_type(:jsonb).
-                        with_options(default: { 'note' => [] }, null: false) }
+                        with_options(default: { 'note' => [] }) }
 
     it { is_expected.to have_db_column(:subject_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:related_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:cartographics_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:publication_json).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:digital_origin).
                         of_type(:integer).
@@ -66,7 +70,7 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
 
     it { is_expected.to have_db_column(:resource_type_manuscript).
                         of_type(:boolean).
-                        with_options(default: false, null: false) }
+                        with_options(default: false) }
 
     it { is_expected.to have_db_column(:origin_event).
                        of_type(:string) }
@@ -120,6 +124,7 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
 
     it { is_expected.to have_db_index([:descriptable_type, :descriptable_id]).unique(true) }
     it { is_expected.to have_db_index(:physical_location_id) }
+    it { is_expected.to have_db_index(:license_id) }
     it { is_expected.to have_db_index(:identifier_json) }
     it { is_expected.to have_db_index(:title_json) }
     it { is_expected.to have_db_index(:date_json) }
@@ -218,7 +223,6 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
       {
         genres: 'Curator::ControlledTerms::Genre',
         resource_types: 'Curator::ControlledTerms::ResourceType',
-        licenses: 'Curator::ControlledTerms::License',
         languages: 'Curator::ControlledTerms::Language',
         subject_topics: 'Curator::ControlledTerms::Subject',
         subject_names: 'Curator::ControlledTerms::Name',
@@ -233,6 +237,11 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
                         inverse_of(:physical_locations_of).
                         class_name('Curator::ControlledTerms::Name').
                         required }
+
+    it { is_expected.to belong_to(:license).
+                       inverse_of(:licensees).
+                       class_name('Curator::ControlledTerms::License').
+                       required }
 
     it { is_expected.to have_many(:name_roles).
                         inverse_of(:descriptive).
@@ -288,8 +297,20 @@ RSpec.describe Curator::Metastreams::Descriptive, type: :model do
       end
     end
 
+    describe '.with_license' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.includes(:license).to_sql }
+
+      it { is_expected.to respond_to(:with_license) }
+
+      it 'expects the scope sql to match the :expected_scope_sql' do
+        expect(subject.with_license.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
     it_behaves_like 'for_serialization' do
-      let(:expected_scope_sql) { described_class.merge(described_class.with_mappings).merge(described_class.with_physical_location).to_sql }
+      let(:expected_scope_sql) { described_class.merge(described_class.with_mappings).merge(described_class.with_physical_location).merge(described_class.with_license).to_sql }
     end
   end
 end

--- a/spec/models/curator/metastreams/workflow_spec.rb
+++ b/spec/models/curator/metastreams/workflow_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Curator::Metastreams::Workflow, type: :model do
 
     it { is_expected.to have_db_column(:publishing_state).
                         of_type(:integer).
-                        with_options(default: 'draft', null: false) }
+                        with_options(default: 'draft') }
 
     it { is_expected.to have_db_column(:processing_state).
                        of_type(:integer) }

--- a/spec/models/curator/shared/controlled_terms/nomenclature.rb
+++ b/spec/models/curator/shared/controlled_terms/nomenclature.rb
@@ -13,7 +13,7 @@ RSpec.shared_examples 'nomenclature', type: :model do
     it_behaves_like 'archivable'
 
     it { is_expected.to have_db_column(:type).of_type(:string).with_options(null: false) }
-    it { is_expected.to have_db_column(:term_data).of_type(:jsonb).with_options(null: false) }
+    it { is_expected.to have_db_column(:term_data).of_type(:jsonb) }
     it { is_expected.to have_db_column(:authority_id).of_type(:integer) }
 
     it { is_expected.to have_db_index(:authority_id) }

--- a/spec/models/curator/shared/filestreams/file_set.rb
+++ b/spec/models/curator/shared/filestreams/file_set.rb
@@ -30,7 +30,7 @@ RSpec.shared_examples 'file_set', type: :model do
 
     it { is_expected.to have_db_column(:pagination).
                         of_type(:jsonb).
-                        with_options(default: '{}', null: false) }
+                        with_options(default: '{}') }
 
     it { is_expected.to have_db_column(:file_set_of_id).
                         of_type(:integer).

--- a/spec/models/curator/shared/filestreams/thumbnailable.rb
+++ b/spec/models/curator/shared/filestreams/thumbnailable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'thumbnailable', type: :model do
+  describe 'has_one_attached #image_thumbnail_300' do
+    it { is_expected.to respond_to(:image_thumbnail_300) }
+
+    it 'expects each of the attachment types to be a kind of ActiveStorage::Attachment' do
+      expect(subject.image_thumbnail_300).to be_an_instance_of(ActiveStorage::Attached::One)
+    end
+  end
+end

--- a/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
+++ b/spec/models/curator/shared/mappings/has_exemplary_file_set.rb
@@ -2,16 +2,15 @@
 
 RSpec.shared_examples 'has_exemplary_file_set', type: :model do
   describe '#exemplary_file_set' do
-    let!(:exemplary_file_set) { create(:curator_filestreams_image) }
+    let(:exemplary_file_set) { create(:curator_filestreams_image) }
 
     before(:each) do
-      subject.exemplary_image_mapping = build(:curator_mappings_exemplary_image, exemplary_file_set: exemplary_file_set)
-      subject.save!
+      create(:curator_mappings_exemplary_image, exemplary_file_set: exemplary_file_set, exemplary_object: subject)
     end
 
     it 'returns the exemplary FileSet' do
-      expect(subject.exemplary_image_mapping).to be_truthy
-      expect(subject.exemplary_file_set.ark_id).to eq(exemplary_file_set.ark_id)
+      expect(subject.reload.exemplary_image_mapping).to be_truthy
+      expect(subject.reload.exemplary_file_set.ark_id).to eq(exemplary_file_set.ark_id)
     end
   end
 end

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -207,13 +207,13 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
           end
         end
 
-        describe 'licenses' do
-          let(:licenses) { descriptive.licenses }
+        describe 'license' do
+          let(:license) { descriptive.license }
           let(:license_attrs) { %i(label uri) }
           it 'sets the licenses data' do
-            expect(licenses).to all(be_an_instance_of(Curator::ControlledTerms::License))
-            desc_json['licenses'].each do |license_json|
-              expect(collection_as_json(licenses, { methods: license_attrs, only: license_attrs })).to include(license_json.slice(*license_attrs))
+            expect(license).to be_an_instance_of(Curator::ControlledTerms::License)
+            license_attrs.each do |attr|
+              expect(license.send(attr)).to eq desc_json['license'][attr]
             end
           end
         end

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -300,6 +300,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
       it 'sets the correct administrative metadata' do
         expect(administrative.description_standard).to eq administrative_json['description_standard']
         expect(administrative.flagged).to eq administrative_json['flagged']
+        expect(administrative.hosting_status).to eq(administrative_json['hosting_status'])
       end
     end
   end

--- a/spec/services/curator/filestreams/file_set_factory_service_spec.rb
+++ b/spec/services/curator/filestreams/file_set_factory_service_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Curator::Filestreams::FileSetFactoryService, type: :service do
       end
 
       describe 'exemplary_image_of' do
-        let(:exemplary_image_object) { @file_set.exemplary_image_objects.first }
+        let(:exemplary_image_object) { @file_set.exemplary_image_of_objects.first }
         it 'sets the exemplary_image_object relationship' do
           expect(exemplary_image_object).to be_an_instance_of(Curator::DigitalObject)
           expect(exemplary_image_object.ark_id).to eq @object_json['exemplary_image_of'][0]['ark_id']
         end
 
-        let(:exemplary_image_collection) { @file_set.exemplary_image_collections.first }
+        let(:exemplary_image_collection) { @file_set.exemplary_image_of_collections.first }
         it 'sets the exemplary_image_collection relationship' do
           expect(exemplary_image_collection).to be_an_instance_of(Curator::Collection)
           expect(exemplary_image_collection.ark_id).to eq @object_json['exemplary_image_of'][1]['ark_id']

--- a/spec/support/serializer_helper.rb
+++ b/spec/support/serializer_helper.rb
@@ -55,7 +55,7 @@ module SerializerHelper
             only: [:label, :id_from_auth, :authority_code],
             methods: [:label, :id_from_auth, :authority_code]
           },
-          licenses: {
+          license: {
             only: [:label, :uri],
             methods: [:label, :uri]
           },


### PR DESCRIPTION
- Changed `license` to `belongs_to` on descriptive. And removed ability to be mapped through the `dec_terms` mapping table. Updated indexer

- Fixed issue with `workflow`, `administrative`  not referencing the parent class when mapped from `file_set` 

- Added `Metadata` to `VALID_EXEMPLARY_FILE_SET_TYPES` in `ExemplaryImage` mapping table

- Fixed `has_one` `exemplary_file_set` not working and removed `delegate` declaration 

- Added `exemplary_image_of` method that combines relationships declared in a `file_set`'s `exemplary_image_of_mappings`. Also changed type based to `exemplary_image_of_collections` and `exemplary_image_of_objects`

- Made a `Filestreams::Thumbanilable` concern that includes declaration for `has_one_attached :image_thumbnail_300` and included in all relevant `file_sets` and for `institution`

-Added `hosting_status enum` column  to `administrative` class and updated indexer. 

- Removed unnecessary `null` constraints from migrations including a `default` constraint
