### PR TITLE
Resolves #184 - Timeouts not being applied to client correctly

### DIFF
--- a/app/services/concerns/curator/filestreams/attacher.rb
+++ b/app/services/concerns/curator/filestreams/attacher.rb
@@ -231,10 +231,10 @@ module Curator
           return if fedora_content_location.blank?
 
           http = Down::Http.new do |client|
-            client.timeout(connect: 120, write: 240, read: 540)
             # adding conditionals on fedora_content_location.match?(/FOXML/)
             # causes errors, so just use basic auth on everything
-            client.basic_auth(user: Curator.config.fedora_credentials[:fedora_username],
+            client.timeout(connect: 120, write: 240, read: 540)
+                  .basic_auth(user: Curator.config.fedora_credentials[:fedora_username],
                               pass: Curator.config.fedora_credentials[:fedora_password])
           end
           http.download(fedora_content_location)


### PR DESCRIPTION
Resolved the issue where the `Down::Http` client was using the default `read_timeout` which is 30 seconds.