### PR TITLE
Base64 attachment

### DIFF
--- a/app/controllers/curator/filestreams/file_sets_controller.rb
+++ b/app/controllers/curator/filestreams/file_sets_controller.rb
@@ -48,11 +48,14 @@ module Curator
                                              workflow: [:ingest_origin, :publishing_state, :processing_state]
                                           },
                                          files: [:key, :created_at, :file_name, :file_type, :content_type, :byte_size,
-                                                 :checksum_md5, io: [:ingest_filepath, :fedora_content_location], metadata: {}])
+                                                 :checksum_md5, metadata: {},
+                                                 io: [:ingest_filepath, :fedora_content_location, :base64_string]])
       when 'update'
         params.require(:file_set).permit(:position, pagination: [:page_label, :page_type, :hand_side],
                                          exemplary_image_of: [:ark_id, :_destroy],
-                                         files: [:key, :file_name, :file_type, :content_type, :byte_size, :checksum_md5, io: [:ingest_filepath, :fedora_content_location], metadata: {}])
+                                         files: [:key, :file_name, :file_type, :content_type, :byte_size, :checksum_md5,
+                                                 io: [:ingest_filepath, :fedora_content_location, :base64_string],
+                                                 metadata: {}])
       else
         params
       end

--- a/app/models/curator/filestreams/metadata.rb
+++ b/app/models/curator/filestreams/metadata.rb
@@ -19,15 +19,13 @@ module Curator
     after_update_commit :set_as_exemplary
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
-      if file_set_of.is_harvested?
-        super(%i(metadata_oai image_thumbnail_300))
-      else
-        required_derivatives.any? { |a| derivative_attachment_uploaded?(a) }
-      end
+      return super(%i(metadata_oai image_thumbnail_300)) if file_set_of.is_harvested?
+
+      required_derivatives.any? { |a| derivative_attachment_uploaded?(a) }
     end
 
     def set_as_exemplary
-      return unless image_thumbnail_300.attached? && file_set_of.exemplary_file_set.blank? && file_set_of.is_harvested?
+      return unless image_thumbnail_300.uploaded? && file_set_of.exemplary_file_set.blank? && file_set_of.is_harvested?
 
       exemplary_image_of_mappings.create(exemplary_object: file_set_of)
     end

--- a/app/models/curator/filestreams/metadata.rb
+++ b/app/models/curator/filestreams/metadata.rb
@@ -16,8 +16,20 @@ module Curator
 
     has_paper_trail
 
-    def derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
-      required_derivatives.any? { |a| derivative_attachment_uploaded?(a) }
+    after_update_commit :set_as_exemplary
+
+    def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
+      if file_set_of.is_harvested?
+        super(%i(metadata_oai image_thumbnail_300))
+      else
+        required_derivatives.any? { |a| derivative_attachment_uploaded?(a) }
+      end
+    end
+
+    def set_as_exemplary
+      return unless image_thumbnail_300.attached? && file_set_of.exemplary_file_set.blank? && file_set_of.is_harvested?
+
+      exemplary_image_of_mappings.create(exemplary_object: file_set_of)
     end
   end
 end

--- a/app/services/concerns/curator/filestreams/attacher.rb
+++ b/app/services/concerns/curator/filestreams/attacher.rb
@@ -101,6 +101,10 @@ module Curator
           io.dig('ingest_filepath').present?
         end
 
+        def base64_content?(io = {})
+          io.dig('base64_string').present?
+        end
+
         private
 
         # @param attachment_attributes [Hash]
@@ -195,6 +199,8 @@ module Curator
 
           return file_path_io(io_hash['ingest_filepath']) if ingest_content?(io_hash)
 
+          return base64_io(io_hash['base64_string']) if base64_content?(io_hash)
+
           raise ActiveRecord::RecordNotSaved, "Unknown content for io #{type}"
         end
 
@@ -269,6 +275,10 @@ module Curator
           else
             raise ActiveStorage::Error, "Unknown object class for uploaded file: #{uploaded_file.class}"
           end
+        end
+
+        def base64_io(base64_string)
+          StringIO.new(Base64.decode64(base64_string))
         end
       end
     end

--- a/spec/models/curator/filestreams/metadata_spec.rb
+++ b/spec/models/curator/filestreams/metadata_spec.rb
@@ -24,4 +24,26 @@ RSpec.describe Curator::Filestreams::Metadata, type: :model do
       let(:has_one_file_attachments) { %i(metadata_ia metadata_ia_scan metadata_marc_xml metadata_mods metadata_oai) }
     end
   end
+
+  describe '#required_derivatives_complete?' do
+    it 'expects :DEFAULT_REQUIRED_DERIVATIVES to be a defined constant' do
+      expect(described_class).to be_const_defined(:DEFAULT_REQUIRED_DERIVATIVES)
+    end
+
+    it 'is expected to respond_to #required_derivatives_complete?' do
+      expect(subject).to respond_to(:required_derivatives_complete?).with(1).argument
+      expect(subject).to_not be_required_derivatives_complete
+    end
+  end
+
+  describe 'Callbacks' do
+    describe '.after_update_commit' do
+      subject { create(:curator_filestreams_metadata) }
+
+      it 'runs #set_as_exemplary callback on :update' do
+        expect(subject).to receive(:set_as_exemplary).at_least(:once)
+        subject.touch
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Support Base64-encoded string in Filestreams::Attacher (#264)
* Add exemplary relationship to `Filestreams::Metadata` when image_thumbnail_300 attached (#265)
