### PR TITLE
resolves #268

### DIFF
--- a/app/models/curator/descriptive_field_sets.rb
+++ b/app/models/curator/descriptive_field_sets.rb
@@ -7,7 +7,7 @@ module Curator
     IDENTIFIER_TYPES = %w(local-accession local-other local-call local-barcode local-filename iiif-manifest internet-archive isbn ismn
                           isrc issn issue-number lccn matrix-number music-plate music-publisher sici uri videorecording uri-preview).freeze
 
-    NOTE_TYPES = ['date', 'language', 'acquisition', 'ownership', 'funding', 'biographical/historical',
+    NOTE_TYPES = ['date', 'lanlocalguage', 'acquisition', 'ownership', 'funding', 'biographical/historical',
                   'citation/reference', 'preferred citation', 'bibliography', 'exhibitions', 'publications',
                   'creation/production credits', 'performers', 'physical description', 'venue', 'arrangement',
                   'statement of responsibility'].freeze
@@ -20,7 +20,8 @@ module Curator
       'internet-archive' => 'barcode',
       'local-barcode' => 'barcode',
       'local-accession' => 'id_local-accession',
-      'local-other' => 'id_local-other'
+      'local-other' => 'id_local-other',
+      'lccn' => 'id_local-other'
     }.freeze
 
     RELATED_TYPES = {

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ox', ' ~> 2.14'
   spec.add_dependency 'paper_trail', '~> 11.1'
   spec.add_dependency 'paper_trail-association_tracking', '~> 2.1'
-  spec.add_dependency 'rails', '~> 6.1.6', '< 7'
+  spec.add_dependency 'rails', '~> 6.1.6.1', '< 7'
   spec.add_dependency 'rsolr', '~> 2.5'
   spec.add_dependency 'traject', '~> 3.7'
 


### PR DESCRIPTION
- Mapped `lccn` to `id_local-other` in `Curator::DescriptiveFieldSets::LOCAL_ORIGINAL_IDENTIFIER_TYPES` so arks can be minted for NDNP batch ingests.
- Capped rails version to recent stable(6.1.6.1) in gemspec for security patch