### PR TITLE
Test rails 6 1 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ env:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
     - INGEST_SOURCE_DIRECTORY=/opt/ingest_source
   jobs:
-    - "RAILS_VERSION=6.1.4.4"
+    - "RAILS_VERSION=6.1.5"

--- a/app/services/concerns/curator/filestreams/attacher.rb
+++ b/app/services/concerns/curator/filestreams/attacher.rb
@@ -35,7 +35,7 @@ module Curator
               end
             end
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              Concurrent::Promises.zip(*attachment_futures).value!
+              Concurrent::Promises.zip(*attachment_futures).value! # NOTE: value! will propogate any errors raised to main thread
             end
           end
         end
@@ -65,7 +65,7 @@ module Curator
               record.public_send(attachment_type).attach(attachable)
             rescue Azure::Core::Http::HTTPError, Faraday::Error => e
               raise ActiveRecord::RecordNotSaved, "Could not attach files due to an Azure Http Error. Reason: #{e.message}"
-            rescue ActiveStorage::Error, ActiveRecord::RecordNotSaved => e
+            rescue StandardError
               raise
             end
 

--- a/app/services/concerns/curator/filestreams/attacher.rb
+++ b/app/services/concerns/curator/filestreams/attacher.rb
@@ -35,7 +35,7 @@ module Curator
               end
             end
             ActiveSupport::Dependencies.interlock.permit_concurrent_loads do
-              Concurrent::Promises.zip(*attachment_futures).wait!
+              Concurrent::Promises.zip(*attachment_futures).value!
             end
           end
         end
@@ -65,6 +65,8 @@ module Curator
               record.public_send(attachment_type).attach(attachable)
             rescue Azure::Core::Http::HTTPError, Faraday::Error => e
               raise ActiveRecord::RecordNotSaved, "Could not attach files due to an Azure Http Error. Reason: #{e.message}"
+            rescue ActiveStorage::Error, ActiveRecord::RecordNotSaved => e
+              raise
             end
 
             check_file_fixity!(record.public_send(attachment_type), attributes['byte_size'], attributes['checksum_md5'])

--- a/app/services/curator/filestreams/file_set_factory_service.rb
+++ b/app/services/curator/filestreams/file_set_factory_service.rb
@@ -9,6 +9,7 @@ module Curator
       super(json_data: json_data)
 
       @file_set_type = @json_attrs.fetch('file_set_type')
+      @purge_blobs_on_fail = true
     end
 
     def call

--- a/app/services/curator/institution_factory_service.rb
+++ b/app/services/curator/institution_factory_service.rb
@@ -6,6 +6,12 @@ module Curator
     include ControlledTerms::Locateable
     include Filestreams::Attacher
 
+    def initialize(json_data: {})
+      super(json_data: json_data)
+
+      @purge_blobs_on_fail = true
+    end
+
     def call
       location_json_attrs = @json_attrs.fetch('location', {}).with_indifferent_access
       with_transaction do

--- a/app/services/curator/institution_updater_service.rb
+++ b/app/services/curator/institution_updater_service.rb
@@ -8,6 +8,12 @@ module Curator
     include ControlledTerms::Locateable
     include Filestreams::Attacher
 
+    def initialize(record, json_data: {})
+      super(record, json_data: json_data)
+
+      @purge_blobs_on_fail = true
+    end
+
     def call
       location_json_attrs = @json_attrs.fetch('location', {}).with_indifferent_access
       host_collections_attributes = @json_attrs.fetch('host_collections_attributes', [])

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ox', '~> 2.14'
   spec.add_dependency 'paper_trail', '~> 11.1'
   spec.add_dependency 'paper_trail-association_tracking', '~> 2.1'
-  spec.add_dependency 'rails', '~> 6.1.4', '< 7'
+  spec.add_dependency 'rails', '~> 6.1.5', '< 7'
   spec.add_dependency 'rsolr', '~> 2.5'
   spec.add_dependency 'traject', '~> 3.6'
 

--- a/lib/curator/services/updater_service.rb
+++ b/lib/curator/services/updater_service.rb
@@ -24,6 +24,7 @@ module Curator
           # NOTE: Had to add #to_h for when :json_data is received through the controller as ActionController::Parameters
           @json_attrs = json_data.to_h.with_indifferent_access
           @ark_id = @json_attrs.fetch('ark_id', nil)
+          @purge_blobs_on_fail = false
         end
 
         private


### PR DESCRIPTION
- Ran specs against rails 6.1.5
- Added instance variable called `@purge_blobs_on_fail` and added it to applicable factory/updater services and made a method `purge_blobs_on_fail?`. This method is used to determine if the `  purge_unattached_files!` should be run in the ensure block of the`with_transaction` method. This will prevent a bug with curator accidentally destroying files in azure when an update received from the `avi_processor` fails.
- Fixed a couple bugs in `Attacher` concern by using `value!` instead of `wait!` after `zip!`-ing a the `attachment_futures` array. This propagates any errors raised up into the main thread according to the concurrent-ruby docs. Also added an additional rescue block to re raise any errors that inherit from `StandardError`. These two fixes should prevent a `PG::ForeignKeyViolation: ERROR` that started occurring after PR #221 