### PR TITLE
import from Fedora/Bplmodels

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -745,6 +745,8 @@ RSpec/MultipleExpectations:
   Exclude:
     - 'spec/lib/curator/parsers/edtf_date_parser_spec.rb'
     - 'spec/services/curator/digital_object_factory_service_spec.rb'
+    - 'spec/indexers/concerns/curator/indexer/attachment_indexer_spec.rb'
+    - 'spec/services/curator/shared/attachable.rb'
 
 RSpec/OverwritingSetup:
   Enabled: true

--- a/app/controllers/curator/filestreams/file_sets_controller.rb
+++ b/app/controllers/curator/filestreams/file_sets_controller.rb
@@ -41,12 +41,16 @@ module Curator
                                           exemplary_image_of: [:ark_id],
                                           pagination: [:page_label, :page_type, :hand_side],
                                           metastreams: {
-                                            administrative: [:description_standard, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
+                                            administrative: [:description_standard, :hosting_status, :harvestable,
+                                                             :flagged, destination_site: [], access_edit_group: []],
                                              workflow: [:ingest_origin, :publishing_state, :processing_state]
                                           },
-                                          files: [:key, :created_at, :file_name, :file_type, :content_type, :byte_size, :checksum, io: {}, metadata: {}])
+                                         files: [:key, :created_at, :file_name, :file_type, :content_type, :byte_size,
+                                                  :checksum_md5, io: {}, metadata: {}])
       when 'update'
-        params.require(:file_set).permit(:position, pagination: [:page_label, :page_type, :hand_side], exemplary_image_of: [:ark_id, :_destroy], files: [:key, :file_name, :file_type, :content_type, :byte_size, :checksum, io: {}, metadata: {}])
+        params.require(:file_set).permit(:position, pagination: [:page_label, :page_type, :hand_side],
+                                         exemplary_image_of: [:ark_id, :_destroy],
+                                         files: [:key, :file_name, :file_type, :content_type, :byte_size, :checksum_md5, io: {}, metadata: {}])
       else
         params
       end

--- a/app/controllers/curator/filestreams/file_sets_controller.rb
+++ b/app/controllers/curator/filestreams/file_sets_controller.rb
@@ -46,7 +46,7 @@ module Curator
                                              workflow: [:ingest_origin, :publishing_state, :processing_state]
                                           },
                                          files: [:key, :created_at, :file_name, :file_type, :content_type, :byte_size,
-                                                  :checksum_md5, io: {}, metadata: {}])
+                                                 :checksum_md5, io: {}, metadata: {}])
       when 'update'
         params.require(:file_set).permit(:position, pagination: [:page_label, :page_type, :hand_side],
                                          exemplary_image_of: [:ark_id, :_destroy],

--- a/app/controllers/curator/institutions_controller.rb
+++ b/app/controllers/curator/institutions_controller.rb
@@ -41,17 +41,17 @@ module Curator
       when 'create'
         params.require(:institution).permit(
                     :ark_id, :created_at, :updated_at, :name, :abstract, :url,
-                    files: [:created_at, :file_name, :file_type, :content_type, :byte_size, :checksum, io: {}, metadata: {}],
+                    files: [:created_at, :file_name, :file_type, :content_type, :byte_size,
+                            :checksum_md5, io: [:fedora_content_location], metadata: {}],
                     location: {},
                     metastreams: {
                       administrative: [:description_standard, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
-                                    workflow: [:ingest_origin, :publishing_state, :processing_state]
+                      workflow: [:ingest_origin, :publishing_state, :processing_state]
                     }
                   )
       when 'update'
-        params.require(:institution).permit(:abstract, :url, location: {},
-                                            host_collections_attributes: [:id, :name, :_destroy],
-                                            files: [:file_name, :file_type, :content_type, :byte_size, :checksum, io: {}, metadata: {}])
+        params.require(:institution).permit(:abstract, :url, location: {}, host_collections_attributes: [:id, :name, :_destroy],
+                                            files: [:file_name, :file_type, :content_type, :byte_size, :checksum_md5, io: {}, metadata: {}])
       else
         params
       end

--- a/app/indexers/concerns/curator/indexer/attachment_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/attachment_indexer.rb
@@ -6,7 +6,7 @@ module Curator
     module AttachmentIndexer
       extend ActiveSupport::Concern
 
-      ATTACHMENT_FIELDS = %i(byte_size content_type checksum).freeze
+      ATTACHMENT_FIELDS = %i(byte_size content_type checksum key).freeze
       HAS_ONE_ATTACHMENT_TYPES = %i(audio_access audio_primary document_access document_primary
                                     ebook_access_epub ebook_access_mobi ebook_access_daisy
                                     image_access_800 image_georectified_primary image_primary image_negative_master
@@ -47,6 +47,7 @@ module Curator
             #   attachments[attachment_type] = attachments_arr
             # end
             context.output_hash['attachments_ss'] = attachments.present? ? attachments.to_json : nil
+            to_field 'exemplary_image_key_ss', obj_extract('image_thumbnail_300_attachment', 'key')
           end
         end
       end

--- a/app/indexers/concerns/curator/indexer/attachment_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/attachment_indexer.rb
@@ -6,7 +6,7 @@ module Curator
     module AttachmentIndexer
       extend ActiveSupport::Concern
 
-      ATTACHMENT_FIELDS = %i(byte_size content_type checksum key).freeze
+      ATTACHMENT_FIELDS = %i(byte_size content_type checksum key service_name).freeze
       HAS_ONE_ATTACHMENT_TYPES = %i(audio_access audio_primary document_access document_primary
                                     ebook_access_epub ebook_access_mobi ebook_access_daisy
                                     image_access_800 image_georectified_primary image_primary image_negative_master
@@ -46,8 +46,11 @@ module Curator
             #   end
             #   attachments[attachment_type] = attachments_arr
             # end
-            context.output_hash['attachments_ss'] = attachments.present? ? attachments.to_json : nil
-            to_field 'exemplary_image_key_ss', obj_extract('image_thumbnail_300_attachment', 'key')
+            next unless attachments.present?
+
+            context.output_hash['attachments_ss'] = attachments.to_json
+            key_base = attachments[attachments.keys.first][:key].gsub(/\/[^\/]*\z/, '')
+            context.output_hash['storage_key_base_ss'] = key_base
           end
         end
       end

--- a/app/indexers/concerns/curator/indexer/attachment_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/attachment_indexer.rb
@@ -46,7 +46,7 @@ module Curator
             #   end
             #   attachments[attachment_type] = attachments_arr
             # end
-            next unless attachments.present?
+            next if attachments.blank?
 
             context.output_hash['attachments_ss'] = attachments.to_json
             key_base = attachments[attachments.keys.first][:key].gsub(/\/[^\/]*\z/, '')

--- a/app/indexers/concerns/curator/indexer/exemplary_image_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/exemplary_image_indexer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Curator
+  class Indexer < Traject::Indexer
+    module ExemplaryImageIndexer
+      extend ActiveSupport::Concern
+      included do
+        configure do
+          each_record do |record, context|
+            exemplary = if record.is_a?(Curator::Institution)
+                          record
+                        else
+                          record.exemplary_file_set
+                        end
+            next if exemplary.blank?
+
+            context.output_hash['exemplary_image_ssi'] = exemplary.ark_id
+            key_base = exemplary&.image_thumbnail_300&.key&.gsub(/\/[^\/]*\z/, '')
+            context.output_hash['exemplary_image_key_base_ss'] = key_base
+
+            next unless exemplary.respond_to?(:file_set_type)
+
+            context.output_hash['exemplary_image_iiif_bsi'] = false unless exemplary.file_set_type == 'Curator::Filestreams::Image'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -4,6 +4,7 @@ module Curator
   class CollectionIndexer < Curator::Indexer
     include Curator::Indexer::WorkflowIndexer
     include Curator::Indexer::AdministrativeIndexer
+    include Curator::Indexer::ExemplaryImageIndexer
 
     # TODO: add indexing for: edit_access_group_ssim
     configure do
@@ -15,13 +16,6 @@ module Curator
       to_field %w(physical_location_ssim physical_location_tim institution_name_ssi institution_name_ti),
                obj_extract('institution', 'name')
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
-
-      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
-      to_field 'exemplary_image_key_ss', obj_extract('exemplary_file_set', 'image_thumbnail_300_attachment', 'key')
-      to_field 'exemplary_image_iiif_bsi' do |record, accumulator|
-        exemplary_file_set_type = record.exemplary_file_set&.file_set_type
-        accumulator << false unless exemplary_file_set_type == 'Curator::Filestreams::Image'
-      end
       to_field %w(genre_basic_ssim genre_basic_tim) do |record, accumulator|
         accumulator << 'Collections'
         # iterate over child DigitalObject and get genre values

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -17,6 +17,7 @@ module Curator
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
 
       to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
+      to_field 'exemplary_image_key_ss', obj_extract('exemplary_file_set', 'image_thumbnail_300_attachment', 'key')
       to_field 'exemplary_image_iiif_bsi' do |record, accumulator|
         exemplary_file_set_type = record.exemplary_file_set&.file_set_type
         accumulator << false unless exemplary_file_set_type == 'Curator::Filestreams::Image'

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -19,10 +19,14 @@ module Curator
         accumulator.concat record.is_member_of_collection.pluck(:ark_id)
       end
       to_field 'contained_by_ssi', obj_extract('contained_by', 'ark_id')
-      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
-      to_field 'exemplary_image_key_ss', obj_extract('exemplary_file_set', 'image_thumbnail_300_attachment', 'key')
       to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_sets.pluck(:file_name_base).uniq }
+      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
       each_record do |record, context|
+        if record.exemplary_file_set.present?
+          key_base = record.exemplary_file_set&.image_thumbnail_300&.key&.gsub(/\/[^\/]*\z/, '')
+          context.output_hash['exemplary_image_key_base_ss'] = key_base
+        end
+
         if record.image_file_sets.present?
           has_searchable_pages, georeferenced = false, false
           record.image_file_sets.each do |image_file_set|

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -5,6 +5,7 @@ module Curator
     include Curator::Indexer::DescriptiveIndexer
     include Curator::Indexer::WorkflowIndexer
     include Curator::Indexer::AdministrativeIndexer
+    include Curator::Indexer::ExemplaryImageIndexer
 
     # TODO: add indexing for: contained_by_ark_id_ssi edit_access_group_ssim
     configure do
@@ -20,13 +21,7 @@ module Curator
       end
       to_field 'contained_by_ssi', obj_extract('contained_by', 'ark_id')
       to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_sets.pluck(:file_name_base).uniq }
-      to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
       each_record do |record, context|
-        if record.exemplary_file_set.present?
-          key_base = record.exemplary_file_set&.image_thumbnail_300&.key&.gsub(/\/[^\/]*\z/, '')
-          context.output_hash['exemplary_image_key_base_ss'] = key_base
-        end
-
         if record.image_file_sets.present?
           has_searchable_pages, georeferenced = false, false
           record.image_file_sets.each do |image_file_set|

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -20,6 +20,7 @@ module Curator
       end
       to_field 'contained_by_ssi', obj_extract('contained_by', 'ark_id')
       to_field 'exemplary_image_ssi', obj_extract('exemplary_file_set', 'ark_id')
+      to_field 'exemplary_image_key_ss', obj_extract('exemplary_file_set', 'image_thumbnail_300_attachment', 'key')
       to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_sets.pluck(:file_name_base).uniq }
       each_record do |record, context|
         if record.image_file_sets.present?

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -5,6 +5,7 @@ module Curator
     include Curator::Indexer::WorkflowIndexer
     include Curator::Indexer::AdministrativeIndexer
     include Curator::Indexer::GeographicIndexer
+    include Curator::Indexer::ExemplaryImageIndexer
 
     # TODO: add indexing for: edit_access_group_ssim
     configure do
@@ -15,7 +16,6 @@ module Curator
       to_field 'abstract_tsi', obj_extract('abstract')
       to_field 'institution_url_ss', obj_extract('url')
       to_field %w(genre_basic_ssim genre_basic_tsim), obj_extract('class', 'name', 'demodulize')
-      to_field 'exemplary_image_key_ss', obj_extract('image_thumbnail_300_attachment', 'key')
     end
   end
 end

--- a/app/indexers/curator/institution_indexer.rb
+++ b/app/indexers/curator/institution_indexer.rb
@@ -15,6 +15,7 @@ module Curator
       to_field 'abstract_tsi', obj_extract('abstract')
       to_field 'institution_url_ss', obj_extract('url')
       to_field %w(genre_basic_ssim genre_basic_tsim), obj_extract('class', 'name', 'demodulize')
+      to_field 'exemplary_image_key_ss', obj_extract('image_thumbnail_300_attachment', 'key')
     end
   end
 end

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -47,7 +47,7 @@ module Curator
     validates :file_name_base, presence: true
     validates :file_set_type, presence: true, inclusion: { in: Filestreams.file_set_types.collect { |type| "Curator::Filestreams::#{type}" } }
 
-    after_commit :reindex_digital_objects
+    after_commit :reindex_digital_objects, :reindex_collections
 
     def ark_params
       super.merge({
@@ -93,6 +93,10 @@ module Curator
 
     def reindex_digital_objects
       file_set_members_of.find_each { |digital_object| digital_object.update_index }
+    end
+
+    def reindex_collections
+      exemplary_image_of_collections.find_each { |collection| collection.update_index }
     end
   end
 end

--- a/app/services/concerns/curator/metastreams/descriptive_field_set_attrs.rb
+++ b/app/services/concerns/curator/metastreams/descriptive_field_set_attrs.rb
@@ -97,7 +97,7 @@ module Curator
       end
 
       def rights_statement(json_attrs = {})
-        rights_statement_term_data = json_attrs.fetch(:rights_statement)
+        rights_statement_term_data = json_attrs.fetch(:rights_statement, {})
         find_or_create_nomenclature(
           nomenclature_class: Curator.controlled_terms.rights_statement_class,
           term_data: rights_statement_term_data

--- a/app/services/curator/collection_factory_service.rb
+++ b/app/services/curator/collection_factory_service.rb
@@ -24,7 +24,7 @@ module Curator
           end
 
           build_administrative(collection) do |administrative|
-            [:description_standard, :flagged, :destination_site, :harvestable].each do |attr|
+            [:description_standard, :flagged, :destination_site, :harvestable, :hosting_status].each do |attr|
               administrative.send("#{attr}=", @admin_json_attrs.fetch(attr)) if @admin_json_attrs.fetch(attr, nil).present?
             end
           end

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -292,7 +292,7 @@
         "rights": "Copyright (c) Leslie Jones.",
         "license": {
             "label": "This work is licensed for use under a Creative Commons Attribution Non-Commercial No Derivatives License (CC BY-NC-ND).",
-            "uri": "https://creativecommons.org/licenses/by-nc-nd/4.0"
+            "uri": "https://creativecommons.org/licenses/by-nc-nd/4.0/"
         },
         "rights_statement": {
           "label": "In Copyright",

--- a/spec/fixtures/files/image_file.json
+++ b/spec/fixtures/files/image_file.json
@@ -1,7 +1,7 @@
 {
   "files": [{
     "file_name": "image_thumbnail_300.jpg",
-    "file_type": "ImageThumbnail300",
+    "file_type": "image_thumbnail_300",
     "content_type": "image/jpeg",
     "byte_size": 8977,
     "checksum_md5": "466561a5c5080652b707bc44b4ea598c",

--- a/spec/fixtures/files/image_file.json
+++ b/spec/fixtures/files/image_file.json
@@ -4,7 +4,7 @@
     "file_type": "ImageThumbnail300",
     "content_type": "image/jpeg",
     "byte_size": 8977,
-    "checksum": "466561a5c5080652b707bc44b4ea598c",
+    "checksum_md5": "466561a5c5080652b707bc44b4ea598c",
     "metadata": {
       "ingest_filepath": "curator/spec/fixtures/files/image_thumbnail_300.jpg"
     }

--- a/spec/fixtures/files/image_file_2.json
+++ b/spec/fixtures/files/image_file_2.json
@@ -1,7 +1,7 @@
 {
   "files": [{
     "file_name": "image_primary.tiff",
-    "file_type": "ImagePrimary",
+    "file_type": "image_primary",
     "content_type": "image/tiff",
     "metadata": {
       "ingest_filepath": "curator/spec/fixtures/files/image_primary.tiff"

--- a/spec/fixtures/files/image_file_3.json
+++ b/spec/fixtures/files/image_file_3.json
@@ -1,7 +1,7 @@
 {
   "files": [{
     "file_name": "image_thumbnail_300_2.jpg",
-    "file_type": "ImageThumbnail300",
+    "file_type": "image_thumbnail_300",
     "content_type": "image/jpeg",
     "byte_size": 38676,
     "checksum_md5": "5c0d4a83fbf0154f09491909f9840028",

--- a/spec/fixtures/files/image_file_3.json
+++ b/spec/fixtures/files/image_file_3.json
@@ -4,7 +4,7 @@
     "file_type": "ImageThumbnail300",
     "content_type": "image/jpeg",
     "byte_size": 38676,
-    "checksum": "5c0d4a83fbf0154f09491909f9840028",
+    "checksum_md5": "5c0d4a83fbf0154f09491909f9840028",
     "metadata": {
       "ingest_filepath": "curator/spec/fixtures/files/image_thumbnail_300_2.jpg"
     }

--- a/spec/fixtures/files/institution_with_thumbnail.json
+++ b/spec/fixtures/files/institution_with_thumbnail.json
@@ -30,7 +30,7 @@
     "files": [
       {
         "file_name": "image_thumbnail_300_institution.png",
-        "file_type": "ImageThumbnail300",
+        "file_type": "image_thumbnail_300",
         "content_type": "image/png",
         "byte_size": 11475,
         "checksum_md5": "3ea351df3cb8b0ca4c5361727e191d0b",

--- a/spec/fixtures/files/institution_with_thumbnail.json
+++ b/spec/fixtures/files/institution_with_thumbnail.json
@@ -33,7 +33,7 @@
         "file_type": "ImageThumbnail300",
         "content_type": "image/png",
         "byte_size": 11475,
-        "checksum": "3ea351df3cb8b0ca4c5361727e191d0b",
+        "checksum_md5": "3ea351df3cb8b0ca4c5361727e191d0b",
         "metadata": {
           "ingest_filepath": "curator/spec/fixtures/files/image_thumbnail_300_institution.png"
         }

--- a/spec/fixtures/files/text_file.json
+++ b/spec/fixtures/files/text_file.json
@@ -4,7 +4,7 @@
     "file_type": "TextPlain",
     "content_type": "text/plain",
     "byte_size": 1125,
-    "checksum": "db1a04a8c807c363814ed99f1364efb2",
+    "checksum_md5": "db1a04a8c807c363814ed99f1364efb2",
     "metadata": {
       "ingest_filepath": "curator/spec/fixtures/files/text_plain.txt"
     }

--- a/spec/fixtures/files/text_file.json
+++ b/spec/fixtures/files/text_file.json
@@ -1,7 +1,7 @@
 {
   "files": [{
     "file_name": "text_plain.txt",
-    "file_type": "TextPlain",
+    "file_type": "text_plain",
     "content_type": "text/plain",
     "byte_size": 1125,
     "checksum_md5": "db1a04a8c807c363814ed99f1364efb2",

--- a/spec/indexers/concerns/curator/indexer/attachment_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/attachment_indexer_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe Curator::Indexer::AttachmentIndexer, type: :indexer do
       expect(field_value['text_plain']['content_type']).to eq 'text/plain'
       expect(field_value['text_plain']['filename']).to eq 'text_plain.txt'
       expect(field_value['text_plain']['checksum']).to be_an_instance_of(String)
+      expect(field_value['text_plain']['service_name']).to eq 'derivatives'
+      expect(field_value['text_plain']['key']).to be_an_instance_of(String)
     end
   end
 end

--- a/spec/indexers/concerns/curator/indexer/exemplary_image_indexer_spec.rb
+++ b/spec/indexers/concerns/curator/indexer/exemplary_image_indexer_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Curator::Indexer::ExemplaryImageIndexer, type: :indexer do
+  describe 'indexing' do
+    let(:indexer_test_class) do
+      Class.new(Curator::Indexer) do
+        include Curator::Indexer::ExemplaryImageIndexer
+      end
+    end
+    let(:file_set) do
+      fs = create(:curator_filestreams_image)
+      attach_thumbnail_file(fs)
+      fs
+    end
+    let!(:digital_object) do
+      digital_obj = create(:curator_digital_object)
+      create(:curator_mappings_exemplary_image, exemplary_object: digital_obj, exemplary_file_set: file_set)
+      digital_obj
+    end
+    let(:indexer) { indexer_test_class.new }
+    let(:indexed) { indexer.map_record(digital_object) }
+
+    it 'sets the exemplary_image field' do
+      expect(indexed['exemplary_image_ssi']).to include(file_set.ark_id)
+    end
+
+    it 'sets the exemplary_image_key_base field' do
+      expect(indexed['exemplary_image_key_base_ss']).to be_an_instance_of(String)
+    end
+  end
+end

--- a/spec/indexers/curator/collection_indexer_spec.rb
+++ b/spec/indexers/curator/collection_indexer_spec.rb
@@ -2,41 +2,28 @@
 
 require 'rails_helper'
 RSpec.describe Curator::CollectionIndexer do
-  # set exemplary mapping here, relationship not created by factory
-  before(:all) do
-    @collection = create(:curator_collection)
-    exemplary_file_set = create(:curator_filestreams_image)
-    exemplary_mapping = Curator::Mappings::ExemplaryImage.new(exemplary_object: @collection,
-                                                              exemplary_file_set: exemplary_file_set)
-    exemplary_mapping.save!
-    @collection = @collection.reload
-  end
-
   describe 'indexing' do
+    let(:collection) { create(:curator_collection) }
     let(:indexer) { described_class.new }
-    let(:indexed) { indexer.map_record(@collection) }
+    let(:indexed) { indexer.map_record(collection) }
 
     it 'sets the title fields' do
-      expect(indexed['title_info_primary_tsi']).to eq [@collection.name]
+      expect(indexed['title_info_primary_tsi']).to eq [collection.name]
       expect(
         indexed['title_info_primary_ssort']
-      ).to eq [Curator::Parsers::InputParser.get_proper_title(@collection.name).last]
+      ).to eq [Curator::Parsers::InputParser.get_proper_title(collection.name).last]
     end
 
     it 'sets the abstract field' do
-      expect(indexed['abstract_tsi']).to eq [@collection.abstract]
+      expect(indexed['abstract_tsi']).to eq [collection.abstract]
     end
 
     it 'sets the physical location and institution fields' do
       pi_fields = %w(physical_location_ssim physical_location_tim institution_name_ssi institution_name_ti)
       pi_fields.each do |field|
-        expect(indexed[field]).to eq [@collection.institution.name]
+        expect(indexed[field]).to eq [collection.institution.name]
       end
-      expect(indexed['institution_ark_id_ssi']).to eq [@collection.institution.ark_id]
-    end
-
-    it 'sets the exemplary image field' do
-      expect(indexed['exemplary_image_ssi']).to eq [@collection.exemplary_file_set.ark_id]
+      expect(indexed['institution_ark_id_ssi']).to eq [collection.institution.ark_id]
     end
 
     it 'sets the genre fields' do

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -3,12 +3,7 @@
 require 'rails_helper'
 RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
   describe 'indexing' do
-    let!(:digital_object) do
-      digital_obj = create(:curator_digital_object, :with_contained_by)
-      create(:curator_mappings_exemplary_image, exemplary_object: digital_obj)
-      digital_obj
-    end
-
+    let!(:digital_object) { create(:curator_digital_object, :with_contained_by) }
     let(:indexer) { described_class.new }
     let(:indexed) { indexer.map_record(digital_object) }
     let(:collections) { digital_object.is_member_of_collection }
@@ -30,17 +25,6 @@ RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
         expect(indexed[field]).to eq collections.map { |c| c.name }
       end
       expect(indexed['collection_ark_id_ssim']).to eq collections.map { |c| c.ark_id }
-    end
-
-    describe 'exemplary image indexing' do
-      let(:file_set) { digital_object.exemplary_file_set }
-      before(:each) do
-        digital_object.reload
-      end
-
-      it 'sets the exemplary image field' do
-        expect(indexed['exemplary_image_ssi']).to include(file_set.ark_id)
-      end
     end
 
     describe 'contained by indexing' do

--- a/spec/services/curator/shared/attachable.rb
+++ b/spec/services/curator/shared/attachable.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples 'attachable', type: :service do
     subject { record.image_thumbnail_300_blob }
 
     it 'sets the file info correctly' do
-      expect(subject.key).to eq("#{record.class.name.demodulize.downcase.pluralize}/#{record.ark_id}/image_thumbnail_300.jpg")
+      expect(subject.key).to include("#{record.class.name.demodulize.downcase.pluralize}/#{record.ark_id}/image_thumbnail_300")
       expect(subject.filename.to_s).to eq(file_json['file_name'])
       expect(subject.metadata['ingest_filepath']).to eq(file_json['metadata']['ingest_filepath'])
       expect(subject.service_name).to eq('derivatives')

--- a/spec/services/curator/shared/attachable.rb
+++ b/spec/services/curator/shared/attachable.rb
@@ -7,10 +7,12 @@ RSpec.shared_examples 'attachable', type: :service do
     subject { record.image_thumbnail_300_blob }
 
     it 'sets the file info correctly' do
+      expect(subject.key).to eq("#{record.class.name.demodulize.downcase.pluralize}/#{record.ark_id}/image_thumbnail_300.jpg")
       expect(subject.filename.to_s).to eq(file_json['file_name'])
       expect(subject.metadata['ingest_filepath']).to eq(file_json['metadata']['ingest_filepath'])
+      expect(subject.service_name).to eq('derivatives')
       expect(subject.byte_size).to eq(file_json['byte_size'])
-      expect(subject.checksum).to eq(Base64.strict_encode64([file_json['checksum']].pack('H*')))
+      expect(subject.checksum).to eq(Base64.strict_encode64([file_json['checksum_md5']].pack('H*')))
     end
   end
 end

--- a/spec/support/file_attachment_helpers.rb
+++ b/spec/support/file_attachment_helpers.rb
@@ -14,6 +14,10 @@ module FileAttachmentHelpers
     attach_fixture_file(:image_georectified_primary, file_set, 'image_georectified_primary.tif')
   end
 
+  def attach_thumbnail_file(file_set)
+    attach_fixture_file(:image_thumbnail_300, file_set, 'image_thumbnail_300.jpg')
+  end
+
   private
 
   def attach_fixture_file(attachment_type, file_set, file_fixture_name)

--- a/spec/vcr/load_seeds.yml
+++ b/spec/vcr/load_seeds.yml
@@ -49,11 +49,13 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"name":"Art and Architecture Thesaurus","code":"aat","base_url":"http://vocab.getty.edu/aat"},{"name":"GeoNames","code":"geonames","base_url":"http://sws.geonames.org"},{"name":"Thesaurus
-        for Graphic Materials","code":"gmgpc","base_url":"http://id.loc.gov/vocabulary/graphicMaterials"},{"name":"ISO639-2
+        for Graphic Materials","code":"gmgpc","base_url":"http://id.loc.gov/vocabulary/graphicMaterials"},
+        {"name":"Homosaurus LGBTQ vocabulary","code":"homoit","base_url":"http://homosaurus.org/v2"},{"name":"ISO639-2
         Languages","code":"iso639-2","base_url":"http://id.loc.gov/vocabulary/iso639-2"},{"name":"Library
         of Congress Genre/Form Terms","code":"lcgft","base_url":"http://id.loc.gov/authorities/genreForms"},{"name":"Thesaurus
         for Graphic Materials","code":"lctgm","base_url":"http://id.loc.gov/vocabulary/graphicMaterials"},{"name":"Library
-        of Congress Subject Headings","code":"lcsh","base_url":"http://id.loc.gov/authorities/subjects"},{"name":"local","code":"local"},{"name":"Library
+        of Congress Subject Headings","code":"lcsh","base_url":"http://id.loc.gov/authorities/subjects"},{"name":"local","code":"local"},
+        {"name":"Medical Subject Headings","code":"mesh","base_url":"https://id.nlm.nih.gov/mesh"},{"name":"Library
         of Congress Name Authority File","code":"naf","base_url":"http://id.loc.gov/authorities/names"},{"name":"MARC
         genre terms","code":"marcgt","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/marcgt"},{"name":"MARC
         Relators Scheme","code":"marcrelator","base_url":"http://id.loc.gov/vocabulary/relators"},{"name":"RBMS
@@ -66,7 +68,8 @@ http_interactions:
         Controlled Vocabularies: Type Evidence","code":"rbtyp","base_url":"http://id.loc.gov/vocabulary/genreFormSchemes/rbtyp"},{"name":"Resource
         Types Scheme","code":"resourceTypes","base_url":"http://id.loc.gov/vocabulary/resourceTypes"},{"name":"Thesaurus
         of Geographic Names","code":"tgn","base_url":"http://vocab.getty.edu/tgn"},{"name":"Getty
-        Union List of Artist Names","code":"ulan","base_url":"http://vocab.getty.edu/ulan"}]'
+        Union List of Artist Names","code":"ulan","base_url":"http://vocab.getty.edu/ulan"},{"name":"Virtual
+        International Authority File","code":"viaf","base_url":"http://viaf.org/viaf"}]'
   recorded_at: Thu, 03 Dec 2020 22:50:44 GMT
 - request:
     method: get
@@ -589,17 +592,17 @@ http_interactions:
       string: '[{"label":"No known restrictions on use."},{"label":"This work is in
         the public domain under a Creative Commons No Rights Reserved License (CC0)."},{"label":"This
         work is licensed for use under a Creative Commons Attribution License (CC
-        BY).","uri":"https://creativecommons.org/licenses/by/4.0"},{"label":"This
+        BY).","uri":"https://creativecommons.org/licenses/by/4.0/"},{"label":"This
         work is licensed for use under a Creative Commons Attribution Share Alike
-        License (CC BY-SA).","uri":"https://creativecommons.org/licenses/by-sa/4.0"},{"label":"This
+        License (CC BY-SA).","uri":"https://creativecommons.org/licenses/by-sa/4.0/"},{"label":"This
         work is licensed for use under a Creative Commons Attribution No Derivatives
-        License (CC BY-ND).","uri":"https://creativecommons.org/licenses/by-nd/4.0"},{"label":"This
+        License (CC BY-ND).","uri":"https://creativecommons.org/licenses/by-nd/4.0/"},{"label":"This
         work is licensed for use under a Creative Commons Attribution Non-Commercial
-        License (CC BY-NC).","uri":"https://creativecommons.org/licenses/by-nc/4.0"},{"label":"This
+        License (CC BY-NC).","uri":"https://creativecommons.org/licenses/by-nc/4.0/"},{"label":"This
         work is licensed for use under a Creative Commons Attribution Non-Commercial
-        Share Alike License (CC BY-NC-SA).","uri":"https://creativecommons.org/licenses/by-nc-sa/4.0"},{"label":"This
+        Share Alike License (CC BY-NC-SA).","uri":"https://creativecommons.org/licenses/by-nc-sa/4.0/"},{"label":"This
         work is licensed for use under a Creative Commons Attribution Non-Commercial
-        No Derivatives License (CC BY-NC-ND).","uri":"https://creativecommons.org/licenses/by-nc-nd/4.0"},{"label":"All
+        No Derivatives License (CC BY-NC-ND).","uri":"https://creativecommons.org/licenses/by-nc-nd/4.0/"},{"label":"All
         rights reserved."},{"label":"Contact host institution for more information."}]'
   recorded_at: Thu, 03 Dec 2020 22:50:54 GMT
 - request:


### PR DESCRIPTION
Updates to support importing content from Fedora via export scripts implemented in [bpmodels](https://github.com/boston-library/bplmodels).
* change `checksum` param in controllers/factory services to `checksum_md5` (in case we ever want to support additional checksum types)
* updates to `Filestreams::Attacher` to support attaching files pulled from Fedora
* index blob key base via new ExemplaryImageIndexer concern (fixes #129)
* misc. updates to factories and seeds to reflect recent changes in bpldc_authority_api (https://github.com/boston-library/bpldc_authority_api/commit/5fcda34e458f95da8e282314054b46f1c15d0f9b)