### PR TITLE
authority API health check and background jobs for Solr indexing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - CI=true
   jobs:
-    - "RAILS_VERSION=6.1.1"
+    - "RAILS_VERSION=6.1.3"

--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -77,7 +77,7 @@ module Curator
     end
 
     def queue_deletion_job
-      Curator::Indexer::DeletionJob.perform_later(self.ark_id)
+      Curator::Indexer::DeletionJob.perform_later(ark_id)
     end
   end
 end

--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -63,13 +63,14 @@ module Curator
     # By default will use:
     #  - curator_indexable_mapper
     #  - a per-update writer, or thread/block-specific writer configured with `self.index_with`
-    def update_index(mapper: curator_indexable_mapper, writer:nil)
+    def update_index(mapper: curator_indexable_mapper, writer: nil)
       RecordIndexUpdater.new(self, mapper: mapper, writer: writer).update_index
     end
 
-    # make sure indexing service is ready before we commit transactions and :update_index
+    # make sure indexing and authority services are ready before we commit transactions and :update_index
     def indexer_health_check
-      raise Curator::Exceptions::CuratorError, 'Indexing service is not ready!' unless SolrUtil.solr_ready?
+      raise Curator::Exceptions::SolrUnavailable unless SolrUtil.ready?
+      raise Curator::Exceptions::AuthorityApiUnavailable unless Curator::ControlledTerms::AuthorityService.ready?
     end
   end
 end

--- a/app/indexers/concerns/curator/solr_util.rb
+++ b/app/indexers/concerns/curator/solr_util.rb
@@ -97,13 +97,13 @@ module Curator
 
     ##
     # check if Solr is online
-    def self.solr_ready?(solr_url: Curator.config.solr_url)
+    def self.ready?(solr_url: Curator.config.solr_url)
       rsolr = RSolr.connect url: solr_url
       begin
         ping_request = rsolr.head('admin/ping')
         ping_request.response[:status] == 200 ? true : false
       rescue StandardError => e
-        Rails.logger.error "ERROR: Solr is not ready: #{e}"
+        Rails.logger.error "ERROR: Solr is not available: #{e}"
         false
       end
     end

--- a/app/jobs/curator/filestreams/derivatives_job.rb
+++ b/app/jobs/curator/filestreams/derivatives_job.rb
@@ -4,9 +4,7 @@ module Curator
   class Filestreams::DerivativesJob < ApplicationJob
     queue_as :filestream_derivatives
 
-    def perform(file_set_class, file_set_id)
-      file_set = file_set_class.constantize.find(file_set_id)
-
+    def perform(file_set)
       payload = file_set.derivatives_payload
 
       Curator::Filestreams::DerivativesService.call(payload: payload)

--- a/app/jobs/curator/indexer/deletion_job.rb
+++ b/app/jobs/curator/indexer/deletion_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer::DeletionJob < ApplicationJob
+    queue_as :indexing
+
+    def perform(ark_id)
+      writer = Curator.config.indexable_settings.writer_instance!
+      writer.delete(ark_id)
+    end
+  end
+end

--- a/app/jobs/curator/indexer/indexing_job.rb
+++ b/app/jobs/curator/indexer/indexing_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer::IndexingJob < ApplicationJob
+    queue_as :indexing
+
+    def perform(obj_to_index)
+      obj_to_index.update_index
+    end
+  end
+end

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -94,7 +94,7 @@ module Curator
     def generate_derivatives
       return if workflowable_type != 'Curator::Filestreams::FileSet'
 
-      Curator::Filestreams::DerivativesJob.perform_later(self.class.name, id)
+      Curator::Filestreams::DerivativesJob.perform_later(self)
     end
   end
 end

--- a/app/services/curator/controlled_terms/authority_service.rb
+++ b/app/services/curator/controlled_terms/authority_service.rb
@@ -28,7 +28,7 @@ module Curator
       rescue Oj::Error => e
         Rails.logger.error "Error Parsing Json For Authority at #{@request_uri}"
         Rails.logger.error "Reason #{e.message}"
-      rescue RemoteServiceError => e
+      rescue Curator::Exceptions::RemoteServiceError => e
         Rails.logger.error "Error Retreiving Json For Authority at #{@request_uri}"
         Rails.logger.error "Reason #{e.message}"
       end
@@ -38,12 +38,10 @@ module Curator
     protected
 
     def fetch_auth_data(client)
-      resp = client.headers(self.class.default_headers).
-                    get(request_uri.to_s)
-
+      resp = client.headers(self.class.default_headers).get(request_uri.to_s)
       json_response = Oj.load(resp.body.to_s)
-
-      raise RemoteServiceError.new('Failed to retreive data from bpldc_auth_api!', json_response, resp.status) if !resp.status.success?
+      raise Curator::Exceptions::RemoteServiceError.new('Failed to retrieve data from bpldc_auth_api!',
+                                                        json_response, resp.status) if !resp.status.success?
 
       json_response
     end

--- a/lib/curator/exceptions.rb
+++ b/lib/curator/exceptions.rb
@@ -4,7 +4,7 @@ module Curator
   module Exceptions
     extend ActiveSupport::Autoload
 
-    # Base Exception for everything curataor related
+    # Base Exception for everything curator related
     class CuratorError < StandardError; end
 
     # Base exception for any error expected to be serialized in controller
@@ -89,6 +89,10 @@ module Curator
       autoload :NotAcceptable, File.expand_path('./exceptions/controller_errors.rb', __dir__)
       # Serializable ModelError Subclasses
       autoload :InvalidRecord, File.expand_path('./exceptions/model_errors.rb', __dir__)
+      # remote services CuratorError Subclasses
+      autoload :SolrUnavailable, File.expand_path('./exceptions/remote_service_errors.rb', __dir__)
+      autoload :AuthorityApiUnavailable, File.expand_path('./exceptions/remote_service_errors.rb', __dir__)
+      autoload :RemoteServiceError, File.expand_path('./exceptions/remote_service_errors.rb', __dir__)
     end
   end
 end

--- a/lib/curator/exceptions/remote_service_errors.rb
+++ b/lib/curator/exceptions/remote_service_errors.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Curator::Exceptions
+  class SolrUnavailable < CuratorError
+    def message
+      'Solr is not available'
+    end
+  end
+
+  class AuthorityApiUnavailable < CuratorError
+    def message
+      'Authority API is not available'
+    end
+  end
+
+  # NOTE: do not inherit sub classes from this
+  class RemoteServiceError < CuratorError
+    attr_reader :json_response, :code
+
+    def initialize(msg = 'Error Occurred With RemoteService Client', json_response = {}, code = 500)
+      @json_response = JSON.pretty_generate(json_response)
+      @code = code
+      super(msg)
+    end
+  end
+end

--- a/lib/curator/services/remote_service.rb
+++ b/lib/curator/services/remote_service.rb
@@ -54,6 +54,7 @@ module Curator
       class_methods do
         def ready?
           # TODO: remove line below once remote services are containerized for CI builds
+          # until then, we need this or tons of specs will fail, too many for VCR
           return true if ENV.fetch('RAILS_ENV', 'development') == 'test'
 
           begin

--- a/spec/indexers/concerns/curator/solr_util_spec.rb
+++ b/spec/indexers/concerns/curator/solr_util_spec.rb
@@ -2,14 +2,14 @@
 
 require 'rails_helper'
 RSpec.describe Curator::SolrUtil do
-  describe '#solr_ready?' do
+  describe '#ready?' do
     it 'returns true if Solr is available' do
-      expect(described_class).to be_solr_ready
+      expect(described_class).to be_ready
     end
 
     it 'returns false if Solr is not available' do
       ClimateControl.modify SOLR_URL: 'http://127.0.0.1:9999/solr/wrong' do
-        expect(described_class).not_to be_solr_ready
+        expect(described_class).not_to be_ready
       end
     end
   end

--- a/spec/jobs/curator/filestreams/derivatives_job_spec.rb
+++ b/spec/jobs/curator/filestreams/derivatives_job_spec.rb
@@ -1,32 +1,18 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
-
+require_relative '../shared/jobs_shared'
 RSpec.describe Curator::Filestreams::DerivativesJob, type: :job do
   describe 'expected job behavior' do
     subject { described_class }
 
-    let!(:file_set_class) { 'Curator::Filestreams::Image' }
-    let!(:file_set_id) { 1 }
-    let!(:expected_queue) { 'filestream_derivatives' }
+    let(:job_args) { create(:curator_filestreams_image) }
+    let(:expected_queue) { 'filestream_derivatives' }
 
     before(:each) do
       ActiveJob::Base.queue_adapter = :test
     end
 
-    it 'is expected to have been enqueued with correct args' do
-      subject.perform_later(file_set_class, file_set_id)
-      expect(subject).to have_been_enqueued.with(file_set_class, file_set_id)
-    end
-
-    it 'is expected to have been enqueued on correct queue' do
-      subject.perform_later(file_set_class, file_set_id)
-      expect(subject).to have_been_enqueued.on_queue(expected_queue)
-    end
-
-    it 'is expected to be enqueued immediatley' do
-      subject.perform_later(file_set_class, file_set_id)
-      expect(subject).to have_been_enqueued.at(:no_wait)
-    end
+    it_behaves_like 'queueable'
   end
 end

--- a/spec/jobs/curator/indexer/deletion_job_spec.rb
+++ b/spec/jobs/curator/indexer/deletion_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../../../indexers/concerns/curator/shared/indexable_shared'
+require_relative '../shared/jobs_shared'
+RSpec.describe Curator::Indexer::DeletionJob, type: :job do
+  include_context 'indexable_shared'
+
+  describe 'expected job behavior' do
+    subject { described_class }
+
+    let(:job_args) { 'bpl-dev:987654321' }
+    let(:expected_queue) { 'indexing' }
+
+    before(:each) do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it_behaves_like 'queueable'
+
+    it 'sends a delete request to the indexing service' do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      subject.perform_later(job_args)
+      assert_requested :post, solr_update_url,
+                       body: { 'delete' => job_args }.to_json
+    end
+  end
+end

--- a/spec/jobs/curator/indexer/indexing_job_spec.rb
+++ b/spec/jobs/curator/indexer/indexing_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/jobs_shared'
+RSpec.describe Curator::Indexer::IndexingJob, type: :job do
+  describe 'expected job behavior' do
+    subject { described_class }
+
+    let(:job_args) { create(:curator_institution) }
+    let(:expected_queue) { 'indexing' }
+
+    before(:each) do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it_behaves_like 'queueable'
+
+    it 'sends an update request to the indexing service' do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      timestamp = Time.current
+      subject.perform_later(job_args)
+      # don't use assert_requested here, too hard to match body, check solr timestamp instead
+      rsolr = RSolr.connect url: Curator.config.solr_url
+      solr_resp = rsolr.get 'select', params: { q: "id:\"#{job_args.ark_id}\"" }
+      solr_rec = solr_resp['response']['docs'].first
+      expect(solr_rec['timestamp']).to be > timestamp
+    end
+  end
+end

--- a/spec/jobs/curator/shared/jobs_shared.rb
+++ b/spec/jobs/curator/shared/jobs_shared.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'queueable', type: :job do
+  it 'queues the job' do
+    expect do
+      subject.perform_later(job_args)
+    end.to have_enqueued_job.with(job_args).on_queue(expected_queue).at(:no_wait)
+  end
+end

--- a/spec/lib/curator/exceptions/errors_spec.rb
+++ b/spec/lib/curator/exceptions/errors_spec.rb
@@ -36,4 +36,22 @@ RSpec.describe Curator::Exceptions do
       end
     end
   end
+
+  describe 'remote_service_errors' do
+    %i(SolrUnavailable AuthorityApiUnavailable RemoteServiceError).each do |remote_error_const|
+      it { is_expected.to be_const_defined(remote_error_const) }
+
+      describe "Curator::Exception::#{remote_error_const}" do
+        subject { described_class.const_get(remote_error_const) }
+
+        specify { expect(subject).to be <= Curator::Exceptions::CuratorError }
+      end
+    end
+
+    describe 'Curator::Exceptions::RemoteServiceError' do
+      subject { Curator::Exceptions::RemoteServiceError.new }
+
+      it { is_expected.to respond_to(:json_response, :code) }
+    end
+  end
 end

--- a/spec/services/curator/controlled_terms/authority_service_spec.rb
+++ b/spec/services/curator/controlled_terms/authority_service_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/remote_service'
+
+RSpec.describe Curator::ControlledTerms::AuthorityService, type: :service do
+  subject { described_class }
+
+  it_behaves_like 'remote_service'
+
+  it 'expects the .base_url to eq the Curator.config.authority_api_url' do
+    expect(subject.base_url).to eq(Curator.config.authority_api_url)
+  end
+
+  describe '#call' do
+    let(:auth_data) do
+      VCR.use_cassette('services/controlled_terms/authority_service') do
+        described_class.call(path: 'authorities')
+      end
+    end
+
+    it 'fetches the data from the API' do
+      expect(auth_data).to be_a_kind_of(Array)
+      expect(auth_data).to_not be_blank
+    end
+  end
+end

--- a/spec/services/curator/shared/remote_service.rb
+++ b/spec/services/curator/shared/remote_service.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'remote_service', type: :service do
-  it { is_expected.to respond_to(:base_url, :base_uri, :with_client, :pool_options, :timeout_options, :default_headers, :default_path_prefix, :ssl_context) }
-
-  it { is_expected.to be_const_defined(:RemoteServiceError) }
+  it { is_expected.to respond_to(:base_url, :base_uri, :with_client, :pool_options, :timeout_options, :default_headers,
+                                 :default_path_prefix, :ssl_context, :ready?) }
 end

--- a/spec/vcr/services/controlled_terms/authority_service.yml
+++ b/spec/vcr/services/controlled_terms/authority_service.yml
@@ -1,0 +1,71 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/bpldc/authorities
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/4.4.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"4ec7f7e60a0f71681c0efa4ce7b45f1f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 79a078bc-33ed-4b52-a8bb-d947f32202f5
+      X-Runtime:
+      - '0.706115'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"name":"Art and Architecture Thesaurus","code":"aat","base_url":"http://vocab.getty.edu/aat"},{"name":"GeoNames","code":"geonames","base_url":"http://sws.geonames.org"},{"name":"Thesaurus
+        for Graphic Materials","code":"gmgpc","base_url":"http://id.loc.gov/vocabulary/graphicMaterials"},{"name":"ISO639-2
+        Languages","code":"iso639-2","base_url":"http://id.loc.gov/vocabulary/iso639-2"},{"name":"Library
+        of Congress Genre/Form Terms","code":"lcgft","base_url":"http://id.loc.gov/authorities/genreForms"},{"name":"Thesaurus
+        for Graphic Materials","code":"lctgm","base_url":"http://id.loc.gov/vocabulary/graphicMaterials"},{"name":"Library
+        of Congress Subject Headings","code":"lcsh","base_url":"http://id.loc.gov/authorities/subjects"},{"name":"local","code":"local"},{"name":"Library
+        of Congress Name Authority File","code":"naf","base_url":"http://id.loc.gov/authorities/names"},{"name":"MARC
+        genre terms","code":"marcgt","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/marcgt"},{"name":"MARC
+        Relators Scheme","code":"marcrelator","base_url":"http://id.loc.gov/vocabulary/relators"},{"name":"RBMS
+        Controlled Vocabularies: Binding Terms","code":"rbbin","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbbin"},{"name":"RBMS
+        Controlled Vocabularies: Genre Terms","code":"rbgenr","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbgenr"},{"name":"RBMS
+        Controlled Vocabularies: Paper Terms","code":"rbpap","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbpap"},{"name":"RBMS
+        Controlled Vocabularies: Printing \u0026 Publishing Evidence","code":"rbpri","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbpri"},{"name":"RBMS
+        Controlled Vocabularies: Provenance Evidence","code":"rbprov","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbprov"},{"name":"RBMS
+        Controlled Vocabularies: Printing \u0026 Publishing Evidence","code":"rbpub","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbpub"},{"name":"RBMS
+        Controlled Vocabularies: Type Evidence","code":"rbtyp","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbtyp"},{"name":"Resource
+        Types Scheme","code":"resourceTypes","base_url":"http://id.loc.gov/vocabulary/resourceTypes"},{"name":"Thesaurus
+        of Geographic Names","code":"tgn","base_url":"http://vocab.getty.edu/tgn"},{"name":"Getty
+        Union List of Artist Names","code":"ulan","base_url":"http://vocab.getty.edu/ulan"}]'
+  recorded_at: Fri, 05 Mar 2021 22:37:00 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
* Adds a  `ready?` method to `Curator::Services::RemoteService` to check availability of external services/APIs (fixes #83)
* Perform Solr indexing in a background job (fixes #17)
* Group exception classes for remote service connections into a new file `lib/curator/exceptions/remote_service_errors.rb`