### PR TITLE
Bumped Timeouts in remote services

### DIFF
--- a/app/services/concerns/curator/ark_service.rb
+++ b/app/services/concerns/curator/ark_service.rb
@@ -10,7 +10,7 @@ module Curator
       self.base_url = Curator.config.ark_manager_api_url
       self.default_path_prefix = '/api/v2'
       self.default_headers = { accept: 'application/json', content_type: 'application/json' }
-      self.timeout_options = { connect: 5, write: 10, read: 60 }
+      self.timeout_options = { connect: 120, write: 120, read: 120 }
     end
   end
 end

--- a/app/services/curator/controlled_terms/authority_service.rb
+++ b/app/services/curator/controlled_terms/authority_service.rb
@@ -7,7 +7,7 @@ module Curator
     self.base_url = Curator.config.authority_api_url
     self.default_path_prefix = '/bpldc'
     self.default_headers = { accept: 'application/json', content_type: 'application/json' }
-    self.timeout_options = { connect: 5, write: 10, read: 60 }
+    self.timeout_options = { connect: 120, write: 120, read: 120 }
 
     attr_reader :request_uri
 

--- a/lib/curator/services/remote_service.rb
+++ b/lib/curator/services/remote_service.rb
@@ -42,8 +42,8 @@ module Curator
         #TODO will require Authorization options once login in system is set up
         included do
           class_attribute :base_url, instance_accessor: false
-          class_attribute :pool_options, instance_accessor: false, default: { size: ENV.fetch('RAILS_MAX_THREADS') { 5 }, timeout: 5 }
-          class_attribute :timeout_options, instance_accessor: false, default: { connect: 5, write: 5, read: 5 }
+          class_attribute :pool_options, instance_accessor: false, default: { size: ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i + 2, timeout: 60 }
+          class_attribute :timeout_options, instance_accessor: false, default: { connect: 10, write: 10, read: 10 }
           class_attribute :default_headers, instance_accessor: false, default: {}
           class_attribute :default_path_prefix, instance_accessor: false
           class_attribute :ssl_context, instance_accessor: false


### PR DESCRIPTION
- Gave each service a 120 second timeout on connect/read/write
- Gave the `connection_pool` a 60 second idel timeout(This corresponds to nginx keep alive settings)
- Added 2 to the pool size to give the `connection_pool` some additional buffer space