### PR TITLE
add #touch_parent after_commit to :mark_complete

### DIFF
--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -56,7 +56,7 @@ module Curator
         transitions from: :initialized, to: :derivatives
       end
 
-      event :mark_complete, guards: [:is_processable?, :can_complete?] do
+      event :mark_complete, guards: [:is_processable?, :can_complete?], after_commit: :touch_parent do
         transitions from: :derivatives, to: :complete
       end
 
@@ -112,5 +112,9 @@ module Curator
     end
 
     alias regenerate_derivatives generate_derivatives
+
+    def touch_parent
+      workflowable.file_set_of.touch if workflowable_type == 'Curator::Filestreams::FileSet'
+    end
   end
 end

--- a/spec/models/curator/shared/filestreams/file_set.rb
+++ b/spec/models/curator/shared/filestreams/file_set.rb
@@ -83,5 +83,12 @@ RSpec.shared_examples 'file_set', type: :model do
         subject.save
       end
     end
+
+    describe 'reindex_collections' do
+      it 'runs the reindex_collections callback' do
+        expect(subject).to receive(:reindex_collections).at_least(:once)
+        subject.save
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds an after_commit directive to the `mark_complete` AASM event to update the parent DigitalObject of a completed FileSet.

Fixes #198.