### PR TITLE
More mods fixes

### DIFF
--- a/app/decorators/curator/mappings/name_role_mods_decorator.rb
+++ b/app/decorators/curator/mappings/name_role_mods_decorator.rb
@@ -6,18 +6,18 @@ module Curator
 
     # This class wraps and delegates Curator::Mappings::NameRole objects to serialize/display <mods:name> elements and sub elements
 
-    # @param name_roles [Array[Curator::Mappings::NameRole]]
+    # @param name_roles [Array[Curator::Mappings::GroupedNameRoleModsPresenter]]
     # @returns [Array[Curator::Mappings::NameRoleModsDecorator]]
-    def self.wrap_multiple(name_roles = [])
-      name_roles.map(&method(:new))
+    def self.wrap_multiple(grouped_name_roles = [])
+      grouped_name_roles.map(&method(:new))
     end
 
     def name
       super if __getobj__.respond_to?(:name)
     end
 
-    def role
-      super if __getobj__.respond_to?(:role)
+    def roles
+      super if __getobj__.respond_to?(:roles)
     end
 
     # @return [String] - Used for <mods:name type=''> attribute value
@@ -54,16 +54,16 @@ module Curator
       name.affiliation
     end
 
-    # @return [Curator::Mappings::RoleTermModsPresenter | nil] - Used for <mods:role><mods:roleTerm> sub elements
-    def role_term
-      Mappings::RoleTermModsPresenter.new(role) if role.present?
+    # @return [Array[Curator::Mappings::RoleTermModsPresenter | nil]] - Used for <mods:role><mods:roleTerm> sub elements
+    def role_terms
+      Mappings::RoleTermModsPresenter.wrap_multiple(roles) if roles.present?
     end
 
     # @return [Boolean] - Needed for mods serializer
     def blank?
       return true if __getobj__.blank?
 
-      name.blank? && role.blank?
+      name.blank? && roles.blank?
     end
   end
 end

--- a/app/decorators/curator/metastreams/origin_info_mods_decorator.rb
+++ b/app/decorators/curator/metastreams/origin_info_mods_decorator.rb
@@ -10,6 +10,14 @@ module Curator
     ### desc = Curator.metastreams.descriptive_class.for_serialization.find_by(..)
     ### origin_info = Curator::Metastreams:OriginInfoModsDecorator.new(desc)
 
+    def event_type
+      return @event_type if defined?(@event_type)
+
+      return @event_type = nil if !__getobj__.respond_to?(:origin_event)
+
+      @event_type = __getobj__.origin_event
+    end
+
     def publication
       return @publication if defined?(@publication)
 
@@ -85,7 +93,7 @@ module Curator
     def blank?
       return true if __getobj__.blank?
 
-      publisher.blank? && publication.blank? && place.blank? && date.blank?
+      event_type.blank? && publisher.blank? && publication.blank? && place.blank? && date.blank?
     end
 
     # @return [String] - Used for determinining which date the keyDate attribute should be for

--- a/app/presenters/curator/descriptive_field_sets/cartographic_mods_presenter.rb
+++ b/app/presenters/curator/descriptive_field_sets/cartographic_mods_presenter.rb
@@ -29,9 +29,11 @@ module Curator
     end
 
     def coordinates
-      return [] if bounding_box.blank? && cartesian_coords.blank?
+      return if bounding_box.blank? && cartesian_coords.blank?
 
-      Array.wrap(bounding_box) + Array.wrap(cartesian_coords)
+      return bounding_box if bounding_box.present?
+
+      cartesian_coords
     end
 
     # @return [Boolean] - Needed for serializer

--- a/app/presenters/curator/descriptive_field_sets/language_of_cataloging_mods_presenter.rb
+++ b/app/presenters/curator/descriptive_field_sets/language_of_cataloging_mods_presenter.rb
@@ -3,7 +3,6 @@
 module Curator
   class DescriptiveFieldSets::LanguageOfCatalogingModsPresenter
     # This class is for serializing <mods:recordInfo><mods:LanguageOfCataloging> elements/attributes
-    DEFAULT_USAGE = 'primary'
     DEFAULT_LANG_TERM_ATTRS = {
       label: 'eng',
       type: 'code',
@@ -22,13 +21,11 @@ module Curator
     ## @returns [Struct:Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter::LanguageTerm] instance
     LanguageTerm = Struct.new(:label, :type, :authority, :authority_uri, :value_uri, keyword_init: true)
 
-    attr_reader :language_term, :usage
+    attr_reader :language_term
     # @param[optional] language_term_attrs [Hash[defaults to DEFAULT_LANG_TERM_ATTRS]]
-    # @param[optional] usage [String[defaults to DEFAULT_USAGE]]
     # @returns [Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter]
-    def initialize(language_term_attrs = DEFAULT_LANG_TERM_ATTRS, usage = DEFAULT_USAGE)
+    def initialize(language_term_attrs = DEFAULT_LANG_TERM_ATTRS)
       @language_term = LanguageTerm.new(**language_term_attrs)
-      @usage = usage
     end
   end
 end

--- a/app/presenters/curator/mappings/grouped_name_role_mods_presenter.rb
+++ b/app/presenters/curator/mappings/grouped_name_role_mods_presenter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Curator
+  class Mappings::GroupedNameRoleModsPresenter
+    # DESCRIPTION This presenter  class aides in grouping roles by a name for a desriptives's name_roles relation. It is also ...
+    ## ... a required param for the Curator::Mappings::NameRoleModsDecorator
+
+    # @param Hash[Curator::ControlledTerms::Name => Array[Curator::Mappings::DescNameRole]]
+    # @return Array[Curator::Mappings::GroupedNameRoleModsPresenter]
+    # USAGE:
+    ## obj = Curator.digital_object_class.for_serialization.find_by(...)
+    ## name_roles_group = obj.descriptive.name_roles.group_by(&:name)
+    ## grouped_name_roles = Curator::Mappings::GroupedNameRoleModsPresenter.wrap_multiple(name_roles_group)
+    ## decorated_mods_name_roles = Curator::Mappings::NameRoleModsDecorator.wrap_multiple(grouped_name_roles)
+    def self.wrap_multiple(grouped_name_roles = {})
+      return [] if grouped_name_roles.blank?
+
+      grouped_name_roles.inject([]) do |ret, (name, name_roles)|
+        ret << new(name, name_roles)
+      end
+    end
+
+    attr_reader :name, :roles
+
+    # @param name [Curator::ControlledTerms::Name]
+    # @param name_roles [Array[Curator::Mappings::DescNameRole]]
+    # @return [Curator::Mappings::GroupedNameRoleModsPresenter]
+    def initialize(name, name_roles = [])
+      @name = name
+      @roles = name_roles.map(&:role)
+    end
+  end
+end

--- a/app/presenters/curator/mappings/name_part_mods_presenter.rb
+++ b/app/presenters/curator/mappings/name_part_mods_presenter.rb
@@ -2,7 +2,7 @@
 
 module Curator
   class Mappings::NamePartModsPresenter
-    # For serializing <mods:name><mods:namePart> elements
+    # DESCRIPTION For serializing <mods:name><mods:namePart> elements
     # @param label [String]
     # @param[optional] is_date [Boolean]
     # @return [Curator::Mappings::RoleTermModsPresenter] instance

--- a/app/presenters/curator/mappings/role_term_mods_presenter.rb
+++ b/app/presenters/curator/mappings/role_term_mods_presenter.rb
@@ -4,6 +4,10 @@ module Curator
   class Mappings::RoleTermModsPresenter
     # For serializing <mods:role><mods:roleTerm> elements
 
+    def self.wrap_multiple(roles = [])
+      roles.map(&method(:new))
+    end
+
     attr_reader :role
 
     # @param role [Curator::ControlledTerms::Role]

--- a/app/serializers/concerns/curator/metastreams/descriptable_mods.rb
+++ b/app/serializers/concerns/curator/metastreams/descriptable_mods.rb
@@ -44,7 +44,7 @@ module Curator
 
           element :affiliation, target_val: :name_affiliation
 
-          node :role, target_obj: :role_term do
+          node :roles, multi_valued: true, target_obj: :role_terms do
             target_value_blank!
 
             node :roleTerm, target_obj: ->(rt) { rt } do
@@ -285,7 +285,10 @@ module Curator
         multi_node :identifier, target_obj: :identifier_list do
           target_value_as :label
 
-          attribute :type
+          attribute :type do |ident|
+            ident.type == 'videorecording' ? 'videorecording-identifier' : ident.type
+          end
+
           attribute :invalid do |ident|
             ident.invalid == true ? 'yes' : nil
           end
@@ -342,8 +345,6 @@ module Curator
           node :language_of_cataloging do
             target_value_blank!
 
-            attribute :usage
-
             node :language_term do
               target_value_as :label
 
@@ -377,7 +378,8 @@ module Curator
       end
 
       def name_role_list(desc)
-        Curator::Mappings::NameRoleModsDecorator.wrap_multiple(desc.name_roles)
+        grouped_name_roles = Curator::Mappings::GroupedNameRoleModsPresenter.wrap_multiple(desc.name_roles.group_by(&:name))
+        Curator::Mappings::NameRoleModsDecorator.wrap_multiple(grouped_name_roles)
       end
 
       def note_list(desc)

--- a/app/serializers/concerns/curator/metastreams/descriptable_mods.rb
+++ b/app/serializers/concerns/curator/metastreams/descriptable_mods.rb
@@ -76,6 +76,8 @@ module Curator
         node :origin_info do
           target_value_blank!
 
+          attribute :event_type
+
           node :place do
             target_value_blank!
 

--- a/spec/decorators/curator/mappings/name_role_mods_decorator_spec.rb
+++ b/spec/decorators/curator/mappings/name_role_mods_decorator_spec.rb
@@ -6,6 +6,7 @@ require_relative '../shared/name_partable'
 
 RSpec.describe Curator::Mappings::NameRoleModsDecorator, type: :decorators do
   let!(:name_roles) { create_list(:curator_mappings_desc_name_role, 3) }
+  let!(:grouped_name_roles) { Curator::Mappings::GroupedNameRoleModsPresenter.wrap_multiple(name_roles.group_by(&:name)) }
 
   describe 'Base Behavior' do
     it_behaves_like 'curator_decorator' do
@@ -26,10 +27,10 @@ RSpec.describe Curator::Mappings::NameRoleModsDecorator, type: :decorators do
   describe 'Decorator specific behavior' do
     subject { described_class.new(name_role) }
 
-    let!(:name_role) { name_roles.sample }
-    let!(:expected_blank_condition) { subject.name.blank? && subject.role.blank? }
+    let!(:name_role) { grouped_name_roles.sample }
+    let!(:expected_blank_condition) { subject.name.blank? && subject.roles.blank? }
 
-    it { is_expected.to respond_to(:name, :role, :name_type, :name_authority, :name_authority_uri, :name_affiliation, :name_value_uri, :role_term).with(0).arguments }
+    it { is_expected.to respond_to(:name, :roles, :name_type, :name_authority, :name_authority_uri, :name_affiliation, :name_value_uri, :role_terms).with(0).arguments }
 
     it 'is expected to return #blank? based on the :expected_blank_condition' do
       expect(subject.blank?).to eq(expected_blank_condition)
@@ -37,15 +38,14 @@ RSpec.describe Curator::Mappings::NameRoleModsDecorator, type: :decorators do
 
     it 'expects the decorator methods to return the correct values' do
       expect(subject.name).to be_an_instance_of(Curator::ControlledTerms::Name).and eql(name_role.name)
-      expect(subject.role).to be_an_instance_of(Curator::ControlledTerms::Role).and eql(name_role.role)
+      expect(subject.roles).to be_an_instance_of(Array).and all(be_an_instance_of(Curator::ControlledTerms::Role))
       expect(subject.name_type).to eql(name_role.name.name_type)
       expect(subject.name_authority).to eql(name_role.name.authority_code)
       expect(subject.name_value_uri).to eql(name_role.name.value_uri)
     end
 
     it 'expects the role_term to be a Curator::Mappings::RoleTermModsPresenter' do
-      expect(subject.role_term).to be_an_instance_of(Curator::Mappings::RoleTermModsPresenter)
-      expect(subject.role_term.role).to eql(name_role.role)
+      expect(subject.role_terms).to be_an_instance_of(Array).and all(be_an_instance_of(Curator::Mappings::RoleTermModsPresenter))
     end
   end
 end

--- a/spec/decorators/curator/metastreams/origin_info_mods_decorator_spec.rb
+++ b/spec/decorators/curator/metastreams/origin_info_mods_decorator_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Curator::Metastreams::OriginInfoModsDecorator, type: :decorators 
   describe 'Decorator Specific Behavior' do
     subject { described_class.new(descriptive) }
 
-    let!(:expected_blank_condition) { subject.publisher.blank? && subject.publication.blank? && subject.place.blank? && subject.date.blank? }
+    let!(:expected_blank_condition) { subject.event_type.blank? && subject.publisher.blank? && subject.publication.blank? && subject.place.blank? && subject.date.blank? }
 
-    it { is_expected.to respond_to(:publication, :edition, :publisher, :date, :place, :dates_inferred?, :date_created, :date_issued, :copyright_date, :issuance, :key_date_for).with(0).arguments }
+    it { is_expected.to respond_to(:publication, :event_type, :edition, :publisher, :date, :place, :dates_inferred?, :date_created, :date_issued, :copyright_date, :issuance, :key_date_for).with(0).arguments }
     it { is_expected.to respond_to(:is_key_date?).with(1).argument }
 
     it 'is expected to return #blank? based on the :expected_blank_condition' do

--- a/spec/presenters/curator/descriptive_field_sets/cartographic_mods_presenter_spec.rb
+++ b/spec/presenters/curator/descriptive_field_sets/cartographic_mods_presenter_spec.rb
@@ -34,10 +34,9 @@ RSpec.describe Curator::DescriptiveFieldSets::CartographicModsPresenter, type: :
         expect(subject.scale).to be(nil)
       end
 
-      it 'expects coordinates to return an array with #bounding_box and #cartesian_coords included' do
-        expect(subject.coordinates).to be_an_instance_of(Array)
-        expect(subject.coordinates).not_to be_empty
-        expect(subject.coordinates).to include(geographic.coordinates, geographic.bounding_box)
+      it 'expects coordinates to  be a String and return and eql bounding_box or cartesian_coords' do
+        expect(subject.coordinates).to be_an_instance_of(String)
+        expect(subject.coordinates).to eql(geographic.coordinates).or eql(geographic.bounding_box)
       end
     end
 
@@ -62,9 +61,8 @@ RSpec.describe Curator::DescriptiveFieldSets::CartographicModsPresenter, type: :
         expect(subject.area_type).to be(nil)
       end
 
-      it 'expects coordinates to return an empty array' do
-        expect(subject.coordinates).to be_an_instance_of(Array)
-        expect(subject.coordinates).to be_empty
+      it 'expects coordinates to be blank' do
+        expect(subject.coordinates).to be_blank
       end
     end
   end

--- a/spec/presenters/curator/descriptive_field_sets/language_of_cataloging_mods_presenter_spec.rb
+++ b/spec/presenters/curator/descriptive_field_sets/language_of_cataloging_mods_presenter_spec.rb
@@ -5,11 +5,10 @@ require 'rails_helper'
 RSpec.describe Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter, type: :presenters do
   subject { described_class }
 
-  specify { expect(subject).to be_const_defined(:DEFAULT_USAGE) }
   specify { expect(subject).to be_const_defined(:DEFAULT_LANG_TERM_ATTRS) }
   specify { expect(subject).to be_const_defined(:LanguageTerm) }
 
-  it { is_expected.to respond_to(:new).with(0..2).arguments }
+  it { is_expected.to respond_to(:new).with(0..1).arguments }
 
   describe Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter::LanguageTerm do
     subject { described_class }
@@ -50,13 +49,8 @@ RSpec.describe Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter,
     subject { described_class.new }
 
     let!(:default_lang_term_attrs) { described_class.const_get(:DEFAULT_LANG_TERM_ATTRS) }
-    let!(:default_usage) { described_class.const_get(:DEFAULT_USAGE) }
 
-    it { is_expected.to respond_to(:language_term, :usage).with(0).arguments }
-
-    it 'expects #usage to eql :DEFAULT_USAGE' do
-      expect(subject.usage).to eql(default_usage)
-    end
+    it { is_expected.to respond_to(:language_term).with(0).arguments }
 
     it 'expects #language_term to be a Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter::LanguageTerm' do
       expect(subject.language_term).to be_an_instance_of(Curator::DescriptiveFieldSets::LanguageOfCatalogingModsPresenter::LanguageTerm)

--- a/spec/presenters/curator/mappings/grouped_name_role_mods_presenter_spec.rb
+++ b/spec/presenters/curator/mappings/grouped_name_role_mods_presenter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Curator::Mappings::GroupedNameRoleModsPresenter, type: :presenters do
+  subject { described_class }
+
+  let!(:name_roles) { create_list(:curator_mappings_desc_name_role, 3) }
+  let!(:grouped_name_roles) { name_roles.group_by(&:name) }
+
+  it { is_expected.to respond_to(:new).with(1..2).arguments }
+  it { is_expected.to respond_to(:wrap_multiple).with(0..1).arguments }
+
+  describe '.wrap_multiple' do
+    subject { described_class.wrap_multiple(grouped_name_roles) }
+
+    it { is_expected.to be_an_instance_of(Array).and all(be_an_instance_of(described_class)) }
+  end
+
+  describe 'instance' do
+    subject { described_class.new(name, desc_name_roles) }
+
+    let!(:grouped_name_role) { grouped_name_roles.to_a.sample }
+    let!(:name) { grouped_name_role.first }
+    let!(:desc_name_roles) { grouped_name_role.last }
+    let!(:roles) { desc_name_roles.map(&:role) }
+
+    it { is_expected.to respond_to(:name, :roles).with(0).arguments }
+
+    it 'expects #name to be an instance of Curator::ControlledTerms::Name and equal :name' do
+      expect(subject.name).to be_an_instance_of(Curator::ControlledTerms::Name).and equal(name)
+    end
+
+    it 'expects roles to be an array of Curator::ControlledTerms::Role and match_array :roles' do
+      expect(subject.roles).to be_an_instance_of(Array).and all(be_an_instance_of(Curator::ControlledTerms::Role))
+      expect(subject.roles).to match_array(roles)
+    end
+  end
+end


### PR DESCRIPTION
- Added new presenter class to group `Curator::Metastreams::Descriptive#name_roles` by name to resolve #250 
- Added specs for new presenter class.
- Fixed issue with coordinates not displaying on `geographic` subjects to resolve #249 
- Added inline method to rename identifier `type` attribute from `videorecording` to `videorecording-identifier` in `descriptable_mods` concern to resolve #251 
- removed `usage` attribute in `language_of_cataloging` presenter and removed declaration in  `descriptable_mods` concern under the `language_of_cataloging` node to resolve #252 
- Modified all related specs to reflect new changes