### PR TITLE
Enable Audio 

### DIFF
--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -105,8 +105,8 @@ module Curator
     def generate_derivatives
       return if workflowable_type != 'Curator::Filestreams::FileSet'
 
-      # Skip Audio and Metadata File Set types as they are not set up on the avi processor yet
-      return if %w(Audio Metadata).map { |fsc| "Curator::Filestreams::#{fsc}" }.include?(workflowable.class.name)
+      # Skip Metadata File Set types since they are processed via a different workflow
+      return if workflowable.class.name == 'Curator::Filestreams::Metadata'
 
       Curator::Filestreams::DerivativesJob.set(wait: 2.seconds).perform_later(workflowable_type, workflowable_id)
     end


### PR DESCRIPTION
- Changed clause in `Workflow#generate_derivatives` to allow Audio `file_sets` to be processed in the `avi_processor`
- Resolves #283