### PR TITLE
Update ruby-277

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - bundle exec rails app:curator:setup
 
 rvm:
-  - 2.7.6
+  - 2.7.7
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Currently all data models have been created with basic routes and json serialize
     * `Postgresql ~9.6(v 12 stable is recommended)`
     * `Redis`
     * `Imagemagick`
-    * `Ruby  >= 2.6.10`
+    * `Ruby  >= 2.7`
     * [Docker](https://docs.docker.com/)
 
 2. Clone Project

--- a/app/models/curator/controlled_terms/authority.rb
+++ b/app/models/curator/controlled_terms/authority.rb
@@ -18,7 +18,7 @@ module Curator
       has_many :subjects, class_name: 'Curator::ControlledTerms::Subject'
     end
 
-    has_paper_trail
+    has_paper_trail ignore: %i(lock_version)
 
     # code below for fetching canonical name is deprecated
     # authorities are pre-loaded using db/seeds.rb with data from BPLDC Authority API

--- a/app/models/curator/controlled_terms/nomenclature.rb
+++ b/app/models/curator/controlled_terms/nomenclature.rb
@@ -14,6 +14,6 @@ module Curator
 
     validates :type, presence: true, inclusion: { in: ControlledTerms.nomenclature_types.collect { |type| "Curator::ControlledTerms::#{type}" } }
 
-    has_paper_trail
+    has_paper_trail ignore: %i(lock_version)
   end
 end

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -9,7 +9,7 @@ module Curator
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
 

--- a/app/models/curator/filestreams/audio.rb
+++ b/app/models/curator/filestreams/audio.rb
@@ -17,7 +17,7 @@ module Curator
       has_one_attached :text_plain
     end
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       return super(required_derivatives.dup.delete_if { |el| el == derivative_source.name.to_sym }) if required_derivatives.include?(derivative_source&.name&.to_sym)

--- a/app/models/curator/filestreams/document.rb
+++ b/app/models/curator/filestreams/document.rb
@@ -15,7 +15,7 @@ module Curator
       has_one_attached :text_plain
     end
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       return super(required_derivatives.dup.delete_if { |el| el == :document_access }) if derivative_source.present? && text_plain.attached?

--- a/app/models/curator/filestreams/ereader.rb
+++ b/app/models/curator/filestreams/ereader.rb
@@ -14,7 +14,7 @@ module Curator
       has_one_attached :ebook_access_daisy
     end
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       super(required_derivatives)

--- a/app/models/curator/filestreams/image.rb
+++ b/app/models/curator/filestreams/image.rb
@@ -24,7 +24,7 @@ module Curator
     after_destroy_commit :invalidate_iiif_cache
     after_update_commit :invalidate_iiif_manifest, if: :saved_change_to_position?
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       # return super without image service if image_service if the derivative_source

--- a/app/models/curator/filestreams/metadata.rb
+++ b/app/models/curator/filestreams/metadata.rb
@@ -14,7 +14,7 @@ module Curator
     has_one_attached :metadata_mods
     has_one_attached :metadata_oai
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     after_update_commit :set_as_exemplary
 

--- a/app/models/curator/filestreams/text.rb
+++ b/app/models/curator/filestreams/text.rb
@@ -9,7 +9,7 @@ module Curator
     has_one_attached :text_plain, service: :derivatives
     has_one_attached :text_coordinates_primary
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       super(required_derivatives)

--- a/app/models/curator/filestreams/video.rb
+++ b/app/models/curator/filestreams/video.rb
@@ -18,7 +18,7 @@ module Curator
       has_one_attached :video_access_webm
     end
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     def required_derivatives_complete?(required_derivatives = DEFAULT_REQUIRED_DERIVATIVES)
       return super(required_derivatives.dup.delete_if { |el| el == derivative_source.name.to_sym }) if required_derivatives.include?(derivative_source&.name&.to_sym)

--- a/app/models/curator/metastreams/administrative.rb
+++ b/app/models/curator/metastreams/administrative.rb
@@ -19,7 +19,7 @@ module Curator
 
     validate :validate_destination_site
 
-    has_paper_trail if: proc { |a| [Curator.digital_object_class.name, Curator::Filestreams::FileSet.name].include?(a.administratable_type) }
+    has_paper_trail skip: %i(lock_version), if: proc { |a| [Curator.digital_object_class.name, Curator::Filestreams::FileSet.name].include?(a.administratable_type) }
 
     scope :local_id_finder, -> (oai_header_id) { where.not(oai_header_id: nil).where(oai_header_id: oai_header_id) }
 

--- a/app/models/curator/metastreams/descriptive.rb
+++ b/app/models/curator/metastreams/descriptive.rb
@@ -7,7 +7,7 @@ module Curator
     include AttrJson::Record::Dirty
     include AttrJson::NestedAttributes
 
-    has_paper_trail
+    has_paper_trail skip: %i(lock_version)
 
     enum digital_origin: {
       born_digital: 'born_digital',

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -65,7 +65,7 @@ module Curator
       end
     end
 
-    has_paper_trail if: proc { |w| w.is_processable? }
+    has_paper_trail skip: %i(lock_version), if: proc { |w| w.is_processable? }
 
     ## START GUARD CLAUSES
     def is_processable?

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -46,8 +46,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'nokogiri', '>= 1.13.8'
   spec.add_dependency 'oj', '~> 3.13'
   spec.add_dependency 'ox', ' ~> 2.14'
-  spec.add_dependency 'paper_trail', '~> 11.1'
-  spec.add_dependency 'paper_trail-association_tracking', '~> 2.1'
+  spec.add_dependency 'paper_trail', '~> 12.3'
+  spec.add_dependency 'paper_trail-association_tracking', '~> 2.2'
   spec.add_dependency 'rails', '~> 6.1.7', '< 7'
   spec.add_dependency 'rsolr', '~> 2.5'
   spec.add_dependency 'traject', '~> 3.7'
@@ -55,6 +55,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'image_processing', '~> 1.12'
   spec.add_development_dependency 'mini_magick', '~> 4.11'
   spec.add_development_dependency 'pg', '>= 0.18', '< 2.0'
-  spec.add_development_dependency 'redis', '~> 4.7', '< 5'
+  spec.add_development_dependency 'redis', '~> 4.8', '< 5'
   spec.add_development_dependency 'solr_wrapper', '~> 4'
 end

--- a/lib/curator/engine.rb
+++ b/lib/curator/engine.rb
@@ -56,6 +56,7 @@ module Curator
 
     config.before_initialize do
       Alba.backend = :oj_rails
+      PaperTrail.config.version_limit = 5
       PaperTrail.config.track_associations = true
       PaperTrail.config.has_paper_trail_defaults = { on: %i(update destroy touch) }
       Curator.setup!


### PR DESCRIPTION
- Updated and tested app against latest ruby 2.7 version
- Updated additional gems
- Updated `paper-trail` and `paper_trail-association_tracking` gems 
- Prevent `paper_trail` from tracking `lock_version` column(See note below)
- Added version limits to `paper_trail` config

## NOTE:
We should run the following script once deployed to update the versions and remove the `lock_version` column manually

```
PaperTrail::Version.transaction do
  PaperTrail::Version.find_each do |ptv|

    next unless (ptv.object.present? && ptv.object.key?('lock_version')) || (ptv.object_changes.present? && ptv.object_changes.key?('lock_version'))

    ptv.object = ptv.object.dup.except('lock_version') if ptv.object.present?
    ptv.object_changes = ptv.object_changes.dup.except('lock_version') if ptv.object_changes.present?
    ptv.save!
  end
end
```
