### PR TITLE
Fix 287

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,12 +23,12 @@ end
 group :development, :test do
   gem 'awesome_print', '~> 1.9'
   gem 'azure-storage-blob', '~> 2.0', require: false
-  gem 'dotenv-rails', '~> 2.7'
+  gem 'dotenv-rails', '~> 2.8'
   gem 'factory_bot_rails', '~> 6.2'
-  gem 'faker', '~> 2.19'
+  gem 'faker', '~> 2.22'
   gem 'pry', '~> 0.13.1'
   gem 'pry-rails'
-  gem 'puma', '~> 5.6.4'
+  gem 'puma', '~> 5.6.5'
   gem 'rubocop', '~> 0.75.1', require: false
   gem 'rubocop-performance', '~> 1.5', require: false
   gem 'rubocop-rails', '~> 2.4.2', require: false
@@ -41,6 +41,6 @@ group :test do
   gem 'database_cleaner-active_record', '~> 2'
   gem 'rspec-rails', '~> 5.1'
   gem 'shoulda-matchers', '~> 5.1'
-  gem 'vcr', '~> 6.0'
-  gem 'webmock', '~> 3.14'
+  gem 'vcr', '~> 6.1'
+  gem 'webmock', '~> 3.18'
 end

--- a/app/presenters/curator/mappings/name_part_mods_presenter.rb
+++ b/app/presenters/curator/mappings/name_part_mods_presenter.rb
@@ -9,7 +9,7 @@ module Curator
     attr_reader :label, :is_date
 
     def initialize(label, is_date = false)
-      @label = label
+      @label = label.to_s.encode('utf-8')
       @is_date = is_date
     end
 

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'aasm', '~> 5.3' # Acts as a state machine. Useful for tracking states of objects and triggering call backs between state trasnistion
-  spec.add_dependency 'activerecord-postgres_enum', '~> 1.7' # For using defined postgres enum types
+  spec.add_dependency 'activerecord-postgres_enum', '~> 1.7', '< 2.0' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
-  spec.add_dependency 'addressable', '>= 2.8.0'
+  spec.add_dependency 'addressable', '>= 2.8.1'
   spec.add_dependency 'after_commit_everywhere', '~> 1.2' # Required for using aasm with active record
   spec.add_dependency 'alba', '~> 1.6.0'
   spec.add_dependency 'attr_json', '~> 1.4.0'
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'down', '~> 5.3'
   spec.add_dependency 'htmlentities', '~> 4.3' # TODO: Look into replacing this since the last released in 2014. I recommend turning this into its own parser class.
   spec.add_dependency 'http', '~> 5.1'
-  spec.add_dependency 'mime-types', '~> 3.3'
+  spec.add_dependency 'mime-types', '~> 3.4'
   spec.add_dependency 'nokogiri', '>= 1.13.8'
   spec.add_dependency 'oj', '~> 3.13'
   spec.add_dependency 'ox', ' ~> 2.14'

--- a/lib/curator/parsers/input_parser.rb
+++ b/lib/curator/parsers/input_parser.rb
@@ -49,15 +49,20 @@ module Curator
         return [input_string] if !input_string.match?(Curator::Parsers::Constants::CORP_NAME_INPUT_MATCHER)
 
         name_parts_array = []
-        in_str = input_string
+        in_str = input_string.dup
 
-        while in_str =~ Curator::Parsers::Constants::CORP_NAME_INPUT_MATCHER
+        # Changed to use #match? rater than =~ since it retuns true/false rather than Integer/nil
+        while in_str.match?(Curator::Parsers::Constants::CORP_NAME_INPUT_MATCHER)
           snip = Curator::Parsers::Constants::CORP_NAME_INPUT_MATCHER.match(in_str).post_match
           sub_part = in_str.gsub(snip, '')
           name_parts_array << sub_part.gsub(/\.\z/, '').strip
           in_str = snip
         end
-
+        # Add the last part of the in_str(with rmoved periods and stripped whitespace) if it isn't already present in the name_parts_array
+        # Added this due to corporate names like "United States. Work Projects Administration" only returning [United States]
+        # This last part was missing from the original bplmodels code https://github.com/boston-library/bplmodels/blob/e780be71db82b8b39278973ff9015cc7df7208a9/lib/bplmodels/datastream_input_funcs.rb#L42
+        final_name_part = in_str.gsub(/\.\z/, '').strip
+        name_parts_array << final_name_part if final_name_part.present? && name_parts_array.exclude?(final_name_part)
         name_parts_array
       end
 

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -61,6 +61,19 @@
         "name_roles": [
           {
             "name": {
+                "label": "United States. Work Projects Administration",
+                "id_from_auth": "n80046793",
+                "authority_code": "naf",
+                "name_type": "corporate"
+            },
+            "role": {
+                "label": "Sponsor",
+                "id_from_auth": "spn",
+                "authority_code": "marcrelator"
+            }
+          },
+          {
+            "name": {
                 "label": "Catholic Church",
                 "name_type": "corporate",
                 "authority_code": "naf",

--- a/spec/fixtures/files/digital_object_2.json
+++ b/spec/fixtures/files/digital_object_2.json
@@ -37,7 +37,7 @@
           {
             "name": {
               "name_type": "corporate",
-              "label": "Fowler u0026 Downs"
+              "label": "Fowler \u0026 Downs"
             },
             "role": {
               "label": "Creator",
@@ -68,7 +68,7 @@
         ],
         "digital_origin": "reformatted_digital",
         "place_of_publication": "Boston",
-        "publisher": "Hughes u0026 Bailey,",
+        "publisher": "Hughes \u0026 Bailey,",
         "date": {
           "created": "1916"
         },
@@ -85,7 +85,7 @@
             "label": "Includes list of businesses and 46 illustrations of buildings."
           },
           {
-            "label": "Fowler u0026 Downs del.",
+            "label": "Fowler \u0026 Downs del.",
             "type": "statement of responsibility"
           }
         ],

--- a/spec/fixtures/files/digital_object_3.json
+++ b/spec/fixtures/files/digital_object_3.json
@@ -79,7 +79,7 @@
               "name_type": "corporate",
               "authority_code": "naf",
               "id_from_auth": "n50081706",
-              "label": "G.W. Bromley u0026 Co."
+              "label": "G.W. Bromley \u0026 Co."
             },
             "role": {
               "label": "Publisher",

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -36,7 +36,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/vcr'
   c.configure_rspec_metadata!
   c.hook_into :faraday, :webmock
-  # c.default_cassette_options = { record: :new_episodes }
+  c.default_cassette_options = { record: :new_episodes }
   c.ignore_request do |request|
     request.uri =~ /solr/
   end

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
           let(:json_names) { desc_json['name_roles'].map { |nr| nr['name'] } }
           let(:json_roles) { desc_json['name_roles'].map { |nr| nr['role'] } }
           it 'sets the correct number of names and roles' do
-            expect(name_roles.count).to eq 2
+            expect(name_roles.count).to be >= 2
           end
 
           it 'sets the name data' do

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
           let(:json_names) { desc_json['name_roles'].map { |nr| nr['name'] } }
           let(:json_roles) { desc_json['name_roles'].map { |nr| nr['role'] } }
           it 'sets the correct number of names and roles' do
-            expect(name_roles.count).to be >= 2
+            expect(name_roles.count).to eq 3
           end
 
           it 'sets the name data' do


### PR DESCRIPTION
- Fixed bug in `Curator::Parsers::InputParser.corp_name_part_splitter` 
- Fixes #287
- Updated some gem dependencies
- Added forward slash to unicode characters in fixtures to ensure they encode properly
- Updated specs