### PR TITLE
Fix image service params

### DIFF
--- a/app/models/curator/filestreams/image.rb
+++ b/app/models/curator/filestreams/image.rb
@@ -41,18 +41,18 @@ module Curator
       payload = super
       payload[:file_stream][:original_ingest_file_path] = derivative_source.metadata['ingest_filepath']
       if derivative_source.name == 'image_primary' && image_service.uploaded?
-        payload[:file_stream][:image_primary_data] = {
-          derivatives: {
-            id: image_service.key,
-            storage: "#{image_service.service_name}_store",
-            metadata: {
-              filename: image_service.filename.to_s,
-              md5: image_service.checksum,
-              size: image_service.byte_size,
-              mime_type: image_service.content_type
-            }
+        image_primary_data = { derivatives: {} }
+        image_primary_data[:derivatives][:image_service] = {
+          id: image_service.key,
+          storage: "#{image_service.service_name}_store",
+          metadata: {
+            filename: image_service.filename.to_s,
+            md5: image_service.checksum,
+            size: image_service.byte_size,
+            mime_type: image_service.content_type
           }
         }
+        payload[:file_streams][:image_primary_data] = image_primary_data
       end
 
       return payload if !text_coordinates_primary.uploaded?


### PR DESCRIPTION
- Fixed `avi_params` request payload format if image has `image_service` and image primary attached

- Fixes #302