### PR TITLE
Add oai header

### DIFF
--- a/app/controllers/curator/digital_objects_controller.rb
+++ b/app/controllers/curator/digital_objects_controller.rb
@@ -46,7 +46,7 @@ module Curator
                                                contained_by: [:ark_id],
                                                metastreams: {
                                                  descriptive: descriptive_permitted_params,
-                                                 administrative: [:description_standard, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
+                                                 administrative: [:description_standard, :oai_header_id, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
                                                  workflow: [:ingest_origin, :publishing_state, :processing_state]
                                                })
       when 'update'

--- a/app/controllers/curator/metastreams/administratives_controller.rb
+++ b/app/controllers/curator/metastreams/administratives_controller.rb
@@ -34,7 +34,7 @@ module Curator
         when 'collection'
           params.require(:administrative).permit(:harvestable, destination_site: [], access_edit_group: [])
         when 'digital_object'
-          params.require(:administrative).permit(:description_standard, :flagged, :harvestable, destination_site: [], access_edit_group: [])
+          params.require(:administrative).permit(:description_standard, :oai_header_id, :flagged, :harvestable, destination_site: [], access_edit_group: [])
         when 'audio', 'document', 'ereader', 'image', 'metadata', 'text', 'video'
           params.require(:administrative).permit(access_edit_group: [])
         else

--- a/app/indexers/concerns/curator/indexer/administrative_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/administrative_indexer.rb
@@ -9,6 +9,7 @@ module Curator
           to_field 'destination_site_ssim', obj_extract('administrative', 'destination_site')
           to_field 'hosting_status_ssi', obj_extract('administrative', 'hosting_status')
           to_field 'harvesting_status_bsi', obj_extract('administrative', 'harvestable')
+          to_field 'oai_header_id_ss', obj_extract('administrative', 'oai_header_id')
           to_field('flagged_content_ssi') { |rec, acc| acc << true if rec.administrative&.flagged }
         end
       end

--- a/app/models/curator/metastreams/administrative.rb
+++ b/app/models/curator/metastreams/administrative.rb
@@ -10,6 +10,7 @@ module Curator
     enum hosting_status: { hosted: 0, harvested: 1 }.freeze
 
     validates :hosting_status, presence: true
+    validates :oai_header_id, uniqueness: { allow_nil: true, allow_blank: true }
     validates :administratable_id, uniqueness: { scope: :administratable_type }
     validates :administratable_type, inclusion: { in: Metastreams.valid_base_types + Metastreams.valid_filestream_types }
 

--- a/app/serializers/curator/metastreams/administrative_serializer.rb
+++ b/app/serializers/curator/metastreams/administrative_serializer.rb
@@ -3,7 +3,7 @@
 module Curator
   class Metastreams::AdministrativeSerializer < Curator::Serializers::AbstractSerializer
     schema_as_json root: :administrative do
-      attributes :description_standard, :flagged, :harvestable, :destination_site
+      attributes :description_standard, :flagged, :harvestable, :destination_site, :oai_header_id
     end
   end
 end

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -27,7 +27,7 @@ module Curator
           end
 
           build_administrative(digital_object) do |admin|
-            [:description_standard, :flagged, :destination_site, :hosting_status, :harvestable].each do |attr|
+            [:description_standard, :flagged, :destination_site, :hosting_status, :harvestable, :oai_header_id].each do |attr|
               admin.send("#{attr}=", @admin_json_attrs.fetch(attr, nil))
             end
           end

--- a/app/services/curator/metastreams/administrative_updater_service.rb
+++ b/app/services/curator/metastreams/administrative_updater_service.rb
@@ -4,7 +4,7 @@ module Curator
   class Metastreams::AdministrativeUpdaterService < Services::Base
     include Services::UpdaterService
 
-    SIMPLE_ATTRIBUTES_LIST = %i(destination_site flagged description_standard harvestable).freeze
+    SIMPLE_ATTRIBUTES_LIST = %i(destination_site flagged description_standard harvestable oai_header_id).freeze
 
     def call
       access_edit_group_attrs = @json_attrs.fetch('access_edit_group', [])

--- a/db/migrate/20190919202256_create_curator_metastreams_administratives.rb
+++ b/db/migrate/20190919202256_create_curator_metastreams_administratives.rb
@@ -4,6 +4,7 @@ class CreateCuratorMetastreamsAdministratives < ActiveRecord::Migration[5.2]
   def change
     create_table :curator_metastreams_administratives do |t|
       t.belongs_to :administratable, polymorphic: true, index: { unique: true, using: :btree, name: 'unique_idx_meta_admin_on_metastreamable_poly' }, null: false
+      t.string :oai_header_id, index: { unique: true }
       t.integer :description_standard, index: { using: :btree, where: 'description_standard is not null', name: 'idx_administrative_on_not_null_desc_standard' }
       t.integer :hosting_status, index: { using: :btree }, default: 0
       t.boolean :harvestable, index: { using: :btree }, default: true

--- a/spec/controllers/curator/digital_objects_controller_spec.rb
+++ b/spec/controllers/curator/digital_objects_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Curator::DigitalObjectsController, type: :controller do
   let!(:resource) { create(:curator_digital_object) }
   let!(:valid_attributes) do
     attributes = attributes_for(:curator_digital_object).except(:administrative, :descriptive, :workflow)
-    relation_attributes = load_json_fixture('digital_object')
+    relation_attributes = load_json_fixture('digital_object_4', 'digital_object')
     parent = create(:curator_collection, institution: create(:curator_institution, :with_location))
 
     attributes.merge!({

--- a/spec/controllers/curator/metastreams/administratives_controller_spec.rb
+++ b/spec/controllers/curator/metastreams/administratives_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe Curator::Metastreams::AdministrativesController, type: :controlle
           attributes[:description_standard] = 'cco'
           attributes[:flagged] = true
           attributes[:harvestable] = true
+          attributes[:oai_header_id] = "oai:test:#{SecureRandom.hex}"
         end
         attributes
       end

--- a/spec/factories/curator/metastreams/administratives.rb
+++ b/spec/factories/curator/metastreams/administratives.rb
@@ -32,6 +32,11 @@ FactoryBot.define do
       end
     end
 
+    trait :for_oai_object do
+      oai_header_id { "oai:test:#{SecureRandom.hex}" }
+      for_object
+    end
+
     trait :for_file_set do
       transient do
         file_type { Curator.filestreams.file_set_types.map { |type| "curator_filestreams_#{type}".to_sym }.sample }

--- a/spec/fixtures/files/digital_object_4.json
+++ b/spec/fixtures/files/digital_object_4.json
@@ -143,6 +143,7 @@
           "commonwealth"
         ],
         "harvestable": true,
+        "oai_header_id": "oai:bos:123456",
         "hosting_status": "harvested",
         "access_edit_group": [
           "superuser",

--- a/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Curator::Indexer::AdministrativeIndexer do
       admin_obj = create(:curator_institution)
       admin_obj.administrative = create(:curator_metastreams_administrative)
       admin_obj.administrative.flagged = true # so we can test indexing
-      admin_obj.administrative.oai_header_id = "test:1a234b5"
+      admin_obj.administrative.oai_header_id = 'test:1a234b5' # so we can test indexing
       admin_obj
     end
     let(:indexed) { indexer.map_record(administratable_object) }

--- a/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/administrative_indexer_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Curator::Indexer::AdministrativeIndexer do
       admin_obj = create(:curator_institution)
       admin_obj.administrative = create(:curator_metastreams_administrative)
       admin_obj.administrative.flagged = true # so we can test indexing
+      admin_obj.administrative.oai_header_id = "test:1a234b5"
       admin_obj
     end
     let(:indexed) { indexer.map_record(administratable_object) }
@@ -20,6 +21,10 @@ RSpec.describe Curator::Indexer::AdministrativeIndexer do
 
     it 'sets the destination_site field' do
       expect(indexed['destination_site_ssim']).to eq administrative.destination_site
+    end
+
+    it 'sets the oai_header_id field' do
+      expect(indexed['oai_header_id_ss']).to eq [administrative.oai_header_id]
     end
 
     it 'sets the hosting_status field' do

--- a/spec/models/curator/metastreams/administrative_spec.rb
+++ b/spec/models/curator/metastreams/administrative_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe Curator::Metastreams::Administrative, type: :model do
     it { is_expected.to have_db_column(:destination_site).
                         of_type(:string).
                         with_options(default: ['commonwealth'], array: true) }
+
     it { is_expected.to have_db_column(:oai_header_id).
-                        of_type(:string)
-                      }
+                        of_type(:string) }
 
     it { is_expected.to have_db_index([:administratable_type, :administratable_id]).unique(true) }
     it { is_expected.to have_db_index(:description_standard) }

--- a/spec/models/curator/metastreams/administrative_spec.rb
+++ b/spec/models/curator/metastreams/administrative_spec.rb
@@ -39,12 +39,16 @@ RSpec.describe Curator::Metastreams::Administrative, type: :model do
     it { is_expected.to have_db_column(:destination_site).
                         of_type(:string).
                         with_options(default: ['commonwealth'], array: true) }
+    it { is_expected.to have_db_column(:oai_header_id).
+                        of_type(:string)
+                      }
 
     it { is_expected.to have_db_index([:administratable_type, :administratable_id]).unique(true) }
     it { is_expected.to have_db_index(:description_standard) }
     it { is_expected.to have_db_index(:hosting_status) }
     it { is_expected.to have_db_index(:destination_site) }
     it { is_expected.to have_db_index(:harvestable) }
+    it { is_expected.to have_db_index(:oai_header_id).unique(true) }
 
     it { is_expected.to define_enum_for(:description_standard).
                         with_values(aacr: 0, cco: 1, dacs: 2, gihc: 3, local: 4, rda: 5, dcrmg: 6, amremm: 7, dcrmb: 8, dcrmc: 9, dcrmmss: 10, appm: 11).

--- a/spec/serializers/curator/digital_object_serializer_spec.rb
+++ b/spec/serializers/curator/digital_object_serializer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Curator::DigitalObjectSerializer, type: :serializers do
           },
           administrative: {
             root: true,
-            only: [:description_standard, :harvestable, :flagged, :destination_site]
+            only: [:description_standard, :harvestable, :flagged, :destination_site, :oai_header_id]
           },
           descriptive: descriptive_as_json_options,
           workflow: {

--- a/spec/serializers/curator/metastreams/administrative_serializer_spec.rb
+++ b/spec/serializers/curator/metastreams/administrative_serializer_spec.rb
@@ -5,7 +5,7 @@ require_relative '../shared/json_serialization'
 
 RSpec.describe Curator::Metastreams::AdministrativeSerializer, type: :serializers do
   let!(:administrative_count) { 3 }
-  let!(:record_collection) { create_list(:curator_metastreams_administrative, administrative_count) }
+  let!(:record_collection) { create_list(:curator_metastreams_administrative, administrative_count, :for_oai_object) }
   let!(:record) { record_collection.last }
 
   describe 'Serialization' do
@@ -15,7 +15,7 @@ RSpec.describe Curator::Metastreams::AdministrativeSerializer, type: :serializer
       let(:expected_as_json_options) do
         {
           root: true,
-          only: [:description_standard, :flagged, :harvestable, :destination_site]
+          only: [:description_standard, :flagged, :harvestable, :destination_site, :oai_header_id]
         }
       end
     end

--- a/spec/services/curator/metastreams/administrative_updater_service_spec.rb
+++ b/spec/services/curator/metastreams/administrative_updater_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Curator::Metastreams::AdministrativeUpdaterService, type: :servic
       specify { expect(subject.administratable.updated_at).not_to eq(@administratable_updated_at) }
 
       it 'expects the attributes to have been updated' do
-        [:flagged, :harvestable].each do |attr|
+        [:flagged, :harvestable, :oai_header_id].each do |attr|
           expect(subject.public_send(attr)).to eq(@update_attributes[attr])
         end
         expect(subject.description_standard).to eq(@update_attributes[:description_standard].to_s)

--- a/spec/services/curator/shared/factory_service_metastreams_shared.rb
+++ b/spec/services/curator/shared/factory_service_metastreams_shared.rb
@@ -27,6 +27,7 @@ RSpec.shared_examples 'factory_administratable', type: :service do
     end
 
     it 'sets the correct administrative metadata' do
+      expect(administrative.oai_header_id).to eq(administrative_json['oai_header_id'])
       expect(administrative.harvestable).to eq true
       expect(administrative.destination_site).to eq administrative_json['destination_site']
     end


### PR DESCRIPTION
- Added `oai_header_id` to `Curator::Metastreams::Administrative` 
- Added `oai_header_id_ss` to `Curator::Indexer::AdministrativeIndexer`
- Applied this change to all relevant serializers, controllers, factory/updater services.
- Updated Specs for all changed/relevant classes
- resolves #96 