### PR TITLE
Resolve 160 165

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ before_install:
   - sudo cp /etc/postgresql/{9.3,12}/main/pg_hba.conf
   - sudo pg_ctlcluster 12 main restart
   - gem update --system --no-document
-  - gem install bundler:2.2.21 --no-document
+  - gem install bundler:2.2.23 --no-document
 
 before_script:
   - bundle exec rails app:curator:setup
 
 rvm:
   - 2.5.9
-  - 2.6.7
+  - 2.6.8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 rvm:
   - 2.5.9
-  - 2.6.8
+  - 2.6.7
 
 env:
   global:

--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -54,7 +54,6 @@ module Curator
       class_attribute :curator_indexable_auto_callbacks, default: true
 
       after_save_commit :queue_indexing_job, if: -> { Curator::Indexable.auto_callbacks?(self) }
-      # after_destroy :indexer_health_check
       after_destroy_commit :queue_deletion_job, if: -> { Curator::Indexable.auto_callbacks?(self) }
     end
 
@@ -64,12 +63,6 @@ module Curator
     #  - a per-update writer, or thread/block-specific writer configured with `self.index_with`
     def update_index(mapper: curator_indexable_mapper, writer: nil)
       RecordIndexUpdater.new(self, mapper: mapper, writer: writer).update_index
-    end
-
-    # make sure indexing and authority services are ready before we commit transactions and :update_index
-    def indexer_health_check
-      raise Curator::Exceptions::SolrUnavailable unless SolrUtil.ready?
-      raise Curator::Exceptions::AuthorityApiUnavailable unless Curator::ControlledTerms::AuthorityService.ready?
     end
 
     def queue_indexing_job

--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -54,7 +54,7 @@ module Curator
       class_attribute :curator_indexable_auto_callbacks, default: true
 
       after_save_commit :queue_indexing_job, if: -> { Curator::Indexable.auto_callbacks?(self) }
-      after_destroy :indexer_health_check
+      # after_destroy :indexer_health_check
       after_destroy_commit :queue_deletion_job, if: -> { Curator::Indexable.auto_callbacks?(self) }
     end
 

--- a/app/indexers/concerns/curator/indexer/geographic_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/geographic_indexer.rb
@@ -26,7 +26,7 @@ module Curator
               context.output_hash['subject_geo_label_sim'] << geo_label if geo_auth
 
               if geo_auth == 'tgn' || geo_auth == 'geonames'
-                auth_url = "/#{geo_auth}/#{subject_geo.id_from_auth}"
+                auth_url = "#{geo_auth}/#{subject_geo.id_from_auth}"
                 auth_data = Curator::ControlledTerms::AuthorityService.call(path: auth_url, path_prefix: '/geomash')
                 if auth_data && auth_data[:hier_geo].present?
                   if auth_data[:non_hier_geo].present?

--- a/app/jobs/curator/ark_delete_job.rb
+++ b/app/jobs/curator/ark_delete_job.rb
@@ -1,0 +1,18 @@
+module Curator
+  class ArkDeleteJob < ApplicationJob
+    queue_as :arks
+
+    retry_on Curator::Exceptions::ArkManagerApiUnavailable, ActiveRecord::RecordNotDestroyed, attempts: 3
+
+    before_perform do
+      minter_service_available = Curator::MinterService.ready?
+
+      raise Curator::Exceptions::ArkManagerApiUnavailable if !minter_service_available
+    end
+
+
+    def perform(ark_id)
+      Curator::ArkDeleteService.call(ark_id)
+    end
+  end
+end

--- a/app/jobs/curator/ark_delete_job.rb
+++ b/app/jobs/curator/ark_delete_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Curator
   class ArkDeleteJob < ApplicationJob
     queue_as :arks
@@ -9,7 +11,6 @@ module Curator
 
       raise Curator::Exceptions::ArkManagerApiUnavailable if !minter_service_available
     end
-
 
     def perform(ark_id)
       Curator::ArkDeleteService.call(ark_id)

--- a/app/jobs/curator/indexer/deletion_job.rb
+++ b/app/jobs/curator/indexer/deletion_job.rb
@@ -4,6 +4,13 @@ module Curator
   class Indexer::DeletionJob < ApplicationJob
     queue_as :indexing
 
+    retry_on Curator::Exceptions::SolrUnavailable, Curator::Exceptions::AuthorityApiUnavailable, ActiveRecord::StaleObjectError, attempts: 3
+
+    before_perform do
+      raise Curator::Exceptions::SolrUnavailable if !Curator::SolrUtil.ready?
+      raise Curator::Exceptions::AuthorityApiUnavailable if !Curator::ControlledTerms::AuthorityService.ready?
+    end
+
     def perform(ark_id)
       writer = Curator.config.indexable_settings.writer_instance!
       writer.delete(ark_id)

--- a/app/jobs/curator/indexer/indexing_job.rb
+++ b/app/jobs/curator/indexer/indexing_job.rb
@@ -4,10 +4,14 @@ module Curator
   class Indexer::IndexingJob < ApplicationJob
     queue_as :indexing
 
-    retry_on Curator::Exceptions::SolrUnavailable, Curator::Exceptions::AuthorityApiUnavailable, attempts: 3
+    retry_on Curator::Exceptions::SolrUnavailable, Curator::Exceptions::AuthorityApiUnavailable, ActiveRecord::StaleObjectError, attempts: 3
+
+    before_perform do
+      raise Curator::Exceptions::SolrUnavailable if !Curator::SolrUtil.ready?
+      raise Curator::Exceptions::AuthorityApiUnavailable if !Curator::ControlledTerms::AuthorityService.ready?
+    end
 
     def perform(obj_to_index)
-      obj_to_index.indexer_health_check
       obj_to_index.update_index
     end
   end

--- a/app/models/concerns/curator/mintable.rb
+++ b/app/models/concerns/curator/mintable.rb
@@ -10,6 +10,8 @@ module Curator
       before_validation :generate_ark_id, on: :create
 
       validates :ark_id, presence: true, uniqueness: true, on: :create
+
+      after_destroy_commit :destroy_ark
     end
 
     module InstanceMethods
@@ -19,6 +21,10 @@ module Curator
       # rubocop:disable Metrics/LineLength
       # TODO: We should validate the arks have actual entries in the ark manager database on on create. Otherwise the permalink urls will be broken. As well as the the other functionalities the ark manager provides. I'm currently holding off until we are done testing but ideally we should implment this check once we are ready for the migration on prod. Also we should add an after_destroy commit that "deletes" the ark entries. This won't actually delet them since they will just be flagged as actuve = false. Ideally we should put this in a background job.
       # rubocop:enable Metrics/LineLength
+
+      def destroy_ark
+        Curator::ArkDeleteJob.perform_later(ark_id)
+      end
 
       def generate_ark_id
         return if ark_id.present?

--- a/app/services/curator/ark_delete_service.rb
+++ b/app/services/curator/ark_delete_service.rb
@@ -16,7 +16,7 @@ module Curator
           delete_ark(client)
         end
       rescue HTTP::Error => e
-        Rails.logger.error 'HTTP Error Occured Generating Ark'
+        Rails.logger.error 'HTTP Error Occured Destroying Ark'
         Rails.logger.error "Reason #{e.message}"
         raise ActiveRecord::RecordNotDestroyed, 'Error Destroying Ark!'
       rescue Oj::Error => e
@@ -24,10 +24,10 @@ module Curator
         Rails.logger.error "Reason #{e.message}"
         raise ActiveRecord::RecordNotDestroyed, 'Error Destroying Ark!'
       rescue Curator::Exceptions::RemoteServiceError => e
-        puts 'Error Occured Generating Ark'
-        puts "Reason #{e.message}"
-        puts "Response code #{e.code}"
-        puts "Response #{e.json_response}"
+        Rails.logger.error 'Error Occured Destroying Ark'
+        Rails.logger.error "Reason #{e.message}"
+        Rails.logger.error "Response code #{e.code}"
+        Rails.logger.error "Response #{e.json_response}"
         raise ActiveRecord::RecordNotDestroyed, 'Error Destroying Ark!'
       end
       false

--- a/app/services/curator/digital_object_factory_service.rb
+++ b/app/services/curator/digital_object_factory_service.rb
@@ -57,7 +57,7 @@ module Curator
             %w(genres resource_types languages).each do |map_type|
               mapped_terms = @desc_json_attrs.fetch(map_type, []).map do |map_attrs|
                 term_for_mapping(map_attrs, nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
-              end.compact.delete_if { |mt| descriptive.desc_terms.exists?(mapped_term: mt) }
+              end.compact.delete_if { |mt| !descriptive.new_record? && descriptive.desc_terms.exists?(mapped_term: mt) }
 
               next if mapped_terms.blank?
 

--- a/app/services/curator/filestreams/file_set_factory_service.rb
+++ b/app/services/curator/filestreams/file_set_factory_service.rb
@@ -63,12 +63,13 @@ module Curator
       return if exemplary_ids.blank?
 
       exemplary_ids.each do |ex_ark_id|
-        ex_obj = Curator.digital_object_class.find_by(ark_id: ex_ark_id) ||
-                 Curator.collection_class.find_by(ark_id: ex_ark_id)
+        ex_obj = Curator.digital_object_class.select(:id, :ark_id).find_by(ark_id: ex_ark_id) ||
+                 Curator.collection_class.select(:id, :ark_id).find_by(ark_id: ex_ark_id)
 
         raise ActiveRecord::RecordNotSaved, "Bad exemplary id! #{ex_ark_id} is either not in the repo or is not a DigitalObject or Collection" unless ex_obj
 
-        ex_obj.lock!
+        next if !file_set.new_record? && file_set.exemplary_image_of_mappings.exist?(exemplary_object: ex_object)
+
         build_exemplary(file_set) do |exemplary_img|
           exemplary_img.exemplary_object = ex_obj
         end

--- a/app/services/curator/filestreams/file_set_updater_service.rb
+++ b/app/services/curator/filestreams/file_set_updater_service.rb
@@ -82,7 +82,7 @@ module Curator
         Curator.digital_object_class.select(:id, :ark_id).find_by(ark_id: ex_obj_ark_id) ||
                  Curator.collection_class.select(:id, :ark_id).find_by!(ark_id: ex_obj_ark_id)
       end.compact.delete_if { |eo| !@record.exemplary_image_of_mappings.exists?(exemplary_object: eo) }
-      
+
       @record.exemplary_image_of_mappings.destroy_by(exemplary_object: exemplary_objects)
     rescue ActiveRecord::RecordNotFound => e
       @record.errors.add(:exemplary_image_of_mappings, "#{e.message} with ark_id=#{admin_set_ark_id}")

--- a/app/services/curator/metastreams/descriptive_updater_service.rb
+++ b/app/services/curator/metastreams/descriptive_updater_service.rb
@@ -141,7 +141,7 @@ module Curator
 
       host_collections = host_collection_names.map do |host_col_name|
         find_or_create_host_collection(host_col_name, @record.digital_object.institution)
-      end.compact.delete_if { |hc|  @record.desc_host_collections.exists?(host_collection: hc) }
+      end.compact.delete_if { |hc| @record.desc_host_collections.exists?(host_collection: hc) }
 
       return if host_collections.blank?
 
@@ -153,7 +153,7 @@ module Curator
     def add_subject_terms!(subject_terms = [])
       return if subject_terms.blank?
 
-      terms_to_add = subject_terms.delete_if { |st|  @record.desc_terms.exists?(mapped_term: st) }
+      terms_to_add = subject_terms.delete_if { |st| @record.desc_terms.exists?(mapped_term: st) }
 
       return if terms_to_add.blank?
 
@@ -191,8 +191,8 @@ module Curator
         next if !map_attrs.key?(:_destroy)
 
         term_for_mapping(map_attrs.except(:_destroy),
-                                       nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
-      end.compact.delete_if { |mt|  !@record.desc_terms.exixts?(mapped_term: mt) }
+                         nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
+      end.compact.delete_if { |mt| !@record.desc_terms.exixts?(mapped_term: mt) }
 
       return if terms_to_destroy.blank?
 
@@ -216,7 +216,7 @@ module Curator
 
       mapped_name_roles = name_role_attrs.map do |nr_attrs|
         name_role(nr_attrs.fetch(:name), nr_attrs.fetch(:role))
-      end.compact.delete_if { |nr_attrs| !@record.name_roles.exists?(mnr_attrs) }
+      end.compact.delete_if { |mnr_attrs| !@record.name_roles.exists?(mnr_attrs) }
 
       return if mapped_name_roles.blank?
 

--- a/app/services/curator/metastreams/descriptive_updater_service.rb
+++ b/app/services/curator/metastreams/descriptive_updater_service.rb
@@ -139,14 +139,13 @@ module Curator
 
       return if host_collection_names.blank?
 
-      host_collection_names.each do |host_col_name|
-        host_collection = find_or_create_host_collection(host_col_name,
-                                                         @record.digital_object.institution)
+      host_collections = host_collection_names.map do |host_col_name|
+        find_or_create_host_collection(host_col_name, @record.digital_object.institution)
+      end.compact.delete_if { |hc|  @record.desc_host_collections.exists?(host_collection: hc) }
 
-        next if @record.desc_host_collections.exists?(host_collection: host_collection)
+      return if host_collections.blank?
 
-        @record.desc_host_collections.build(host_collection: host_collection)
-      end
+      host_collections.each { |hc| @record.desc_host_collections.build(host_collection: hc) }
     end
 
     private
@@ -154,51 +153,50 @@ module Curator
     def add_subject_terms!(subject_terms = [])
       return if subject_terms.blank?
 
-      subject_terms.each do |subject_term|
-        next if @record.desc_terms.exists?(mapped_term: subject_term)
+      terms_to_add = subject_terms.delete_if { |st|  @record.desc_terms.exists?(mapped_term: st) }
 
-        @record.desc_terms.build(mapped_term: subject_term)
-      end
+      return if terms_to_add.blank?
+
+      terms_to_add.each { |term_to_add| @record.desc_terms.build(mapped_term: term_to_add) }
     end
 
     def remove_subject_terms!(subject_terms = [])
       return if subject_terms.blank?
 
-      subject_terms.each do |subject_term|
-        next if !@record.desc_terms.exists?(mapped_term: subject_term)
+      terms_to_destroy = subject_terms.delete_if { |st| !@record.desc_terms.exists?(mapped_term: st) }
 
-        @record.desc_terms.where(mapped_term: subject_term).destroy_all
-      end
+      return if terms_to_destroy.blank?
+
+      @record.desc_terms.destroy_by(mapped_term: terms_to_destroy)
     end
 
     def add_mapped_terms!(map_type, mapped_terms = [])
       return if mapped_terms.blank?
 
-      mapped_terms.each do |map_attrs|
+      terms_to_add = mapped_terms.map do |map_attrs|
         next if map_attrs.key?(:_destroy)
 
-        mapped_term = term_for_mapping(map_attrs,
-                                       nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
+        term_for_mapping(map_attrs, nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
+      end.compact.delete_if { |mt| @record.desc_terms.exists?(mapped_term: mt) }
 
-        next if @record.desc_terms.exists?(mapped_term: mapped_term)
+      return if terms_to_add.blank?
 
-        @record.desc_terms.build(mapped_term: mapped_term)
-      end
+      terms_to_add.each { |term_to_add| @record.desc_terms.build(mapped_term: term_to_add) }
     end
 
     def remove_mapped_terms!(map_type, mapped_terms = [])
       return if mapped_terms.blank?
 
-      mapped_terms.each do |map_attrs|
+      terms_to_destroy = mapped_terms.map do |map_attrs|
         next if !map_attrs.key?(:_destroy)
 
-        mapped_term = term_for_mapping(map_attrs.except(:_destroy),
+        term_for_mapping(map_attrs.except(:_destroy),
                                        nomenclature_class: Curator.controlled_terms.public_send("#{map_type.singularize}_class"))
+      end.compact.delete_if { |mt|  !@record.desc_terms.exixts?(mapped_term: mt) }
 
-        next if !@record.desc_terms.exists?(mapped_term: mapped_term)
+      return if terms_to_destroy.blank?
 
-        @record.desc_terms.where(mapped_term: mapped_term).destroy_all
-      end
+      @record.desc_terms.destroy_by(mapped_term: terms_to_destroy)
     end
 
     def add_name_roles!(name_role_attrs = [])
@@ -206,13 +204,11 @@ module Curator
 
       mapped_name_roles = name_role_attrs.map do |nr_attrs|
         name_role(nr_attrs.fetch(:name), nr_attrs.fetch(:role))
-      end
+      end.compact.delete_if { |mnr_attrs| @record.name_roles.exists?(mnr_attrs) }
 
-      mapped_name_roles.each do |mnr_attrs|
-        next if @record.name_roles.exists?(mnr_attrs)
+      return if mapped_name_roles.blank?
 
-        @record.name_roles.build(mnr_attrs)
-      end
+      mapped_name_roles.each { |mnr| @record.name_roles.build(mnr) }
     end
 
     def remove_name_roles!(name_role_attrs = [])
@@ -220,13 +216,11 @@ module Curator
 
       mapped_name_roles = name_role_attrs.map do |nr_attrs|
         name_role(nr_attrs.fetch(:name), nr_attrs.fetch(:role))
-      end
+      end.compact.delete_if { |nr_attrs| !@record.name_roles.exists?(mnr_attrs) }
 
-      mapped_name_roles.each do |mnr_attrs|
-        next if !@record.name_roles.exists?(mnr_attrs)
+      return if mapped_name_roles.blank?
 
-        @record.name_roles.where(mnr_attrs).destroy_all
-      end
+      @record.name_roles.destroy_by(mapped_name_roles)
     end
   end
 end

--- a/app/services/curator/minter_service.rb
+++ b/app/services/curator/minter_service.rb
@@ -20,18 +20,19 @@ module Curator
       rescue HTTP::Error => e
         Rails.logger.error 'HTTP Error Occured Generating Ark'
         Rails.logger.error "Reason #{e.message}"
-        raise 'Error Generating Ark!'
+        raise ActiveRecord::RecordNotSaved, 'Error Generating Ark!'
       rescue Oj::Error => e
         Rails.logger.error 'Invalid JSON From Ark Response'
         Rails.logger.error "Reason #{e.message}"
-        raise 'Error Generating Ark!'
+        raise ActiveRecord::RecordNotSaved, 'Error Generating Ark!'
       rescue Curator::Exceptions::RemoteServiceError => e
         Rails.logger.error 'Error Occured Generating Ark'
         Rails.logger.error "Reason #{e.message}"
         Rails.logger.error "Response code #{e.code}"
         Rails.logger.error "Response #{e.json_response}"
-        raise 'Error Generating Ark!'
+        raise ActiveRecord::RecordNotSaved, 'Error Generating Ark!'
       end
+      false
     end
 
     protected

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aasm', '~> 5.2' # Acts as a state machine. Useful for tracking states of objects and triggering call backs between state trasnistion
   spec.add_dependency 'activerecord-postgres_enum', '~> 1.6' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
-  spec.add_dependency 'addressable', '~> 2.8'
+  spec.add_dependency 'addressable', '>= 2.8'
   spec.add_dependency 'after_commit_everywhere', '~> 1.0' # Required for using aasm with active record
   spec.add_dependency 'attr_json', '~> 1.3'
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.1'

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aasm', '~> 5.2' # Acts as a state machine. Useful for tracking states of objects and triggering call backs between state trasnistion
   spec.add_dependency 'activerecord-postgres_enum', '~> 1.6' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
-  spec.add_dependency 'addressable', '>= 2.8'
+  spec.add_dependency 'addressable', '>= 2.8.0'
   spec.add_dependency 'after_commit_everywhere', '~> 1.0' # Required for using aasm with active record
   spec.add_dependency 'attr_json', '~> 1.3'
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.1'

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aasm', '~> 5.2' # Acts as a state machine. Useful for tracking states of objects and triggering call backs between state trasnistion
   spec.add_dependency 'activerecord-postgres_enum', '~> 1.6' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
-  spec.add_dependency 'addressable', '2.7'
+  spec.add_dependency 'addressable', '2.8'
   spec.add_dependency 'after_commit_everywhere', '~> 1.0' # Required for using aasm with active record
   spec.add_dependency 'attr_json', '~> 1.3'
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.1'
@@ -42,17 +42,17 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'htmlentities', '~> 4.3' # TODO: Look into replacing this since the last released in 2014. I recommend turning this into its own parser class.
   spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'mime-types', '~> 3.3'
-  spec.add_dependency 'oj', '~> 3.11'
+  spec.add_dependency 'oj', '~> 3.12'
   spec.add_dependency 'ox', '~> 2.14'
   spec.add_dependency 'paper_trail', '~> 11.1'
   spec.add_dependency 'paper_trail-association_tracking', '~> 2.1'
   spec.add_dependency 'rails', '~> 6.1.4', '< 6.2'
   spec.add_dependency 'rsolr', '~> 2.3'
-  spec.add_dependency 'traject', '~> 3.5'
+  spec.add_dependency 'traject', '~> 3.6'
 
-  spec.add_development_dependency 'image_processing', '~> 1.11'
+  spec.add_development_dependency 'image_processing', '~> 1.12'
   spec.add_development_dependency 'mini_magick', '~> 4.11'
   spec.add_development_dependency 'pg', '~> 1.2'
-  spec.add_development_dependency 'redis', '~> 4.2'
+  spec.add_development_dependency 'redis', '~> 4.3'
   spec.add_development_dependency 'solr_wrapper', '~> 3.1'
 end

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aasm', '~> 5.2' # Acts as a state machine. Useful for tracking states of objects and triggering call backs between state trasnistion
   spec.add_dependency 'activerecord-postgres_enum', '~> 1.6' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
-  spec.add_dependency 'addressable', '2.8'
+  spec.add_dependency 'addressable', '~> 2.8'
   spec.add_dependency 'after_commit_everywhere', '~> 1.0' # Required for using aasm with active record
   spec.add_dependency 'attr_json', '~> 1.3'
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.1'

--- a/spec/indexers/concerns/curator/indexable_spec.rb
+++ b/spec/indexers/concerns/curator/indexable_spec.rb
@@ -49,33 +49,6 @@ RSpec.describe Curator::Indexable do
     end
   end
 
-  describe '#indexer_health_check' do
-    it 'does not raise an error if the indexing service is available' do
-      expect do
-        @indexable_object.indexer_health_check
-      end.not_to raise_error
-    end
-
-    it 'throws SolrUnavailable if the indexing service is not available' do
-      ClimateControl.modify SOLR_URL: 'http://127.0.0.1:9999/solr/wrong' do
-        expect do
-          @indexable_object.indexer_health_check
-        end.to raise_error(Curator::Exceptions::SolrUnavailable)
-      end
-    end
-
-    # TODO: change ClimateControl.modify to change AUTHORITY_API_URL
-    # once remote services are containerized for CI build
-    # Curator::Services::AuthorityService.ready? always returns true when RAILS_ENV = 'test'
-    it 'throws AuthorityApiUnavailable if the authority service is not available' do
-      ClimateControl.modify RAILS_ENV: 'development' do
-        expect do
-          @indexable_object.indexer_health_check
-        end.to raise_error(Curator::Exceptions::AuthorityApiUnavailable)
-      end
-    end
-  end
-
   describe 'background jobs' do
     before(:each) do
       ActiveJob::Base.queue_adapter = :test

--- a/spec/jobs/curator/ark_delete_job_spec.rb
+++ b/spec/jobs/curator/ark_delete_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/jobs_shared'
+
+RSpec.describe Curator::ArkDeleteJob, type: :job do
+
+  describe 'expected job behavior' do
+    subject { described_class }
+
+    let(:job_args) { 'bpl-dev:987654321' }
+    let(:expected_queue) { :arks }
+    let(:ark_manager_destroy_url) { "#{Curator.config.ark_manager_api_url}/api/v2/#{job_args}" }
+
+    before(:each) do
+      ActiveJob::Base.queue_adapter = :test
+    end
+
+    it_behaves_like 'queueable'
+
+    skip 'sends a delete request to the indexing service' do
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+      subject.perform_later(job_args)
+      assert_requested :delete, ark_manager_destroy_url
+    end
+  end
+end

--- a/spec/jobs/curator/ark_delete_job_spec.rb
+++ b/spec/jobs/curator/ark_delete_job_spec.rb
@@ -4,24 +4,29 @@ require 'rails_helper'
 require_relative './shared/jobs_shared'
 
 RSpec.describe Curator::ArkDeleteJob, type: :job do
-
   describe 'expected job behavior' do
     subject { described_class }
 
     let(:job_args) { 'bpl-dev:987654321' }
-    let(:expected_queue) { :arks }
-    let(:ark_manager_destroy_url) { "#{Curator.config.ark_manager_api_url}/api/v2/#{job_args}" }
-
-    before(:each) do
-      ActiveJob::Base.queue_adapter = :test
-    end
+    let(:expected_queue) { 'arks' }
 
     it_behaves_like 'queueable'
 
-    skip 'sends a delete request to the indexing service' do
-      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-      subject.perform_later(job_args)
-      assert_requested :delete, ark_manager_destroy_url
+    describe '#perform_later' do
+      let(:ark_manager_destroy_url) { "#{Curator.config.ark_manager_api_url}/api/v2/arks/#{job_args}" }
+
+      around(:each) do |spec|
+        ActiveJob::Base.queue_adapter = :test
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+        VCR.use_cassette('jobs/ark_delete_job') do
+          spec.run
+        end
+      end
+
+      it 'sends a delete request to the indexing service' do
+        subject.perform_later(job_args)
+        expect(a_request(:delete, ark_manager_destroy_url)).to have_been_made.at_least_once
+      end
     end
   end
 end

--- a/spec/jobs/curator/indexer/indexing_job_spec.rb
+++ b/spec/jobs/curator/indexer/indexing_job_spec.rb
@@ -9,21 +9,28 @@ RSpec.describe Curator::Indexer::IndexingJob, type: :job do
     let(:job_args) { create(:curator_institution) }
     let(:expected_queue) { 'indexing' }
 
-    before(:each) do
-      ActiveJob::Base.queue_adapter = :test
-    end
-
     it_behaves_like 'queueable'
 
-    it 'sends an update request to the indexing service' do
-      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-      timestamp = Time.current
-      subject.perform_later(job_args)
-      # don't use assert_requested here, too hard to match body, check solr timestamp instead
-      rsolr = RSolr.connect url: Curator.config.solr_url
-      solr_resp = rsolr.get 'select', params: { q: "id:\"#{job_args.ark_id}\"" }
-      solr_rec = solr_resp['response']['docs'].first
-      expect(solr_rec['timestamp']).to be > timestamp
+    describe '#perform_later' do
+      let!(:solr_client) { RSolr.connect(url: Curator.config.solr_url) }
+
+      around(:each) do |spec|
+        ActiveJob::Base.queue_adapter = :test
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+        spec.run
+      end
+
+      it 'sends an update request to the indexing service' do
+        timestamp = Time.current
+        subject.perform_later(job_args)
+
+        # NOTE: don't use assert_requested here, too hard to match body, check solr timestamp instead
+
+        solr_resp = solr_client.get 'select', params: { q: "id:\"#{job_args.ark_id}\"" }
+        solr_rec = solr_resp.dig('response', 'docs')&.first
+        expect(solr_rec).to be_a_kind_of(Hash).and have_key('timestamp')
+        expect(solr_rec['timestamp']).to be > timestamp
+      end
     end
   end
 end

--- a/spec/jobs/curator/shared/jobs_shared.rb
+++ b/spec/jobs/curator/shared/jobs_shared.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'queueable', type: :job do
-  it 'queues the job' do
-    expect do
-      subject.perform_later(job_args)
-    end.to have_enqueued_job.with(job_args).on_queue(expected_queue).at(:no_wait)
+  describe 'expected job enqueued' do
+    around(:each) do |spec|
+      ActiveJob::Base.queue_adapter = :test
+      ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+      spec.run
+    end
+
+    it 'enqueues the job' do
+      expect do
+        subject.perform_later(job_args)
+      end.to have_enqueued_job.with(job_args).on_queue(expected_queue).at(:no_wait)
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,7 +32,8 @@ require 'vcr'
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr'
   c.configure_rspec_metadata!
-  c.hook_into :webmock
+  c.hook_into :faraday, :webmock
+  c.default_cassette_options = { record: ENV['CI'].present? ? :none : :new_episodes }
   c.ignore_request do |request|
     request.uri =~ /solr/
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr'
   c.configure_rspec_metadata!
   c.hook_into :faraday, :webmock
-  c.default_cassette_options = { record: ENV['CI'].present? ? :none : :new_episodes }
+  # c.default_cassette_options = { record: :new_episodes }
   c.ignore_request do |request|
     request.uri =~ /solr/
   end

--- a/spec/services/curator/ark_delete_service_spec.rb
+++ b/spec/services/curator/ark_delete_service_spec.rb
@@ -1,0 +1,35 @@
+#frozen_string_literal: true
+
+require 'rails_helper'
+require_relative './shared/remote_service'
+
+RSpec.describe Curator::ArkDeleteService, type: :service do
+  subject { described_class }
+
+  it_behaves_like 'remote_service'
+
+  it 'expects the .base_url to eq the Curator.config.ark_manager_api_url' do
+    expect(subject.base_url).to eq(Curator.config.ark_manager_api_url)
+  end
+
+  describe '#call' do
+    before(:all) do
+      @mintable ||= build(:curator_institution, ark_id: nil)
+
+      VCR.use_cassette('services/institutions/destroy_ark') do
+        @ark_id = Curator::MinterService.call(@mintable.ark_params)
+      end
+    end
+
+    let(:ark_url) { "#{Curator.config.ark_manager_api_url}/api/v2/#{@ark_id}" }
+
+    it 'expects the ark to ark been successfully deleted' do
+      VCR.use_cassette('services/destroy_ark') do
+        result = described_class.call(@ark_id)
+        expect(result).to be_truthy
+        verify_result = HTTP.get(ark_url)
+        expect(verify_result.code).to be(404)
+      end
+    end
+  end
+end

--- a/spec/services/curator/institution_factory_service_spec.rb
+++ b/spec/services/curator/institution_factory_service_spec.rb
@@ -8,9 +8,11 @@ RSpec.describe Curator::InstitutionFactoryService, type: :service do
   before(:all) do
     @object_json = load_json_fixture('institution_with_thumbnail', 'institution')
     @object_json['files'][0]['metadata']['ingest_filepath'] = file_fixture('image_thumbnail_300_institution.png').to_s
-    expect do
-      @success, @institution = handle_factory_result(described_class, @object_json)
-    end.to change { Curator::Institution.count }.by(1)
+    VCR.use_cassette('services/institution_factory_service') do
+      expect do
+        @success, @institution = handle_factory_result(described_class, @object_json)
+      end.to change { Curator::Institution.count }.by(1)
+    end
   end
 
   specify { expect(@success).to be_truthy }

--- a/spec/tasks/reindex_all_spec.rb
+++ b/spec/tasks/reindex_all_spec.rb
@@ -22,7 +22,11 @@ RSpec.describe 'curator:reindex_all task', type: :task do
 
   it 'Updates the solr index for all the objects in the DB' do
     current_timestamp = Time.current
-    Rake::Task['curator:reindex_all'].invoke
+    VCR.use_cassette('tasks/reindex_all') do
+      Rails.logger.silence do
+        Rake::Task['curator:reindex_all'].invoke
+      end
+    end
     expect(record_timestamps.count).to eq(ark_ids.count)
     expect(record_timestamps).to all(be > current_timestamp)
   end

--- a/spec/vcr/controllers/descriptive_update.yml
+++ b/spec/vcr/controllers/descriptive_update.yml
@@ -51,4 +51,55 @@ http_interactions:
       string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
         and Central America","county":"Essex","country":"United States","state":"Massachusetts"}}'
   recorded_at: Wed, 07 Jul 2021 16:40:25 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2050042
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"47db2d414028f515f4fa550b66b1e696"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 322cebd0-e9bf-4a92-9e24-5a73dfc5916e
+      X-Runtime:
+      - '0.008667'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
+        and Central America","county":"Essex","country":"United States","state":"Massachusetts"}}'
+  recorded_at: Tue, 13 Jul 2021 15:13:12 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/jobs/ark_delete_job.yml
+++ b/spec/vcr/jobs/ark_delete_job.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: http://127.0.0.1:3002/api/v2/arks/bpl-dev:3n206530d
+    uri: http://127.0.0.1:3002/api/v2/arks/bpl-dev:987654321
     body:
       encoding: UTF-8
       string: ''
@@ -19,8 +19,8 @@ http_interactions:
       - http.rb/5.0.1
   response:
     status:
-      code: 204
-      message: No Content
+      code: 404
+      message: Not Found
     headers:
       X-Frame-Options:
       - SAMEORIGIN
@@ -34,14 +34,19 @@ http_interactions:
       - none
       Referrer-Policy:
       - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2b285467-e259-48c8-900f-abe709c39664
+      - f4d61efa-7ccc-4a3c-9f2a-29748b062d54
       X-Runtime:
-      - '0.018241'
+      - '0.013180'
+      Transfer-Encoding:
+      - chunked
     body:
-      encoding: ASCII-8BIT
-      string: ''
-  recorded_at: Tue, 13 Jul 2021 17:17:20 GMT
+      encoding: UTF-8
+      string: '{"errors":[{"title":"Not found","status":404,"detail":"can''t find
+        record with friendly id: \"bpl-dev:987654321\"","source":{"pointer":"/api/v2/arks/bpl-dev:987654321"}}]}'
+  recorded_at: Tue, 13 Jul 2021 14:43:30 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/services/destroy_ark.yml
+++ b/spec/vcr/services/destroy_ark.yml
@@ -1,0 +1,143 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: http://127.0.0.1:3002/api/v2/arks/bpl-dev:pr76f341v
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 64879af8-4319-4660-a04c-ff3a47f03908
+      X-Runtime:
+      - '0.005175'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"Not found","status":404,"detail":"can''t find
+        record with friendly id: \"bpl-dev:pr76f341v\"","source":{"pointer":"/api/v2/arks/bpl-dev:pr76f341v"}}]}'
+  recorded_at: Mon, 12 Jul 2021 20:29:09 GMT
+- request:
+    method: delete
+    uri: http://127.0.0.1:3002/api/v2/arks/bpl-dev:3n206528c
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 595b22bb-71be-4978-82a6-e196e8c46b67
+      X-Runtime:
+      - '0.017061'
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Mon, 12 Jul 2021 20:35:40 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3002/api/v2/bpl-dev:3n206528c
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Connection:
+      - close
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 9f9d1432-500f-425b-b87a-40e81aa452c9
+      X-Runtime:
+      - '0.001691'
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"errors":[{"title":"Not found","status":404,"detail":"No Route Matches
+        This Url","source":{"pointer":"/api/v2/bpl-dev:3n206528c"}}]}'
+  recorded_at: Mon, 12 Jul 2021 20:35:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr/services/institutions/ark_for_destroy.yml
+++ b/spec/vcr/services/institutions/ark_for_destroy.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:3002/api/v2/arks
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"namespace_ark":"50959","namespace_id":"bpl-dev","url_base":"https://search-dc3dev.bpl.org","model_type":"Curator::Institution","secondary_parent_pids":[],"local_original_identifier_type":"physical_location","local_original_identifier":"Osinski
+        Academy"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f00589085d77cdd4ad7245e2e9ac935e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1b6ddab7-e63d-4742-99ef-b4d79822dc74
+      X-Runtime:
+      - '0.052566'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"id":6423,"pid":"bpl-dev:3n206530d","created_at":"2021-07-13T17:17:20.773Z","updated_at":"2021-07-13T17:17:20.773Z","model_type":"Curator::Institution","local_original_identifier":"Osinski
+        Academy","local_original_identifier_type":"physical_location","namespace_ark":"50959","namespace_id":"bpl-dev","secondary_parent_pids":[],"url_base":"https://search-dc3dev.bpl.org"}}'
+  recorded_at: Tue, 13 Jul 2021 17:17:20 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr/services/institutions/destroy_ark.yml
+++ b/spec/vcr/services/institutions/destroy_ark.yml
@@ -1,0 +1,151 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: http://127.0.0.1:3002/api/v2/arks/%7B:namespace_ark=%3E%2250959%22,%20:namespace_id=%3E%22bpl-dev%22,%20:url_base=%3E%22https://search-dc3dev.bpl.org%22,%20:model_type=%3E%22Curator::Institution%22,%20:parent_pid=%3Enil,%20:secondary_parent_pids=%3E%5B%5D,%20:local_original_identifier_type=%3E%22physical_location%22,%20:local_original_identifier=%3E%22East%20Wyoming%20Academy%22%7D
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/html
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - '0259fb30-1887-44f0-8bf4-1aaed6259ac2'
+      X-Runtime:
+      - '0.003104'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Mon, 12 Jul 2021 20:32:17 GMT
+- request:
+    method: delete
+    uri: http://127.0.0.1:3002/api/v2/arks/%7B:namespace_ark=%3E%2250959%22,%20:namespace_id=%3E%22bpl-dev%22,%20:url_base=%3E%22https://search-dc3dev.bpl.org%22,%20:model_type=%3E%22Curator::Institution%22,%20:parent_pid=%3Enil,%20:secondary_parent_pids=%3E%5B%5D,%20:local_original_identifier_type=%3E%22physical_location%22,%20:local_original_identifier=%3E%22Northern%20Montana%20University%22%7D
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - text/html
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f89d51c4-9fa2-48b4-a4da-a394a4190d79
+      X-Runtime:
+      - '0.002642'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+  recorded_at: Mon, 12 Jul 2021 20:33:28 GMT
+- request:
+    method: post
+    uri: http://127.0.0.1:3002/api/v2/arks
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"namespace_ark":"50959","namespace_id":"bpl-dev","url_base":"https://search-dc3dev.bpl.org","model_type":"Curator::Institution","secondary_parent_pids":[],"local_original_identifier_type":"physical_location","local_original_identifier":"South
+        Hyatt University"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"6a440b42050ee521c720ddd7b530951a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fd5e75fb-db1f-416c-81cd-5bd20446ab11
+      X-Runtime:
+      - '0.044394'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"id":6421,"pid":"bpl-dev:3n206528c","created_at":"2021-07-12T20:35:40.888Z","updated_at":"2021-07-12T20:35:40.888Z","model_type":"Curator::Institution","local_original_identifier":"South
+        Hyatt University","local_original_identifier_type":"physical_location","namespace_ark":"50959","namespace_id":"bpl-dev","secondary_parent_pids":[],"url_base":"https://search-dc3dev.bpl.org"}}'
+  recorded_at: Mon, 12 Jul 2021 20:35:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr/services/institutions/verify_ark_destroyed.yml
+++ b/spec/vcr/services/institutions/verify_ark_destroyed.yml
@@ -1,26 +1,22 @@
 ---
 http_interactions:
 - request:
-    method: delete
+    method: get
     uri: http://127.0.0.1:3002/api/v2/arks/bpl-dev:3n206530d
     body:
       encoding: UTF-8
       string: ''
     headers:
-      Accept:
-      - application/json
-      Content-Type:
-      - application/json
       Connection:
-      - Keep-Alive
+      - close
       Host:
       - 127.0.0.1:3002
       User-Agent:
       - http.rb/5.0.1
   response:
     status:
-      code: 204
-      message: No Content
+      code: 404
+      message: Not Found
     headers:
       X-Frame-Options:
       - SAMEORIGIN
@@ -34,14 +30,21 @@ http_interactions:
       - none
       Referrer-Policy:
       - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 2b285467-e259-48c8-900f-abe709c39664
+      - 60ed4ac1-c873-448f-a679-220083ea4ba0
       X-Runtime:
-      - '0.018241'
+      - '0.004498'
+      Connection:
+      - close
+      Transfer-Encoding:
+      - chunked
     body:
-      encoding: ASCII-8BIT
-      string: ''
+      encoding: UTF-8
+      string: '{"errors":[{"title":"Not found","status":404,"detail":"can''t find
+        record with friendly id: \"bpl-dev:3n206530d\"","source":{"pointer":"/api/v2/arks/bpl-dev:3n206530d"}}]}'
   recorded_at: Tue, 13 Jul 2021 17:17:20 GMT
 recorded_with: VCR 6.0.0

--- a/spec/vcr/services/metastreams/descriptive/update.yml
+++ b/spec/vcr/services/metastreams/descriptive/update.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2050042
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"47db2d414028f515f4fa550b66b1e696"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 727d4974-3c73-4798-a027-8bbd8cc67a37
+      X-Runtime:
+      - '1.095801'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
+        and Central America","county":"Essex","country":"United States","state":"Massachusetts"}}'
+  recorded_at: Tue, 13 Jul 2021 14:14:04 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr/tasks/reindex_all.yml
+++ b/spec/vcr/tasks/reindex_all.yml
@@ -1,0 +1,309 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/1005467
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"db2b8ee073dfced7c5f6212cd98abdb2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f1531b35-f37f-45ab-b299-4d591ac4ceaa
+      X-Runtime:
+      - '0.801310'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.2833","longitude":"-71.1167","combined":"42.2833,-71.1167"},"hier_geo":{"city_section":"Roslindale","city":"Boston","continent":"North
+        and Central America","county":"Suffolk","country":"United States","state":"Massachusetts"}}'
+  recorded_at: Mon, 12 Jul 2021 19:17:39 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2050042
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"47db2d414028f515f4fa550b66b1e696"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 260146d0-0088-45c3-ab67-f0237730c4b9
+      X-Runtime:
+      - '0.881636'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
+        and Central America","county":"Essex","country":"United States","state":"Massachusetts"}}'
+  recorded_at: Mon, 12 Jul 2021 20:44:41 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/1004027
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"461a1cfe0d2c73952d6af55b76a37c47"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c8c09f57-0a0b-4029-a8bd-4828264fd674
+      X-Runtime:
+      - '0.001807'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.35","longitude":"-71.0833","combined":"42.35,-71.0833"},"hier_geo":{"city_section":"Back
+        Bay","city":"Boston","continent":"North and Central America","county":"Suffolk","country":"United
+        States","state":"Massachusetts"}}'
+  recorded_at: Mon, 12 Jul 2021 20:44:41 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2120926
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"fd77e23b4555c7045798e21df4331e8d"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e41399de-3d32-4887-bc2e-4a995f230c51
+      X-Runtime:
+      - '0.001466'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"44.9333","longitude":"-91.3833","combined":"44.9333,-91.3833"},"hier_geo":{"city":"Chippewa
+        Falls","continent":"North and Central America","county":"Chippewa","country":"United
+        States","state":"Wisconsin"}}'
+  recorded_at: Mon, 12 Jul 2021 20:44:41 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2362636
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f9836fb9c94d119272fed2726ba18ad6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cf7a02c1-6ca9-46a9-a988-85eceadbe9ca
+      X-Runtime:
+      - '0.001593'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"43.7333","longitude":"-70.1167","combined":"43.7333,-70.1167"},"hier_geo":{"island":"Great
+        Chebeague Island","continent":"North and Central America","county":"Cumberland","country":"United
+        States","state":"Maine"}}'
+  recorded_at: Mon, 12 Jul 2021 20:44:41 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/geonames/4942742
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.0.1
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 41c70f5a-1aa8-4b75-aa85-c23490ec8e51
+      X-Runtime:
+      - '0.187347'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"error":"undefined method `geoname'' for #\u003cNokogiri::XML::Element:0x00007fac04131d40\u003e"}'
+  recorded_at: Mon, 12 Jul 2021 20:44:41 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Note Leaving 162 Out per this PR

- Refactored adding and removing child objects in factory services to skip already existing items on create and non existing ones on remove
- Added `ArkDeleteService` that makes a `DELETE` call to the ark-manager when a `Mintable` object is `destroyed` (NOTE this doesn't actually delete the ark it just marks the `deleted` column true in the ark-manager database
- Added A ark delete background job to call the `ArkDeleteSerivce` service asynchrounsly on a `after_destroy_commit` callback for a `Mintable` object
- Added `faraday` hook in `VCR` config(on top of webmock) to create more robust cassettes. 
- Recorded `new_episodes` for certain specs
- Refactored specs using `assert_requested` to use `expect(a_request(...))` to be more in line with `rspec`s Style.
- Updated `addressable` version in `gemspec` to resolve dependabot alert
- Refactored and added `before_perform` to jobs that require a health check on a service before interacting with them (ie `solr`, `ark-manager`, `auth-api`)