### PR TITLE
Resolve 175

### DIFF
--- a/app/models/concerns/curator/metastreams/administratable.rb
+++ b/app/models/concerns/curator/metastreams/administratable.rb
@@ -11,6 +11,8 @@ module Curator
 
         validates :administrative, presence: true
         validates_associated :administrative, on: :create
+
+        delegate :oai_object?, to: :administrative, allow_nil: true
       end
     end
   end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -41,12 +41,21 @@ module Curator
     after_update_commit :reindex_collection_members
 
     def ark_params
-      super.except(:oai_namespace_id).merge({
+      return super.except(:oai_namespace_id).merge({
+        parent_pid: institution&.ark_id,
+          secondary_parent_pids: [],
+          local_original_identifier_type: 'institution_collection_name',
+          local_original_identifier: name
+      }) if !oai_object?
+
+      params = super.merge({
         parent_pid: institution&.ark_id,
           secondary_parent_pids: [],
           local_original_identifier_type: 'institution_collection_name',
           local_original_identifier: name
       })
+      params[:namespace_id] = params.delete(:oai_namespace_id)
+      params
     end
 
     private

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -82,7 +82,7 @@ module Curator
       return super.except(:oai_namespace_id).merge({
         parent_pid: admin_set&.ark_id,
         secondary_parent_pids: []
-      }.merge(local_id_params)) if administrative&.oai_header_id.blank?
+      }.merge(local_id_params)) if !oai_object?
 
       params = super.merge({
         parent_pid: admin_set&.ark_id,

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -56,12 +56,21 @@ module Curator
     after_commit :reindex_digital_objects, :reindex_collections
 
     def ark_params
-      super.except(:oai_namespace_id).merge({
+      return super.except(:oai_namespace_id).merge({
+        parent_pid: file_set_of&.ark_id,
+          secondary_parent_pids: [],
+          local_original_identifier_type: 'filename',
+          local_original_identifier: file_name_base
+      }) if !file_set_of&.oai_object?
+
+      params = super.merge({
         parent_pid: file_set_of&.ark_id,
           secondary_parent_pids: [],
           local_original_identifier_type: 'filename',
           local_original_identifier: file_name_base
       })
+      params[:namespace_id] = params.delete(:oai_namespace_id)
+      params
     end
 
     def avi_params

--- a/app/models/curator/metastreams/administrative.rb
+++ b/app/models/curator/metastreams/administrative.rb
@@ -22,6 +22,10 @@ module Curator
 
     scope :local_id_finder, -> (oai_header_id) { where.not(oai_header_id: nil).where(oai_header_id: oai_header_id) }
 
+    def oai_object?
+      oai_header_id?
+    end
+
     private
 
     def validate_destination_site

--- a/spec/models/curator/institution_spec.rb
+++ b/spec/models/curator/institution_spec.rb
@@ -13,7 +13,7 @@ require_relative './shared/filestreams/thumbnailable'
 RSpec.describe Curator::Institution, type: :model do
   subject { build(:curator_institution) }
 
-  it_behaves_like 'mintable'
+  it_behaves_like 'mintable', oai_specific: false
 
   describe 'Database' do
     it_behaves_like 'optimistic_lockable'

--- a/spec/models/curator/metastreams/administrative_spec.rb
+++ b/spec/models/curator/metastreams/administrative_spec.rb
@@ -59,6 +59,10 @@ RSpec.describe Curator::Metastreams::Administrative, type: :model do
                         backed_by_column_of_type(:integer) }
   end
 
+  describe 'Instance Methods' do
+    it { is_expected.to respond_to(:oai_object?) }
+  end
+
   describe 'Validations' do
     it { is_expected.to validate_uniqueness_of(:administratable_id).
                         scoped_to(:administratable_type) }

--- a/spec/models/curator/shared/filestreams/file_set.rb
+++ b/spec/models/curator/shared/filestreams/file_set.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples 'file_set', type: :model do
   describe 'Database' do
     it_behaves_like 'optimistic_lockable'
     it_behaves_like 'timestampable'
-    it_behaves_like 'mintable'
+    it_behaves_like 'mintable', oai_specific: true, oai_parent: true
     it_behaves_like 'archivable'
 
     it { is_expected.to have_db_column(:file_set_type).

--- a/spec/models/curator/shared/metastreamable.rb
+++ b/spec/models/curator/shared/metastreamable.rb
@@ -8,6 +8,7 @@ RSpec.shared_examples 'administratable', type: :model do
                       autosave(true) }
 
   it { is_expected.to validate_presence_of(:administrative) }
+  it { is_expected.to delegate_method(:oai_object?).to(:administrative).allow_nil }
 
   describe '#with_administrative' do
     subject { described_class }


### PR DESCRIPTION
- Added method alias for administrative if it has an `oai_header_id` and delegated that method at the object level

- Modified `ark_params` to handle using the `oai_namespace_id` on `file_sets` and `collections`.  Note file sets check if the `file_set_of` is an `oai_object`)

- Updated specs to test for `mintable` models 

- Resolves #175 