### PR TITLE
Getty authorities label-fetching fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -439,6 +439,8 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Enabled: true
   Max: 15
+  Exclude:
+    - 'app/models/concerns/curator/controlled_terms/canonicable.rb'
 
 Metrics/MethodLength:
   Enabled: true

--- a/spec/models/curator/shared/controlled_terms/canonicable.rb
+++ b/spec/models/curator/shared/controlled_terms/canonicable.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'canonicable', type: :model do
-  describe '#fetch_canonical_label' do
+  describe '#set_canonical_label' do
     let!(:nomenclature) { build(factory_key_for(described_class), term_data: term_data, authority: authority) }
 
-    it 'expects #fetch_canonical_name to be called on :before_validate on :create' do
+    it 'expects #set_canonical_label to be called on :before_validate on :create' do
       nomenclature.label = nil
-      expect(nomenclature.send(:should_fetch_canonical_label?)).to be_truthy
+      expect(nomenclature.send(:should_set_canonical_label?)).to be_truthy
       expect { nomenclature.valid? }.to change(nomenclature, :label).
       from(nil).
       to(be_a_kind_of(String))


### PR DESCRIPTION
* Updates code to fetch labels from Getty authorities (based on extensive testing with de-duplication project)
* Creates new `#set_canonical_label` method, so that `#fetch_canonical_label` can be called to retrieve the label value, without mutating the `ControlledTerms::Nomenclature` object