### PR TITLE
index MODS XML in Solr

### DIFF
--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -22,6 +22,9 @@ module Curator
       to_field 'contained_by_ssi', obj_extract('contained_by', 'ark_id')
       to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_sets.pluck(:file_name_base).uniq }
       each_record do |record, context|
+        serializer = Curator::DigitalObjectSerializer.new(record, adapter_key: :mods)
+        context.output_hash['mods_xml_ss'] = Base64.strict_encode64(Zlib::Deflate.deflate(serializer.serialize))
+
         if record.image_file_sets.present?
           has_searchable_pages, georeferenced = false, false
           record.image_file_sets.each do |image_file_set|

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -65,5 +65,16 @@ RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
         end
       end
     end
+
+    describe 'MODS XML indexing' do
+      let(:mods_xml) do
+        serializer = Curator::DigitalObjectSerializer.new(digital_object, adapter_key: :mods)
+        Base64.strict_encode64(Zlib::Deflate.deflate(serializer.serialize))
+      end
+
+      it 'sets the mods_xml field' do
+        expect(indexed['mods_xml_ss']).to eq mods_xml
+      end
+    end
   end
 end


### PR DESCRIPTION
Indexes data from `Metastreams::Descriptive` objects as MODS XML in Solr record as gzipped, base64-encoded string (fixes #233)