### PR TITLE
don't set workflow values where not applicable

### DIFF
--- a/app/indexers/concerns/curator/indexer/identifier_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/identifier_indexer.rb
@@ -13,7 +13,7 @@ module Curator
                            identifier_local_call_tsim identifier_local_call_invalid_tsim
                            identifier_local_barcode_tsim identifier_local_barcode_invalid_tsim
                            identifier_local_accession_tsim identifier_isbn_tsim identifier_lccn_tsim
-                           identifier_ia_id_ssi identifier_uri_ss)
+                           identifier_ia_id_ssi identifier_uri_ss identifier_iiif_manifest_ss)
             id_fields.each { |field| context.output_hash[field] ||= [] }
             record.descriptive.identifier.each do |identifier|
               label = identifier.label
@@ -26,6 +26,8 @@ module Curator
                              'identifier_ia_id_ssi'
                            when 'uri'
                              'identifier_uri_ss'
+                           when 'iiif_manifest'
+                             'identifier_iiif_manifest_ss'
                            else
                              "identifier_#{id_type}_tsim"
                            end

--- a/app/models/concerns/curator/metastreams/workflowable.rb
+++ b/app/models/concerns/curator/metastreams/workflowable.rb
@@ -12,17 +12,18 @@ module Curator
         validates :workflow, presence: true
         validates_associated :workflow, on: :create
 
-        after_create_commit :set_workflow_publish
+        after_create_commit :begin_workflow
 
-        after_update_commit :set_workflow_complete
+        after_update_commit :complete_workflow
 
         private
 
-        def set_workflow_publish
+        def begin_workflow
           workflow.publish! if workflow.may_publish?
+          workflow.process_derivatives! if workflow.may_process_derivatives?
         end
 
-        def set_workflow_complete
+        def complete_workflow
           workflow.mark_complete! if workflow.may_mark_complete?
         end
       end

--- a/app/models/curator/descriptive_field_sets.rb
+++ b/app/models/curator/descriptive_field_sets.rb
@@ -4,9 +4,13 @@ module Curator
   module DescriptiveFieldSets
     extend Curator::NamespaceAccessor
 
-    IDENTIFIER_TYPES = ['local-accession', 'local-other', 'local-call', 'local-barcode', 'internet-archive', 'isbn', 'ismn', 'isrc', 'issn', 'issue-number', 'lccn', 'matrix-number', 'music-plate', 'music-publisher', 'sici', 'uri', 'videorecording'].freeze
+    IDENTIFIER_TYPES = %w(local-accession local-other local-call local-barcode iiif-manifest internet-archive isbn ismn
+                          isrc issn issue-number lccn matrix-number music-plate music-publisher sici uri videorecording).freeze
 
-    NOTE_TYPES = ['date', 'language', 'acquisition', 'ownership', 'funding', 'biographical/historical', 'citation/reference', 'preferred citation', 'bibliography', 'exhibitions', 'publications', 'creation/production credits', 'performers', 'physical description', 'venue', 'arrangement', 'statement of responsibility'].freeze
+    NOTE_TYPES = ['date', 'language', 'acquisition', 'ownership', 'funding', 'biographical/historical',
+                  'citation/reference', 'preferred citation', 'bibliography', 'exhibitions', 'publications',
+                  'creation/production credits', 'performers', 'physical description', 'venue', 'arrangement',
+                  'statement of responsibility'].freeze
 
     LOCAL_ORIGINAL_IDENTIFIER_TYPES = {
       'internet-archive' => 'Barcode',

--- a/app/services/curator/collection_factory_service.rb
+++ b/app/services/curator/collection_factory_service.rb
@@ -18,7 +18,7 @@ module Curator
             [:ingest_origin].each do |attr|
               workflow.send("#{attr}=", @workflow_json_attrs.fetch(attr, ENV['HOME'].to_s))
             end
-            [:processing_state, :publishing_state].each do |attr|
+            [:publishing_state].each do |attr|
               workflow.send("#{attr}=", @workflow_json_attrs.fetch(attr)) if @workflow_json_attrs.fetch(attr, nil).present?
             end
           end

--- a/app/services/curator/filestreams/file_set_factory_service.rb
+++ b/app/services/curator/filestreams/file_set_factory_service.rb
@@ -26,10 +26,7 @@ module Curator
           build_workflow(file_set) do |workflow|
             workflow.send('ingest_origin=', @workflow_json_attrs.fetch(:ingest_origin, ENV['HOME'].to_s))
             processing_state = @workflow_json_attrs.fetch(:processing_state, nil)
-            publishing_state = obj&.workflow&.publishing_state
-            # set publishing state to same value as parent DigitalObject
             workflow.send('processing_state=', processing_state) if processing_state
-            workflow.send('publishing_state=', publishing_state) if publishing_state
           end
 
           # TODO: set access_edit_group permissions

--- a/app/services/curator/institution_factory_service.rb
+++ b/app/services/curator/institution_factory_service.rb
@@ -21,9 +21,7 @@ module Curator
           build_workflow(institution) do |workflow|
             workflow.ingest_origin = @workflow_json_attrs.fetch(:ingest_origin, ENV['HOME'].to_s)
             publishing_state = @workflow_json_attrs.fetch(:publishing_state, nil)
-            processing_state = @workflow_json_attrs.fetch(:processing_state, nil)
             workflow.publishing_state = publishing_state if publishing_state
-            workflow.processing_state = processing_state if processing_state
           end
 
           build_administrative(institution) do |administrative|

--- a/db/migrate/20190919202305_create_curator_metastreams_workflows.rb
+++ b/db/migrate/20190919202305_create_curator_metastreams_workflows.rb
@@ -9,8 +9,8 @@ class CreateCuratorMetastreamsWorkflows < ActiveRecord::Migration[5.2]
 
         create_table :curator_metastreams_workflows do |t|
           t.belongs_to :workflowable, polymorphic: true, index: { unique: true, using: :btree, name: 'unique_idx_meta_workflows_on_metastreamable_poly' }, null: false
-          t.enum :publishing_state, enum_name: :metastreams_workflow_publishing_state, index: { using: :btree, name: 'idx_meta_workflow_on_publsihing_state' }, default: 'draft'
-          t.enum :processing_state, enum_name: :metastreams_workflow_processing_state, index: { using: :btree, name: 'idx_meta_workflow_on_processing_state' }, default: 'initialized'
+          t.enum :publishing_state, enum_name: :metastreams_workflow_publishing_state, index: { using: :btree, name: 'idx_meta_workflow_on_publsihing_state' }, null: true
+          t.enum :processing_state, enum_name: :metastreams_workflow_processing_state, index: { using: :btree, name: 'idx_meta_workflow_on_processing_state' }, null: true
           t.string :ingest_origin, null: false
           t.integer :lock_version
           t.timestamps null: false

--- a/spec/controllers/curator/shared/shared_formats_and_actions.rb
+++ b/spec/controllers/curator/shared/shared_formats_and_actions.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'shared_get', type: :controller do |include_ark_context: f
 
     describe "#show", if: has_member_methods do
       context 'with :id' do
-        it "returns a sucessful response" do
+        it "returns a successful response" do
           id_params = params.dup
           id_params[:id] ||= resource.to_param
 

--- a/spec/factories/curator/collections.rb
+++ b/spec/factories/curator/collections.rb
@@ -13,8 +13,13 @@ FactoryBot.define do
       workflow { nil }
 
       after :build do |collection|
-        collection.administrative = build(:curator_metastreams_administrative, administratable: collection) if collection.administrative.blank?
-        collection.workflow = build(:curator_metastreams_workflow, workflowable: collection) if collection.workflow.blank?
+        collection.administrative = build(:curator_metastreams_administrative,
+                                          :for_collection,
+                                          administratable: collection) if collection.administrative.blank?
+
+        collection.workflow = build(:curator_metastreams_workflow,
+                                    :for_collection,
+                                    workflowable: collection) if collection.workflow.blank?
       end
     end
   end

--- a/spec/factories/curator/digital_objects.rb
+++ b/spec/factories/curator/digital_objects.rb
@@ -20,9 +20,18 @@ FactoryBot.define do
       workflow { nil }
 
       after :build do |digital_object, options|
-        digital_object.administrative = build(:curator_metastreams_administrative, administratable: digital_object) if digital_object.administrative.blank?
-        digital_object.descriptive = build(:curator_metastreams_descriptive, :with_all_desc_terms, desc_term_count: options.desc_term_count, digital_object: digital_object) if digital_object.descriptive.blank?
-        digital_object.workflow = build(:curator_metastreams_workflow, workflowable: digital_object) if digital_object.workflow.blank?
+        digital_object.administrative = build(:curator_metastreams_administrative,
+                                              :for_object,
+                                              administratable: digital_object) if digital_object.administrative.blank?
+
+        digital_object.descriptive = build(:curator_metastreams_descriptive,
+                                           :with_all_desc_terms,
+                                           desc_term_count: options.desc_term_count,
+                                           digital_object: digital_object) if digital_object.descriptive.blank?
+
+        digital_object.workflow = build(:curator_metastreams_workflow,
+                                        :for_digital_object,
+                                        workflowable: digital_object) if digital_object.workflow.blank?
       end
     end
   end

--- a/spec/factories/curator/filestreams/file_set.rb
+++ b/spec/factories/curator/filestreams/file_set.rb
@@ -14,8 +14,13 @@ FactoryBot.define do
       workflow { nil }
 
       after :build do |file_set|
-        file_set.administrative = build(:curator_metastreams_administrative, administratable: file_set) if file_set.administrative.blank?
-        file_set.workflow = build(:curator_metastreams_workflow, workflowable: file_set) if file_set.workflow.blank?
+        file_set.administrative = build(:curator_metastreams_administrative,
+                                        :for_file_set,
+                                        administratable: file_set) if file_set.administrative.blank?
+
+        file_set.workflow = build(:curator_metastreams_workflow,
+                                  :for_file_set,
+                                  workflowable: file_set) if file_set.workflow.blank?
       end
     end
   end

--- a/spec/factories/curator/institutions.rb
+++ b/spec/factories/curator/institutions.rb
@@ -24,8 +24,13 @@ FactoryBot.define do
       workflow { nil }
 
       after :build do |institution|
-        institution.administrative = build(:curator_metastreams_administrative, administratable: institution) if institution.administrative.blank?
-        institution.workflow = build(:curator_metastreams_workflow, workflowable: institution) if institution.workflow.blank?
+        institution.administrative = build(:curator_metastreams_administrative,
+                                           :for_institution,
+                                           administratable: institution) if institution.administrative.blank?
+
+        institution.workflow = build(:curator_metastreams_workflow,
+                                     :for_institution,
+                                     workflowable: institution) if institution.workflow.blank?
       end
     end
 

--- a/spec/factories/curator/metastreams/workflows.rb
+++ b/spec/factories/curator/metastreams/workflows.rb
@@ -6,24 +6,33 @@ FactoryBot.define do
     ingest_origin { Faker::Internet.uuid }
 
     trait :for_institution do
+      publishing_state { 'draft' }
+
       after :build do |workflow|
         workflow.workflowable = build(:curator_institution, workflow: workflow) if workflow.workflowable.blank?
       end
     end
 
     trait :for_collection do
+      publishing_state { 'draft' }
+
       after :build do |workflow|
         workflow.workflowable = build(:curator_collection, workflow: workflow) if workflow.workflowable.blank?
       end
     end
 
     trait :for_digital_object do
+      publishing_state { 'draft' }
+      processing_state { 'initialized' }
+
       after :build do |workflow|
         workflow.workflowable = build(:curator_digital_object, workflow: workflow) if workflow.workflowable.blank?
       end
     end
 
     trait :for_file_set do
+      processing_state { 'initialized' }
+
       transient do
         file_type { Curator.filestreams.file_set_types.map { |type| "curator_filestreams_#{type}".to_sym }.sample }
       end

--- a/spec/fixtures/files/collection_2.json
+++ b/spec/fixtures/files/collection_2.json
@@ -23,8 +23,7 @@
         ]
       },
       "workflow": {
-        "publishing_state": "published",
-        "processing_state": "complete"
+        "publishing_state": "published"
       }
     }
   }

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -4,15 +4,15 @@
     "created_at": "2019-05-20T14:46:08.240Z",
     "updated_at": "2019-05-20T14:51:03.796Z",
     "admin_set": {
-      "ark_id": "commonwealth:987654321"
+      "ark_id": "bpl-dev:987654321"
     },
     "is_member_of_collection": [
       {
-        "ark_id": "commonwealth:987654321"
+        "ark_id": "bpl-dev:987654321"
       }
     ],
     "contained_by": {
-      "ark_id": "commonwealth:zyxwvutsr"
+      "ark_id": "bpl-dev:zyxwvutsr"
     },
     "metastreams": {
       "descriptive": {
@@ -306,7 +306,7 @@
         "harvestable": true,
         "access_edit_group": [
           "superuser",
-          "admin[commonwealth:ijkl54321]"
+          "admin[bpl-dev:ijkl54321]"
         ]
       },
       "workflow": {

--- a/spec/fixtures/files/digital_object_2.json
+++ b/spec/fixtures/files/digital_object_2.json
@@ -4,12 +4,12 @@
     "created_at": "2016-07-29T18:51:41.603Z",
     "updated_at": "2018-04-05T20:00:06.553Z",
     "admin_set": {
-      "ark_id": "commonwealth:198765432",
+      "ark_id": "bpl-dev:198765432",
       "name": "Norman B. Leventhal Map Center Collection"
     },
     "is_member_of_collection": [
       {
-        "ark_id": "commonwealth:198765432",
+        "ark_id": "bpl-dev:198765432",
         "name": "Norman B. Leventhal Map Center Collection"
       }
     ],

--- a/spec/fixtures/files/image_file_set_2.json
+++ b/spec/fixtures/files/image_file_set_2.json
@@ -1,7 +1,7 @@
 {
   "file_set": {
     "file_set_of": {
-      "ark_id": "commonwealth:abcdefghi"
+      "ark_id": "bpl-dev:abcdefghi"
     },
     "position": 0,
     "file_set_type": "image",
@@ -15,7 +15,7 @@
       "administrative": {
         "access_edit_group": [
           "superuser",
-          "admin[commonwealth:ijkl54321]"
+          "admin[bpl-dev:ijkl54321]"
         ]
       },
       "workflow": {

--- a/spec/fixtures/files/institution.json
+++ b/spec/fixtures/files/institution.json
@@ -1,6 +1,6 @@
 {
   "institution": {
-    "ark_id": "commonwealth:123456789",
+    "ark_id": "bpl-dev:123456789",
     "created_at": "2019-05-20T14:46:08.240Z",
     "updated_at": "2019-05-20T14:51:03.796Z",
     "name": "Boston Public Library",
@@ -20,7 +20,7 @@
         ],
         "access_edit_group": [
           "superuser",
-          "admin[commonwealth:abcd12345]"
+          "admin[bpl-dev:abcd12345]"
         ]
       },
       "workflow": {

--- a/spec/indexers/concerns/curator/indexer/workflow_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/workflow_indexer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Curator::Indexer::WorkflowIndexer do
     end
 
     it 'sets the processing_state field' do
-      expect(indexed['processing_state_ssi']).to eq [workflow.processing_state]
+      expect(indexed['processing_state_ssi']).to eq workflow.processing_state
     end
   end
 end

--- a/spec/models/curator/metastreams/workflow_spec.rb
+++ b/spec/models/curator/metastreams/workflow_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Curator::Metastreams::Workflow, type: :model do
 
     it { is_expected.to have_db_column(:publishing_state).
                         of_type(:enum).
-                        with_options(default: 'draft') }
+                        with_options(null: true) }
 
     it { is_expected.to have_db_column(:processing_state).
                         of_type(:enum).
-                        with_options(default: 'initialized') }
+                        with_options(null: true) }
 
     it { is_expected.to have_db_column(:ingest_origin).
                         of_type(:string).

--- a/spec/models/curator/shared/metastreamable.rb
+++ b/spec/models/curator/shared/metastreamable.rb
@@ -54,39 +54,20 @@ RSpec.shared_examples 'workflowable', type: :model do
   end
 
   describe 'Callbacks' do
-    let(:expected_publishing_state) do
-      case described_class.name
-      when *Curator::Metastreams::Workflow::PUBLISHABLE_CLASSES
-        'published'
-      else
-        'draft'
-      end
-    end
-
-    let(:expected_processing_state) do
-      described_class_name = described_class <= Curator::Filestreams::FileSet ? 'Curator::Filestreams::FileSet' : described_class.name
-      case described_class_name
-      when *Curator::Metastreams::Workflow::PROCESSABLE_CLASSES
-        'derivatives'
-      else
-        'initialized'
-      end
-    end
     describe '.after_create_commit' do
       subject { build(factory_key_for(described_class)) }
 
-      it 'runs #set_workflow_publish callback on :create' do
+      it 'runs #begin_workflow callback on :create' do
+        expect(subject).to receive(:begin_workflow).at_least(:once)
         subject.save
-        expect(subject.workflow.publishing_state).to eq(expected_publishing_state)
-        expect(subject.workflow.processing_state).to eq(expected_processing_state)
       end
     end
 
     describe '.after_update_commit' do
       subject { create(factory_key_for(described_class)) }
 
-      it 'runs #set_workflow_complete callback on :update' do
-        expect(subject).to receive(:set_workflow_complete).at_least(:once)
+      it 'runs #complete_workflow callback on :update' do
+        expect(subject).to receive(:complete_workflow).at_least(:once)
         subject.save
       end
     end

--- a/spec/services/curator/filestreams/file_set_factory_service_spec.rb
+++ b/spec/services/curator/filestreams/file_set_factory_service_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Curator::Filestreams::FileSetFactoryService, type: :service do
     @file_set_json['file_set_of']['ark_id'] = parent_obj.ark_id
     @file_set_json['exemplary_image_of'][0]['ark_id'] = parent_obj.ark_id
     @file_set_json['exemplary_image_of'][1]['ark_id'] = parent_col.ark_id
-    @file_set_json['metastreams']['workflow']['publishing_state'] = parent_obj.workflow.publishing_state
     @files_json[0]['metadata']['ingest_filepath'] = file_fixture('image_thumbnail_300.jpg').to_s
     @file_set_json['files'] = @files_json
     expect do

--- a/spec/services/curator/shared/factory_service_metastreams_shared.rb
+++ b/spec/services/curator/shared/factory_service_metastreams_shared.rb
@@ -10,8 +10,8 @@ RSpec.shared_examples 'factory_workflowable', type: :service do
     end
 
     it 'sets the correct workflow metadata' do
-      expect(workflow.processing_state).to eq workflow_json.fetch('processing_state', 'initialized')
-      expect(workflow.publishing_state).to eq workflow_json.fetch('publishing_state', 'published')
+      expect(workflow.processing_state).to eq workflow_json.fetch('processing_state', nil)
+      expect(workflow.publishing_state).to eq workflow_json.fetch('publishing_state', nil)
       expect(workflow.ingest_origin).to eq workflow_json['ingest_origin']
     end
   end


### PR DESCRIPTION
This PR provides functionality to set various `Metastreams::Workflow` properties (`:processing_state`, `:publishing_state`) to `nil` when they are not applicable to the `workflowable` class. (Fixes #110.)

Essentially:
* allow `nil` for those properties in db/ActiveRecord
* set `processing_state` to `nil` if the class does not belong to `Workflow::PROCESSABLE_CLASSES`
* set `publishing_state` to `nil` if the class does not belong to `Workflow::PUBLISHABLE_CLASSES`
* uncouple the `publish` event from the `process_derivatives` event where AASM  is concerned

This PR also includes a bonus fix for #125 (add iiif-manifest to IDENTIFIER_TYPES).
