### PR TITLE
Resolve 316

### DIFF
--- a/app/controllers/concerns/curator/descriptive_params.rb
+++ b/app/controllers/concerns/curator/descriptive_params.rb
@@ -11,7 +11,7 @@ module Curator
     module ParamsPermitHelpers
       private
 
-      REMOVABLE_TERMS = [:genres, :languages, :name_roles, :resource_types].freeze
+      REMOVABLE_TERMS = [:genres, :languages, :name_roles, :resource_types, :host_collections].freeze
 
       REMOVABLE_SUBJECT_TERMS = [:topics, :names, :geos].freeze
 
@@ -37,7 +37,7 @@ module Curator
         :toc_url,
         cartographic: [:projection, scale: []],
         date: [:created, :issued, :copyright],
-        host_collections: [],
+        host_collections: [:name],
         identifier: [:label, :type, :invalid],
         genres: [:label, :id_from_auth, :authority_code, :basic],
         languages: [:label, :id_from_auth, :authority_code],

--- a/app/services/concerns/curator/mappings/find_or_create_host_collection.rb
+++ b/app/services/concerns/curator/mappings/find_or_create_host_collection.rb
@@ -9,12 +9,31 @@ module Curator
     end
 
     module InstanceMethods
-      private
+      protected
 
+      # @param host_col_name [String]
+      # @param institution [Curator::Institution]
+      # @return [Curator::Mappings::HostCollection]
       def find_or_create_host_collection(host_col_name = nil, institution = nil)
         return if host_col_name.blank? || institution.blank?
 
-        institution.host_collections.name_lower(host_col_name).first || institution.host_collections.create!(name: host_col_name)
+        find_host_collection(host_col_name, institution) || create_host_collection!(host_col_name, institution)
+      end
+
+      private
+
+      # @param host_col_name [String]
+      # @param institution [Curator::Institution]
+      # @return [Curator::Mappings::HostCollection | NilClass]
+      def find_host_collection(host_col_name, institution)
+        institution.host_collections.name_lower(host_col_name).first
+      end
+
+      # @param host_col_name [String]
+      # @param institution [Curator::Institution]
+      # @return [Curator::Mappings::HostCollection]
+      def create_host_collection!(host_col_name, institution)
+        institution.host_collections.create!(name: host_col_name)
       end
     end
   end

--- a/lib/curator/engine.rb
+++ b/lib/curator/engine.rb
@@ -78,21 +78,23 @@ module Curator
       Mime::Type.register 'application/mods+xml', :mods
     end
 
-    initializer 'curator.active_storage_table_names' do
-      ActiveStorage::Attached::One.send(:include, Curator::ActiveStorageExtensions::AttachedOneUploaded)
+    initializer 'curator.active_storage_table_names' do |app|
+      app.reloader.to_prepare do
+        ActiveStorage::Attached::One.send(:include, Curator::ActiveStorageExtensions::AttachedOneUploaded)
 
-      ActiveSupport.on_load(:active_storage_record) do
-        ActiveStorage::VariantRecord.table_name = 'curator.active_storage_variant_records'
-      end
+        ActiveSupport.on_load(:active_storage_record) do
+          ActiveStorage::VariantRecord.table_name = 'curator.active_storage_variant_records'
+        end
 
-      ActiveSupport.on_load(:active_storage_blob) do
-        self.table_name = 'curator.active_storage_blobs'
-        include Curator::ActiveStorageExtensions::BlobUploaded
-      end
+        ActiveSupport.on_load(:active_storage_blob) do
+          self.table_name = 'curator.active_storage_blobs'
+          include Curator::ActiveStorageExtensions::BlobUploaded
+        end
 
-      ActiveSupport.on_load(:active_storage_attachment) do
-        self.table_name = 'curator.active_storage_attachments'
-        include Curator::ActiveStorageExtensions::AttachmentUploaded
+        ActiveSupport.on_load(:active_storage_attachment) do
+          self.table_name = 'curator.active_storage_attachments'
+          include Curator::ActiveStorageExtensions::AttachmentUploaded
+        end
       end
     end
 

--- a/spec/fixtures/files/digital_object.json
+++ b/spec/fixtures/files/digital_object.json
@@ -268,8 +268,8 @@
           "projection": "azimuthal equal-area proj."
         },
         "host_collections": [
-          "Medieval and Early Renaissance Manuscripts (Collection of Distinction)",
-          "Colonial and Revolutionary Boston"
+          { "name": "Medieval and Early Renaissance Manuscripts (Collection of Distinction)" },
+          { "name": "Colonial and Revolutionary Boston" }
         ],
         "series": "Series value the first",
         "subseries": "Subseries value",

--- a/spec/fixtures/files/digital_object_2.json
+++ b/spec/fixtures/files/digital_object_2.json
@@ -116,7 +116,7 @@
           ]
         },
         "host_collections": [
-          "Norman B. Leventhal Map Center Collection"
+          { "name": "Norman B. Leventhal Map Center Collection" }
         ],
         "physical_location": {
           "label": "Boston Public Library",

--- a/spec/fixtures/files/digital_object_3.json
+++ b/spec/fixtures/files/digital_object_3.json
@@ -162,7 +162,7 @@
           ]
         },
         "host_collections": [
-          "Norman B. Leventhal Map Center Collection"
+          { "name": "Norman B. Leventhal Map Center Collection" }
         ],
         "physical_location": {
           "label": "Boston Public Library",

--- a/spec/fixtures/files/digital_object_4.json
+++ b/spec/fixtures/files/digital_object_4.json
@@ -126,7 +126,7 @@
           ]
         },
         "host_collections": [
-          "Tallulah Morgan et al. vs James W. Hennigan et al. Case File, 1972 - 1995"
+          { "name": "Tallulah Morgan et al. vs James W. Hennigan et al. Case File, 1972 - 1995" }
         ],
         "physical_location": {
           "label": "National Archives at Boston",

--- a/spec/services/curator/digital_object_factory_service_spec.rb
+++ b/spec/services/curator/digital_object_factory_service_spec.rb
@@ -249,10 +249,12 @@ RSpec.describe Curator::DigitalObjectFactoryService, type: :service do
 
         describe 'host_collections' do
           let(:host_collections) { descriptive.host_collections }
+          let(:host_collection_attributes) { host_collections.map { |hc| { 'name' => hc.name } } }
+
           it 'sets the host_collection data' do
             expect(host_collections.count).to eq 2
             expect(host_collections).to all(be_an_instance_of(Curator::Mappings::HostCollection))
-            expect(host_collections.pluck(:name)).to contain_exactly(*desc_json['host_collections'])
+            expect(host_collection_attributes).to contain_exactly(*desc_json['host_collections'])
           end
         end
 


### PR DESCRIPTION
- Updated, `descriptive_updater_service` to allow host collections to be destroyed
- Updated `descriptive_params` concern to allow `:name` and `:_destroy` flag for `host_collections`
- Updated all related specs and fixtures  
- Resolves #316
- Wrap loading active storage extensions in `app.reloader.to_prepare` block
- Resolves #310
- Some misc code tweaking and housekeeping