### PR TITLE
Ruby 2.7 upgrade

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Gemspec/OrderedDependencies:
   Enabled: true
 
 ####################### LAYOUT ###############################
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
 Layout/BlockAlignment:
@@ -37,7 +37,7 @@ Layout/CaseIndentation:
 Layout/CommentIndentation:
   Enabled: true
 
-Layout/AlignArguments:
+Layout/ArgumentAlignment:
   Enabled: true
 
 Layout/ClosingParenthesisIndentation:
@@ -76,7 +76,7 @@ Layout/EndAlignment:
 Layout/ExtraSpacing:
   Enabled: true
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   Enabled: true
   EnforcedStyle: consistent
 
@@ -86,11 +86,15 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Enabled: true
 
-Layout/LeadingBlankLines:
+Layout/LeadingEmptyLines:
   Enabled: true
 
 Layout/LeadingCommentSpace:
   Enabled: true
+
+Layout/LineLength:
+  Enabled: true
+  Max: 500
 
 Layout/MultilineArrayBraceLayout:
   Enabled: true
@@ -157,7 +161,7 @@ Lint/DuplicateCaseCondition:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -194,7 +198,7 @@ Lint/FloatOutOfRange:
 Lint/FormatParameterMismatch:
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: true
 
 Lint/ImplicitStringConcatenation:
@@ -215,7 +219,7 @@ Lint/LiteralInInterpolation:
 Lint/Loop:
   Enabled: true
 
-Lint/MultipleCompare:
+Lint/MultipleComparison:
   Enabled: true
 
 Lint/NestedMethodDefinition:
@@ -254,7 +258,7 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:
@@ -263,7 +267,7 @@ Lint/UnderscorePrefixedVariableName:
 Lint/UnifiedInteger:
   Enabled: true
 
-Lint/UnneededSplatExpansion:
+Lint/RedundantSplatExpansion:
   Enabled: true
 
 Lint/UnusedMethodArgument:
@@ -411,7 +415,7 @@ Style/SymbolArray:
 Style/WordArray:
   Enabled: false
 
-Style/UnneededInterpolation:
+Style/RedundantInterpolation:
   Enabled: true
 
 ####################### METRICS ###############################
@@ -439,10 +443,6 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Enabled: true
   Max: 100
-
-Metrics/LineLength:
-  Enabled: true
-  Max: 500
 
 ####################### SECURITY ###############################
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - 'app/services/curator/filestreams/file_factory_service.rb'
   DisplayCopNames: true
   DisabledByDefault: true
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 ####################### BUNDLER/GEMSPEC ###############################
 Bundler/OrderedGems:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - bundle exec rails app:curator:setup
 
 rvm:
-  - 2.6.10
+  - 2.7.6
 
 env:
   global:

--- a/Gemfile
+++ b/Gemfile
@@ -22,16 +22,16 @@ end
 
 group :development, :test do
   gem 'awesome_print', '~> 1.9'
-  gem 'azure-storage-blob', '~> 2.0', require: false
+  gem 'azure-storage-blob', '>= 2.0', require: false
   gem 'dotenv-rails', '~> 2.8'
   gem 'factory_bot_rails', '~> 6.2'
   gem 'faker', '~> 2.22'
   gem 'pry', '~> 0.13.1'
   gem 'pry-rails'
-  gem 'puma', '~> 5.6.5'
-  gem 'rubocop', '~> 0.75.1', require: false
-  gem 'rubocop-performance', '~> 1.5', require: false
-  gem 'rubocop-rails', '~> 2.4.2', require: false
+  gem 'puma', '~> 5.6.5', '< 6'
+  gem 'rubocop', '~> 0.80.1', require: false
+  gem 'rubocop-performance', '~> 1.6', require: false
+  gem 'rubocop-rails', '~> 2.5', require: false
   gem 'rubocop-rspec', require: false
 end
 

--- a/app/models/curator/filestreams/image.rb
+++ b/app/models/curator/filestreams/image.rb
@@ -40,6 +40,21 @@ module Curator
 
       payload = super
       payload[:file_stream][:original_ingest_file_path] = derivative_source.metadata['ingest_filepath']
+      if derivative_source.name == 'image_primary' && image_service.uploaded?
+        payload[:file_stream][:image_primary_data] = {
+          derivatives: {
+            id: image_service.key,
+            storage: "#{image_service.service_name}_store",
+            metadata: {
+              filename: image_service.filename.to_s,
+              md5: image_service.checksum,
+              size: image_service.byte_size,
+              mime_type: image_service.content_type
+            }
+          }
+        }
+      end
+
       return payload if !text_coordinates_primary.uploaded?
 
       payload[:file_stream][:mets_alto_stream_attributes] = { original_ingest_file_path: text_coordinates_primary.metadata['ingest_filepath'] }

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Description of Curator.'
   spec.license     = 'MIT'
 
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.7'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
@@ -34,8 +34,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activerecord-postgres_enum', '~> 1.7', '< 2.0' # For using defined postgres enum types
   spec.add_dependency 'acts_as_list', '~> 1.0'
   spec.add_dependency 'addressable', '>= 2.8.1'
-  spec.add_dependency 'after_commit_everywhere', '~> 1.2' # Required for using aasm with active record
-  spec.add_dependency 'alba', '~> 1.6.0'
+  spec.add_dependency 'after_commit_everywhere', '~> 1.3' # Required for using aasm with active record
+  spec.add_dependency 'alba', '~> 1.6.0', '< 2'
   spec.add_dependency 'attr_json', '~> 1.4.0'
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.1'
   spec.add_dependency 'connection_pool', '~> 2.3'
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'image_processing', '~> 1.12'
   spec.add_development_dependency 'mini_magick', '~> 4.11'
-  spec.add_development_dependency 'pg', '~> 1.4'
-  spec.add_development_dependency 'redis', '~> 4.7'
+  spec.add_development_dependency 'pg', '>= 0.18', '< 2.0'
+  spec.add_development_dependency 'redis', '~> 4.7', '< 5'
   spec.add_development_dependency 'solr_wrapper', '~> 4'
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       net.core.somaxconn: 1024
   azure:
     container_name: curator_azure
-    image: mcr.microsoft.com/azure-storage/azurite:3.14.3
+    image: mcr.microsoft.com/azure-storage/azurite:3.20.1
     command: "azurite-blob --blobHost 0.0.0.0 --blobPort 8888 -l /var/lib/azurite/data -d /opt/azurite/debug.log --loose --skipApiVersionCheck"
     restart: always
     volumes:

--- a/lib/curator/version.rb
+++ b/lib/curator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Curator
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end


### PR DESCRIPTION
- Updated `required_ruby_version` to be `>= 2.7`
- Updated `rubocop*` gems and fixed errors
- Updated and capped versions for all other gems
- Ran and retested all specs
- Updated curator version to 0.2.0
NOTE: This will break existing jenkins builds. So I will need to manually update `curator_app`.