### PR TITLE
Resolved oai_header_id not being added on collections + Misc ark service/callback tweaks/fixes

### DIFF
--- a/app/callbacks/curator/mintable_callbacks.rb
+++ b/app/callbacks/curator/mintable_callbacks.rb
@@ -17,8 +17,19 @@ module Curator
 
     # TODO: Refactor factories and fixtures so we can actually test this
     def self.after_validation(mintable)
+      return if Rails.env.test?
+
       begin
-        return if Rails.env.test? || ark_exists?(mintable.ark_id)
+        # NOTE: The following block will cause validation on ark_id presence to fail normally
+        # but with addition of added logging.
+        if mintable.ark_id.blank?
+          Rails.logger.error '============================================================='
+          Rails.logger.error '====No ark response was received in previous callback!======='
+          Rails.logger.error '============================================================='
+          return
+        end
+
+        return if ark_exists?(mintable.ark_id)
 
         mintable_ark = mint_new_ark(mintable)
 

--- a/app/controllers/curator/collections_controller.rb
+++ b/app/controllers/curator/collections_controller.rb
@@ -38,7 +38,7 @@ module Curator
         params.require(:collection).permit(:ark_id, :created_at, :updated_at, :name, :abstract,
                                            institution: [:ark_id],
                                            metastreams: {
-                                             administrative: [:description_standard, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
+                                             administrative: [:oai_header_id, :description_standard, :hosting_status, :harvestable, :flagged, destination_site: [], access_edit_group: []],
                                                            workflow: [:ingest_origin, :publishing_state, :processing_state]
                                            })
       when 'update'

--- a/app/controllers/curator/metastreams/administratives_controller.rb
+++ b/app/controllers/curator/metastreams/administratives_controller.rb
@@ -32,7 +32,7 @@ module Curator
         when 'institution'
           params.require(:administrative).permit(destination_site: [], access_edit_group: [])
         when 'collection'
-          params.require(:administrative).permit(:harvestable, destination_site: [], access_edit_group: [])
+          params.require(:administrative).permit(:harvestable, :oai_header_id, destination_site: [], access_edit_group: [])
         when 'digital_object'
           params.require(:administrative).permit(:description_standard, :oai_header_id, :flagged, :harvestable, destination_site: [], access_edit_group: [])
         when 'audio', 'document', 'ereader', 'image', 'metadata', 'text', 'video'

--- a/app/services/concerns/curator/ark_service.rb
+++ b/app/services/concerns/curator/ark_service.rb
@@ -10,7 +10,7 @@ module Curator
       self.base_url = Curator.config.ark_manager_api_url
       self.default_path_prefix = '/api/v2'
       self.default_headers = { accept: 'application/json', content_type: 'application/json' }
-      self.timeout_options = { connect: 5, write: 5, read: 30 }
+      self.timeout_options = { connect: 5, write: 5, read: 60 }
     end
   end
 end

--- a/app/services/curator/collection_factory_service.rb
+++ b/app/services/curator/collection_factory_service.rb
@@ -25,7 +25,7 @@ module Curator
           end
 
           build_administrative(collection) do |administrative|
-            [:description_standard, :flagged, :destination_site, :harvestable, :hosting_status].each do |attr|
+            [:description_standard, :flagged, :destination_site, :harvestable, :oai_header_id, :hosting_status].each do |attr|
               administrative.send("#{attr}=", @admin_json_attrs.fetch(attr)) if @admin_json_attrs.fetch(attr, nil).present?
             end
           end

--- a/app/services/curator/metastreams/administrative_updater_service.rb
+++ b/app/services/curator/metastreams/administrative_updater_service.rb
@@ -10,7 +10,7 @@ module Curator
       access_edit_group_attrs = @json_attrs.fetch('access_edit_group', [])
       with_transaction do
         simple_attributes_update(SIMPLE_ATTRIBUTES_LIST) do |simple_attr|
-          @record.public_send("#{simple_attr}=", @json_attrs.fetch(simple_attr))
+          @record.public_send("#{simple_attr}=", @json_attrs.fetch(simple_attr)) if @json_attrs[simple_attr].presence
         end
 
         access_edit_group_attrs.each do |access_edit_group_attr|


### PR DESCRIPTION
-  Added oai_header_id as a writable attribute in collections controller/factory service
-  Added oai_header_id as writable attribute in administrative_updater_service/controller(when parent type is a collection)
-  Resolves #177 
-  Bumped read timeout on ark_manager
- Added clause to check if ark_id is blank in after_validation callback and log error message return so it fails on the presence validation.
