### PR TITLE
Fix find nomenclature for geo 325

### DIFF
--- a/app/models/concerns/curator/controlled_terms/id_from_auth_unique_validatable.rb
+++ b/app/models/concerns/curator/controlled_terms/id_from_auth_unique_validatable.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Curator
+  module ControlledTerms
+    module IdFromAuthUniqueValidatable
+      extend ActiveSupport::Concern
+
+      included do
+        validates_with Curator::ControlledTerms::IdFromAuthUniquenessValidator, on: :create
+      end
+    end
+  end
+end

--- a/app/models/curator/controlled_terms/genre.rb
+++ b/app/models/curator/controlled_terms/genre.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
 
     belongs_to :authority, inverse_of: :genres, class_name: 'Curator::ControlledTerms::Authority', optional: true

--- a/app/models/curator/controlled_terms/geographic.rb
+++ b/app/models/curator/controlled_terms/geographic.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
 
     belongs_to :authority, inverse_of: :geographics, class_name: 'Curator::ControlledTerms::Authority', optional: true

--- a/app/models/curator/controlled_terms/language.rb
+++ b/app/models/curator/controlled_terms/language.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::Language < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :languages, class_name: 'Curator::ControlledTerms::Authority'
 

--- a/app/models/curator/controlled_terms/name.rb
+++ b/app/models/curator/controlled_terms/name.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
 
     VALID_NAME_TYPES = %w(personal corporate conference family).freeze

--- a/app/models/curator/controlled_terms/resource_type.rb
+++ b/app/models/curator/controlled_terms/resource_type.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::ResourceType < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :resource_types, class_name: 'Curator::ControlledTerms::Authority'
 

--- a/app/models/curator/controlled_terms/role.rb
+++ b/app/models/curator/controlled_terms/role.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::Role < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :roles, class_name: 'Curator::ControlledTerms::Authority'
 

--- a/app/models/curator/controlled_terms/subject.rb
+++ b/app/models/curator/controlled_terms/subject.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :subjects, class_name: 'Curator::ControlledTerms::Authority', optional: true
 

--- a/app/validators/curator/controlled_terms/id_from_auth_uniqueness_validator.rb
+++ b/app/validators/curator/controlled_terms/id_from_auth_uniqueness_validator.rb
@@ -2,16 +2,18 @@
 
 module Curator
   class ControlledTerms::IdFromAuthUniquenessValidator < ActiveModel::Validator
+    # @param[required] record [Curator::ControlledTerms::Nomenclature]
     def validate(record)
       return if record.id_from_auth.blank? || record.authority.blank?
 
-      record.errors.add(:id_from_auth, "id_from_auth #{record.id_from_auth} has alredy been taken!") if id_from_auth_exists?(record)
+      record.errors.add(:id_from_auth, "#{record.id_from_auth} has already been taken for #{record.class}!") if id_from_auth_exists?(record)
     end
 
     private
 
+    # @param[required] record [Curator::ControlledTerms::Nomenclature]
     def id_from_auth_exists?(record)
-      record.class.where(authority: record.authority).where("controlled_terms_nomenclatures.term_data->>'id_from_auth' = ?", record.id_from_auth).count > 1
+      record.class.where(authority: record.authority).where("controlled_terms_nomenclatures.term_data->>'id_from_auth' = ?", record.id_from_auth).exists?
     end
   end
 end

--- a/app/validators/curator/controlled_terms/id_from_auth_uniqueness_validator.rb
+++ b/app/validators/curator/controlled_terms/id_from_auth_uniqueness_validator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Curator
+  class ControlledTerms::IdFromAuthUniquenessValidator < ActiveModel::Validator
+    def validate(record)
+      return if record.id_from_auth.blank? || record.authority.blank?
+
+      record.errors.add(:id_from_auth, "id_from_auth #{record.id_from_auth} has alredy been taken!") if id_from_auth_exists?(record)
+    end
+
+    private
+
+    def id_from_auth_exists?(record)
+      record.class.where(authority: record.authority).where("controlled_terms_nomenclatures.term_data->>'id_from_auth' = ?", record.id_from_auth).count > 1
+    end
+  end
+end

--- a/spec/controllers/curator/institutions_controller_spec.rb
+++ b/spec/controllers/curator/institutions_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Curator::InstitutionsController, type: :controller do
       id_from_auth: location.id_from_auth,
       coordinates: location.coordinates,
       authority_code: location.authority_code,
+      bounding_box: location.bounding_box,
       area_type: location.area_type
     }
     attributes[:host_collections_attributes] = [

--- a/spec/models/curator/controlled_terms/genre_spec.rb
+++ b/spec/models/curator/controlled_terms/genre_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Genre, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('gmgpc') }
-    let!(:term_data) { { id_from_auth: 'tgm008084' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'tgm008084' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_genre', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/genre_spec.rb
+++ b/spec/models/curator/controlled_terms/genre_spec.rb
@@ -4,12 +4,24 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Genre, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('gmgpc') }
+    let!(:term_data) { { id_from_auth: 'tgm008084' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_genre', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'canonicable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/genre_spec.rb
+++ b/spec/models/curator/controlled_terms/genre_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Genre, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('gmgpc') }
-    let!(:term_data) { { id_from_auth: 'tgm008084' } }
+    let!(:term_data) { { id_from_auth: 'tgm008084' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_genre', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -4,12 +4,25 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('tgn') }
+    let!(:term_data) { { id_from_auth: '7004939', label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_geographic', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
+
   it_behaves_like 'canonicable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('tgn') }
@@ -20,6 +33,7 @@ RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
     after(:each) { VCR.eject_cassette }
     # rubocop:enable RSpec/LetSetup
   end
+
   describe 'attr_json attributes' do
     it { is_expected.to respond_to(:area_type) }
     it { is_expected.to respond_to(:coordinates) }

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('tgn') }
-    let!(:term_data) { { id_from_auth: '7004939', label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } }
+    let!(:term_data) { { id_from_auth: '7004939', label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_geographic', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('tgn') }
-    let!(:term_data) { { id_from_auth: '7004939', label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: '7004939', label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_geographic', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/language_spec.rb
+++ b/spec/models/curator/controlled_terms/language_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Curator::ControlledTerms::Language, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('iso639-2') }
-    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } }
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_language', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/language_spec.rb
+++ b/spec/models/curator/controlled_terms/language_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Curator::ControlledTerms::Language, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('iso639-2') }
-    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_language', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/language_spec.rb
+++ b/spec/models/curator/controlled_terms/language_spec.rb
@@ -4,11 +4,23 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 RSpec.describe Curator::ControlledTerms::Language, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('iso639-2') }
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_language', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   describe 'attr_json attributes' do
     describe 'Validations' do

--- a/spec/models/curator/controlled_terms/name_spec.rb
+++ b/spec/models/curator/controlled_terms/name_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Name, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('gmgpc') }
-    let!(:term_data) { { id_from_auth: 'tgm008084' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'tgm008084' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_name', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/name_spec.rb
+++ b/spec/models/curator/controlled_terms/name_spec.rb
@@ -4,12 +4,24 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Name, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('gmgpc') }
+    let!(:term_data) { { id_from_auth: 'tgm008084' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_name', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'canonicable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/name_spec.rb
+++ b/spec/models/curator/controlled_terms/name_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Name, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('gmgpc') }
-    let!(:term_data) { { id_from_auth: 'tgm008084' } }
+    let!(:term_data) { { id_from_auth: 'tgm008084' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_name', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/resource_type_spec.rb
+++ b/spec/models/curator/controlled_terms/resource_type_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::ResourceType, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('resourceTypes') }
-    let!(:term_data) { { id_from_auth: 'foo', label: 'Foo' } } # NOTE: Had to use non standard term data here in order for spec to pass
+    let!(:term_data) { { id_from_auth: 'foo', label: 'Foo' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_resource_type', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/resource_type_spec.rb
+++ b/spec/models/curator/controlled_terms/resource_type_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::ResourceType, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('resourceTypes') }
-    let!(:term_data) { { id_from_auth: 'foo', label: 'Foo' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'foo', label: 'Foo' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_resource_type', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/resource_type_spec.rb
+++ b/spec/models/curator/controlled_terms/resource_type_spec.rb
@@ -4,12 +4,24 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::ResourceType, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('resourceTypes') }
+    let!(:term_data) { { id_from_auth: 'foo', label: 'Foo' } } # NOTE: Had to use non standard term data here in order for spec to pass
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_resource_type', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   describe 'attr_json attributes' do
     describe 'Validations' do

--- a/spec/models/curator/controlled_terms/role_spec.rb
+++ b/spec/models/curator/controlled_terms/role_spec.rb
@@ -4,12 +4,24 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Role, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('marcrelator') }
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Had to use non standard term data here in order for spec to pass
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_role', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   describe 'attr_json attributes' do
     describe 'Validations' do

--- a/spec/models/curator/controlled_terms/role_spec.rb
+++ b/spec/models/curator/controlled_terms/role_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Role, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('marcrelator') }
-    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Had to use non standard term data here in order for spec to pass
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_role', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/role_spec.rb
+++ b/spec/models/curator/controlled_terms/role_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Role, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('marcrelator') }
-    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } } # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'bar', label: 'Bar' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_role', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/subject_spec.rb
+++ b/spec/models/curator/controlled_terms/subject_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Subject, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('lcsh') }
-    let!(:term_data) { { id_from_auth: 'sh00000000', label: 'Test' } } # NOTE: Had to use non standard term data here in order for spec to pass
+    let!(:term_data) { { id_from_auth: 'sh00000000', label: 'Test' } } # # NOTE: Using invalid data to test that validation fails as expected
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_subject', allow_playback_repeats: true) }
 

--- a/spec/models/curator/controlled_terms/subject_spec.rb
+++ b/spec/models/curator/controlled_terms/subject_spec.rb
@@ -4,12 +4,24 @@ require 'rails_helper'
 require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
+require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Subject, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_uniqueness_validatable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('lcsh') }
+    let!(:term_data) { { id_from_auth: 'sh00000000', label: 'Test' } } # NOTE: Had to use non standard term data here in order for spec to pass
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_subject', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'canonicable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/subject_spec.rb
+++ b/spec/models/curator/controlled_terms/subject_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Curator::ControlledTerms::Subject, type: :model do
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
     let!(:authority) { find_authority_by_code('lcsh') }
-    let!(:term_data) { { id_from_auth: 'sh00000000', label: 'Test' } } # # NOTE: Using invalid data to test that validation fails as expected
+    let!(:term_data) { { id_from_auth: 'sh00000000', label: 'Test' } }
 
     before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_uniqueness_validatable_subject', allow_playback_repeats: true) }
 

--- a/spec/models/curator/shared/controlled_terms/id_from_auth_unique_validatable.rb
+++ b/spec/models/curator/shared/controlled_terms/id_from_auth_unique_validatable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'id_from_auth_uniqueness_validatable', type: :model do
+  describe 'Validations' do
+    subject(:nomenclature) { build(factory_key_for(described_class), term_data: term_data, authority: authority) }
+
+    it { is_expected.to be_valid }
+
+    context 'when invalid' do
+      let!(:expected_error_messgage_key) { :id_from_auth }
+      let!(:expected_error_message) { "Id from auth #{term_data[:id_from_auth]} has already been taken for #{described_class}!" }
+
+      before(:each) do
+        create(factory_key_for(described_class), term_data: term_data, authority: authority)
+        nomenclature.valid?
+      end
+
+      it { is_expected.not_to be_valid }
+
+      it 'expects nomenclature to have errors' do
+        expect(nomenclature.errors).to have_key(expected_error_messgage_key)
+        expect(nomenclature.errors.full_messages).to include(expected_error_message)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -157,6 +157,10 @@ RSpec.configure do |config|
     metadata[:type] = :presenters
   end
 
+  config.define_derived_metadata(file_path: Regexp.new('/spec/validators/')) do |metadata|
+    metadata[:type] = :validators
+  end
+
   config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.

--- a/spec/services/curator/institution_updater_service_spec.rb
+++ b/spec/services/curator/institution_updater_service_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Curator::InstitutionUpdaterService, type: :service do
         id_from_auth: @location.id_from_auth,
         coordinates: @location.coordinates,
         authority_code: @location.authority_code,
+        bounding_box: @location.bounding_box,
         area_type: @location.area_type
       },
       host_collections_attributes: [

--- a/spec/support/authority_finder.rb
+++ b/spec/support/authority_finder.rb
@@ -8,4 +8,5 @@ end
 
 RSpec.configure do |config|
   config.include AuthorityFinder, type: :model
+  config.include AuthorityFinder, type: :validators
 end

--- a/spec/validators/curator/controlled_terms/id_from_auth_uniqueness_validator_spec.rb
+++ b/spec/validators/curator/controlled_terms/id_from_auth_uniqueness_validator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Curator::ControlledTerms::IdFromAuthUniquenessValidator, type: :validators do
+  subject { described_class }
+
+  it { is_expected.to be <= ActiveModel::Validator }
+
+  it { is_expected.to respond_to(:new) }
+
+  describe 'instance' do
+    subject(:validator_instance) { described_class.new }
+
+    it { is_expected.to respond_to(:validate).with(1).argument }
+
+    context 'no id_from_auth' do
+      subject! { validator_instance.validate(record) }
+
+      let!(:authority) { find_authority_by_code('gmgpc') }
+      let!(:record) { create(:curator_controlled_terms_subject, authority: authority, term_data: { label: 'Foo' }) }
+
+      it { is_expected.to be(nil) }
+    end
+
+    context 'no authority' do
+      subject! { validator_instance.validate(record) }
+
+      let!(:record) { create(:curator_controlled_terms_subject, authority: nil, term_data: { id_from_auth: 'testetstetst', label: 'Bar' }) }
+
+      it { is_expected.to be(nil) }
+    end
+
+    context 'validation failure' do
+      subject!(:record) { build(:curator_controlled_terms_subject, authority: authority, term_data: { id_from_auth: 'foobar', label: 'FooBar' }) }
+
+      let!(:authority) { find_authority_by_code('gmgpc') }
+      let!(:existing_record) { create(:curator_controlled_terms_subject, authority: authority, term_data: { id_from_auth: 'foobar', label: 'FooBar' }) }
+      let!(:expected_error_message) { "Id from auth #{existing_record.id_from_auth} has already been taken for #{existing_record.class.name}!" }
+
+      before(:each) do
+        validator_instance.validate(record)
+      end
+
+      it 'is expected to contain errors' do
+        expect(record.errors).to have_key(:id_from_auth)
+        expect(record.errors.full_messages).to include(expected_error_message)
+      end
+    end
+  end
+end

--- a/spec/validators/curator/controlled_terms/id_from_auth_uniqueness_validator_spec.rb
+++ b/spec/validators/curator/controlled_terms/id_from_auth_uniqueness_validator_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Curator::ControlledTerms::IdFromAuthUniquenessValidator, type: :v
 
     it { is_expected.to respond_to(:validate).with(1).argument }
 
-    context 'no id_from_auth' do
+    context 'when no id_from_auth' do
       subject! { validator_instance.validate(record) }
 
       let!(:authority) { find_authority_by_code('gmgpc') }
@@ -23,7 +23,7 @@ RSpec.describe Curator::ControlledTerms::IdFromAuthUniquenessValidator, type: :v
       it { is_expected.to be(nil) }
     end
 
-    context 'no authority' do
+    context 'when no authority' do
       subject! { validator_instance.validate(record) }
 
       let!(:record) { create(:curator_controlled_terms_subject, authority: nil, term_data: { id_from_auth: 'testetstetst', label: 'Bar' }) }
@@ -31,7 +31,7 @@ RSpec.describe Curator::ControlledTerms::IdFromAuthUniquenessValidator, type: :v
       it { is_expected.to be(nil) }
     end
 
-    context 'validation failure' do
+    context 'when validation failure' do
       subject!(:record) { build(:curator_controlled_terms_subject, authority: authority, term_data: { id_from_auth: 'foobar', label: 'FooBar' }) }
 
       let!(:authority) { find_authority_by_code('gmgpc') }
@@ -45,6 +45,22 @@ RSpec.describe Curator::ControlledTerms::IdFromAuthUniquenessValidator, type: :v
       it 'is expected to contain errors' do
         expect(record.errors).to have_key(:id_from_auth)
         expect(record.errors.full_messages).to include(expected_error_message)
+      end
+    end
+
+    context 'when validation success' do
+      subject!(:record) { build(:curator_controlled_terms_subject, authority: authority, term_data: { id_from_auth: 'sh85040989', label: 'Education' }) }
+
+      let!(:authority) { find_authority_by_code('lcsh') }
+
+      before(:each) do
+        validator_instance.validate(record)
+      end
+
+      it { is_expected.to be_valid }
+
+      it 'is expected not to contain errors' do
+        expect(record.errors.full_messages).to be_empty
       end
     end
   end

--- a/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_genre.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_genre.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/search/loc/graphicMaterials?q=tgm008084
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"30e4153c0f76872f4caf8f07c79244d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d680ac65-411f-4238-84c6-088dd1553a5d
+      X-Runtime:
+      - '0.183185'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"info:lc/vocabulary/graphicMaterials/tgm008084","label":"Portrait
+        prints"}]'
+  recorded_at: Thu, 01 Jun 2023 15:33:57 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_geographic.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_geographic.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/search/loc/graphicMaterials?q=tgm008084
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"30e4153c0f76872f4caf8f07c79244d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c3640bba-77df-44da-95c2-1b1e5457afbd
+      X-Runtime:
+      - '0.269240'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"info:lc/vocabulary/graphicMaterials/tgm008084","label":"Portrait
+        prints"}]'
+  recorded_at: Thu, 01 Jun 2023 14:07:51 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_name.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_name.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/search/loc/graphicMaterials?q=tgm008084
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"30e4153c0f76872f4caf8f07c79244d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d15c22ab-c5e3-4d7c-aedd-61b733567fec
+      X-Runtime:
+      - '0.089243'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"info:lc/vocabulary/graphicMaterials/tgm008084","label":"Portrait
+        prints"}]'
+  recorded_at: Thu, 01 Jun 2023 15:33:57 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_subject.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_uniqueness_validatable_subject.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/show/linked_data/loc_direct/subjects/sh2018001243
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.1.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"90d1b8d5e5452ad9175887b592211bbf"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fe793f3e-0ecd-486b-b2b6-a798eb389e97
+      X-Runtime:
+      - '1.137747'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '{"uri":"http://id.loc.gov/authorities/subjects/sh2018001243","id":"sh2018001243","label":["Hurricane
+        Maria, 2017"],"altlabel":["Maria, Hurricane, 2017"],"broader":["http://id.loc.gov/authorities/subjects/sh85063195"],"sameas":["info:lc/authorities/sh2018001243","http://id.loc.gov/authorities/sh2018001243#concept"],"predicates":{"http://www.w3.org/1999/02/22-rdf-syntax-ns#type":["http://www.loc.gov/mads/rdf/v1#Topic","http://www.loc.gov/mads/rdf/v1#Authority","http://www.w3.org/2004/02/skos/core#Concept"],"http://www.loc.gov/mads/rdf/v1#authoritativeLabel":["Hurricane
+        Maria, 2017"],"http://id.loc.gov/ontologies/bflc/marcKey":["150  $aHurricane
+        Maria, 2017"],"http://www.loc.gov/mads/rdf/v1#hasCloseExternalAuthority":["http://www.wikidata.org/entity/Q40178187","http://id.worldcat.org/fast/2002745"],"http://www.loc.gov/mads/rdf/v1#hasBroaderAuthority":["http://id.loc.gov/authorities/subjects/sh85063195"],"http://www.loc.gov/mads/rdf/v1#isMemberOfMADSCollection":["http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings","http://id.loc.gov/authorities/subjects/collection_LCSH_General"],"http://id.loc.gov/ontologies/bflc/subjectOf":["http://id.loc.gov/resources/works/20989074","http://id.loc.gov/resources/works/22745737","http://id.loc.gov/resources/works/22167523","http://id.loc.gov/resources/works/21230274","http://id.loc.gov/resources/works/22154046","http://id.loc.gov/resources/works/22154039","http://id.loc.gov/resources/works/22147858","http://id.loc.gov/resources/works/21075387","http://id.loc.gov/resources/works/21767508","http://id.loc.gov/resources/works/22147987","http://id.loc.gov/resources/works/22180135","http://id.loc.gov/resources/works/21857223","http://id.loc.gov/resources/works/22400001","http://id.loc.gov/resources/works/22156820","http://id.loc.gov/resources/works/22167778","http://id.loc.gov/resources/works/21857228","http://id.loc.gov/resources/works/22118098","http://id.loc.gov/resources/works/22125501","http://id.loc.gov/resources/works/21857213","http://id.loc.gov/resources/works/22452875","http://id.loc.gov/resources/works/21857218","http://id.loc.gov/resources/works/20925565","http://id.loc.gov/resources/works/21431140","http://id.loc.gov/resources/works/20797367","http://id.loc.gov/resources/works/22146592","http://id.loc.gov/resources/works/20665304","http://id.loc.gov/resources/works/22331413","http://id.loc.gov/resources/works/22163275","http://id.loc.gov/resources/works/20470348","http://id.loc.gov/resources/works/22154168","http://id.loc.gov/resources/works/20855959","http://id.loc.gov/resources/works/21204595","http://id.loc.gov/resources/works/20834046","http://id.loc.gov/resources/works/22158230","http://id.loc.gov/resources/works/22154033","http://id.loc.gov/resources/works/22167526","http://id.loc.gov/resources/works/22074697","http://id.loc.gov/resources/works/20855950","http://id.loc.gov/resources/works/22147896","http://id.loc.gov/resources/works/21201503","http://id.loc.gov/resources/works/20887869","http://id.loc.gov/resources/works/21294439","http://id.loc.gov/resources/works/21066972","http://id.loc.gov/resources/works/21536217","http://id.loc.gov/resources/works/22120648","http://id.loc.gov/resources/works/21482282","http://id.loc.gov/resources/works/21451074"],"http://www.loc.gov/mads/rdf/v1#isMemberOfMADSScheme":["http://id.loc.gov/authorities/subjects"],"http://id.loc.gov/vocabulary/identifiers/lccn":["sh2018001243"],"http://www.w3.org/2002/07/owl#sameAs":["info:lc/authorities/sh2018001243","http://id.loc.gov/authorities/sh2018001243#concept"],"http://www.w3.org/2004/02/skos/core#prefLabel":["Hurricane
+        Maria, 2017"],"http://www.w3.org/2004/02/skos/core#broader":["http://id.loc.gov/authorities/subjects/sh85063195"],"http://www.w3.org/2004/02/skos/core#closeMatch":["http://www.wikidata.org/entity/Q40178187","http://id.worldcat.org/fast/2002745"],"http://www.w3.org/2004/02/skos/core#inScheme":["http://id.loc.gov/authorities/subjects"],"http://www.w3.org/2004/02/skos/core#altLabel":["Maria,
+        Hurricane, 2017"]}}'
+  recorded_at: Thu, 01 Jun 2023 15:34:00 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
- Added new custom validator class that validates controlled terms `nomenclatures`  uniqueness by `id_from_auth` and `authority` that should prevent duplications
- Updated and added new specs
- Resolves #325 