### PR TITLE
Issue fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Warning
 
 
-This Project is currently in the early stages of **development** and not recommended for any use outside of **development**
+This Project is currently is still in active **development**
 
 
 ## Description

--- a/app/jobs/concerns/curator/filestreams/iiif_readyable.rb
+++ b/app/jobs/concerns/curator/filestreams/iiif_readyable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Curator
+  module Filestreams
+    module IIIFReadyable
+      extend ActiveSupport::Concern
+
+      included do
+        include InstanceMethods
+      end
+
+      module InstanceMethods
+        protected
+
+        def remote_service_healthcheck!
+          raise Curator::Exceptions::IIIFServerUnavailable if !iiif_server_ready?
+        end
+
+        private
+
+        def iiif_server_ready?
+          raise StandardError, 'Implement Me'
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/curator/filestreams/iiif_cache_invalidate_job.rb
+++ b/app/jobs/curator/filestreams/iiif_cache_invalidate_job.rb
@@ -2,7 +2,8 @@
 
 module Curator
   class Filestreams::IIIFCacheInvalidateJob < ApplicationJob
-    queue_as :default
+    include Curator::Filestreams::IIIFReadyable
+    queue_as :iiif
 
     retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 5.seconds, attempts: 5
     retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
@@ -15,12 +16,6 @@ module Curator
       service_result = Curator::Filestreams::IIIFServerCacheInvalidateService.call(ark_id)
 
       logger.info "IIIF server responded with #{service_result}"
-    end
-
-    protected
-
-    def remote_service_healthcheck!
-      raise Curator::Exceptions::IIIFServerUnavailable if !iiif_server_ready?
     end
 
     private

--- a/app/jobs/curator/filestreams/iiif_manifest_prewarm_job.rb
+++ b/app/jobs/curator/filestreams/iiif_manifest_prewarm_job.rb
@@ -2,16 +2,25 @@
 
 module Curator
   class Filestreams::IIIFManifestPrewarmJob < ApplicationJob
-    queue_as :default
+    include Curator::Filestreams::IIIFReadyable
+    queue_as :iiif
 
-    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 5.seconds, attempts: 5
-    retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
-    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 5.seconds
+    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 15.seconds, attempts: 5
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 15.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 10.seconds
+
+    before_perform { remote_service_healthcheck! }
 
     def perform(ark_id)
       service_result = Curator::Filestreams::IIIFManifestPrewarmService.call(ark_id)
 
       logger.info "IIIF server responded with #{service_result}"
+    end
+
+    private
+
+    def iiif_server_ready?
+      Curator::Filestreams::IIIFManifestPrewarmService.ready?
     end
   end
 end

--- a/app/jobs/curator/filestreams/iiif_manifest_prewarm_job.rb
+++ b/app/jobs/curator/filestreams/iiif_manifest_prewarm_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::IIIFManifestPrewarmJob < ApplicationJob
+    queue_as :default
+
+    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 5.seconds, attempts: 5
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 5.seconds
+
+    def perform(ark_id)
+      service_result = Curator::Filestreams::IIIFManifestPrewarmService.call(ark_id)
+
+      logger.info "IIIF server responded with #{service_result}"
+    end
+  end
+end

--- a/app/models/concerns/curator/controlled_terms/id_from_auth_findable.rb
+++ b/app/models/concerns/curator/controlled_terms/id_from_auth_findable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Curator
+  module ControlledTerms
+    module IdFromAuthFindable
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def find_id_from_auth(id_from_auth)
+          find_id_from_auth!(id_from_auth)
+        rescue ActiveRecord::RecordNotFound
+          nil
+        end
+
+        def find_id_from_auth!(id_from_auth)
+          jsonb_contains(id_from_auth: id_from_auth).first!
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/curator/controlled_terms/reindex_descriptable.rb
+++ b/app/models/concerns/curator/controlled_terms/reindex_descriptable.rb
@@ -15,9 +15,9 @@ module Curator
           object_ids = []
           case term_type
           when 'License'
-            object_ids = licensees.pluck(:digital_object_id)
+            object_ids += licensees.pluck(:digital_object_id)
           when 'RightsStatement'
-            object_ids = rights_statement_of.pluck(:digital_object_id)
+            object_ids += rights_statement_of.pluck(:digital_object_id)
           when 'Name', 'Role'
             object_ids = desc_name_roles.joins(:descriptive).pluck(:'metastreams_descriptives.digital_object_id')
             if term_type == 'Name'
@@ -32,10 +32,9 @@ module Curator
 
           return if object_ids.blank?
 
-          # NOTE: per this comment https://github.com/sciencehistory/kithe/blob/56a65a97292c3d0e273a822080df6d1db8616cfa/app/indexing/kithe/indexable.rb#L57
-          # If we are updating a batch of record in a call back without a background job we should wrap in the index_with batching: true
-          Curator::Indexable.index_with(batching: true) do
-            Curator.digital_object_class.for_reindex_all.where(id: object_ids).find_each(&:update_index)
+          Curator.digital_object_class.where(id: object_ids).find_each do |obj|
+            obj.queue_indexing_job
+            sleep(0.1)
           end
         end
       end

--- a/app/models/concerns/curator/mintable.rb
+++ b/app/models/concerns/curator/mintable.rb
@@ -4,6 +4,18 @@ module Curator
   module Mintable
     extend ActiveSupport::Concern
 
+    class_methods do
+      def find_ark(ark_id)
+        find_ark!(ark_id)
+      rescue ActiveRecord::RecordNotFound
+        nil
+      end
+
+      def find_ark!(ark_id)
+        find_by!(ark_id: ark_id)
+      end
+    end
+
     included do
       include InstanceMethods
 

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -63,10 +63,9 @@ module Curator
     def reindex_collection_members
       return if !saved_change_to_name?
 
-      Curator::Indexable.indexer_health_check!
-
-      Curator::Indexable.index_with(batching: true) do
-        Curator.digital_object_class.for_reindex_all.where(id: collection_members.pluck(:digital_object_id)).find_each(&:update_index)
+      Curator.digital_object_class.where(id: collection_members.pluck(:digital_object_id)).find_each do |obj|
+        obj.queue_indexing_job
+        sleep(0.1)
       end
     end
   end

--- a/app/models/curator/controlled_terms/genre.rb
+++ b/app/models/curator/controlled_terms/genre.rb
@@ -6,6 +6,7 @@ module Curator
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
     include ControlledTerms::IdFromAuthUniqueValidatable
+    include ControlledTerms::IdFromAuthFindable
     include Mappings::MappedTerms
 
     belongs_to :authority, inverse_of: :genres, class_name: 'Curator::ControlledTerms::Authority', optional: true

--- a/app/models/curator/controlled_terms/geographic.rb
+++ b/app/models/curator/controlled_terms/geographic.rb
@@ -6,7 +6,11 @@ module Curator
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
     include ControlledTerms::IdFromAuthUniqueValidatable
+    include ControlledTerms::IdFromAuthFindable
     include Mappings::MappedTerms
+
+    scope :tgns, -> { with_authority.where(authority: { code: 'tgn' }).references(:authority) }
+    scope :geonames, -> { with_authority.where(authority: { code: 'geonames' }).references(:authority) }
 
     belongs_to :authority, inverse_of: :geographics, class_name: 'Curator::ControlledTerms::Authority', optional: true
 
@@ -21,7 +25,10 @@ module Curator
     private
 
     def reindex_associated_institutions
-      institution_locations.find_each { |inst| inst.update_index }
+      institution_locations.find_each do |inst|
+        inst.queue_indexing_job
+        sleep(0.1)
+      end
     end
   end
 end

--- a/app/models/curator/controlled_terms/language.rb
+++ b/app/models/curator/controlled_terms/language.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::Language < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthFindable
     include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :languages, class_name: 'Curator::ControlledTerms::Authority'

--- a/app/models/curator/controlled_terms/name.rb
+++ b/app/models/curator/controlled_terms/name.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthFindable
     include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
 

--- a/app/models/curator/controlled_terms/resource_type.rb
+++ b/app/models/curator/controlled_terms/resource_type.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::ResourceType < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthFindable
     include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :resource_types, class_name: 'Curator::ControlledTerms::Authority'

--- a/app/models/curator/controlled_terms/role.rb
+++ b/app/models/curator/controlled_terms/role.rb
@@ -4,6 +4,7 @@ module Curator
   class ControlledTerms::Role < ControlledTerms::Nomenclature
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthFindable
     include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :roles, class_name: 'Curator::ControlledTerms::Authority'

--- a/app/models/curator/controlled_terms/subject.rb
+++ b/app/models/curator/controlled_terms/subject.rb
@@ -5,6 +5,7 @@ module Curator
     include ControlledTerms::AuthorityDelegation
     include ControlledTerms::Canonicable
     include ControlledTerms::ReindexDescriptable
+    include ControlledTerms::IdFromAuthFindable
     include ControlledTerms::IdFromAuthUniqueValidatable
     include Mappings::MappedTerms
     belongs_to :authority, inverse_of: :subjects, class_name: 'Curator::ControlledTerms::Authority', optional: true

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -123,20 +123,22 @@ module Curator
     end
 
     def reindex_associations
-      Curator::Indexable.indexer_health_check!
-
-      Curator::Indexable.index_with(batching: true) do
-        reindex_digital_objects
-        reindex_collections
-      end
+      reindex_digital_objects
+      reindex_collections
     end
 
     def reindex_digital_objects
-      file_set_members_of.find_each(&:update_index)
+      file_set_members_of.find_each do |obj|
+        obj.queue_indexing_job
+        sleep(0.1)
+      end
     end
 
     def reindex_collections
-      exemplary_image_of_collections.find_each(&:update_index)
+      exemplary_image_of_collections.find_each do |col|
+        col.queue_indexing_job
+        sleep(0.1)
+      end
     end
   end
 end

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -46,13 +46,13 @@ module Curator
     def reindex_associations
       return if !saved_change_to_name?
 
-      Curator::Indexable.indexer_health_check!
-
-      Curator::Indexable.index_with(batching: true) do
-        collections.eager_load(:collection_members).find_each do |col|
-          Curator.digital_object_class.for_reindex_all.where(id: col.collection_members.pluck(:digital_object_id)).find_each(&:update_index)
-          col.update_index
+      collections.eager_load(:collection_members).find_each do |col|
+        Curator.digital_object_class.where(id: col.collection_members.pluck(:digital_object_id)).find_each do |obj|
+          obj.queue_indexing_job
+          sleep(0.1)
         end
+        col.queue_indexing_job
+        sleep(0.1)
       end
     end
   end

--- a/app/models/curator/mappings/host_collection.rb
+++ b/app/models/curator/mappings/host_collection.rb
@@ -19,7 +19,8 @@ module Curator
 
     def reindex_descriptable_objects
       desc_host_collections.find_each do |desc_host_col|
-        desc_host_col.descriptive.digital_object.update_index
+        desc_host_col.descriptive.digital_object.queue_indexing_job
+        sleep(0.1)
       end
     end
   end

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -113,6 +113,14 @@ module Curator
 
     alias regenerate_derivatives generate_derivatives
 
+    def prewarm_iif_manifest
+      return if workflowable_type != 'Curator::Filestreams::FileSet'
+
+      return if workflowable.class.name != 'Curator::Filestreams::Image'
+
+      Curator::Filestreams::IIIFManifestPrewarmJob.set(wait: 2.seconds).perform_later(workflowable.ark_id)
+    end
+
     def touch_parent
       workflowable.file_set_of.touch if workflowable_type == 'Curator::Filestreams::FileSet'
     end

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -56,7 +56,7 @@ module Curator
         transitions from: :initialized, to: :derivatives
       end
 
-      event :mark_complete, guards: [:is_processable?, :can_complete?], after_commit: :touch_parent do
+      event :mark_complete, guards: [:is_processable?, :can_complete?], after_commit: :finalize_complete do
         transitions from: :derivatives, to: :complete
       end
 
@@ -112,6 +112,11 @@ module Curator
     end
 
     alias regenerate_derivatives generate_derivatives
+
+    def finalize_complete
+      prewarm_iif_manifest
+      touch_parent
+    end
 
     def prewarm_iif_manifest
       return if workflowable_type != 'Curator::Filestreams::FileSet'

--- a/app/services/concerns/curator/filestreams/iiif_server_health_check.rb
+++ b/app/services/concerns/curator/filestreams/iiif_server_health_check.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Curator
+  module Filestreams
+    module IIIFServerHealthCheck
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def ready?
+          return true if ENV.fetch('RAILS_ENV', 'development') == 'test'
+
+          begin
+            status = with_client do |client|
+              resp = client.headers(default_headers).head('/health').flush
+              resp.status
+            end
+            status == 200
+          rescue StandardError => e
+            Rails.logger.error "Error: #{name} is not available: #{e.message}"
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/curator/filestreams/iiif_manifest_prewarm_service.rb
+++ b/app/services/curator/filestreams/iiif_manifest_prewarm_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Curator
+  class Filestreams::IIIFManifestPrewarmService < Services::Base
+    include Curator::Services::RemoteService
+
+    self.base_url = Curator.config.iiif_server_url
+    self.default_headers = { content_type: 'application/json' }
+    self.timeout_options = Curator.config.default_remote_service_timeout_opts
+
+    attr_reader :ark_id
+
+    def initialize(ark_id)
+      @ark_id = ark_id
+    end
+
+    def call
+    end
+  end
+end

--- a/app/services/curator/filestreams/iiif_server_cache_invalidate_service.rb
+++ b/app/services/curator/filestreams/iiif_server_cache_invalidate_service.rb
@@ -3,6 +3,7 @@
 module Curator
   class Filestreams::IIIFServerCacheInvalidateService < Services::Base
     include Curator::Services::RemoteService
+    include Curator::Filestreams::IIIFServerHealthCheck
 
     self.base_url = Curator.config.iiif_server_url
     self.default_headers = { content_type: 'application/json' }
@@ -42,21 +43,6 @@ module Curator
         raise
       end
       nil
-    end
-
-    def self.ready?
-      return true if ENV.fetch('RAILS_ENV', 'development') == 'test'
-
-      begin
-        status = with_client do |client|
-          resp = client.headers(default_headers).head('/health').flush
-          resp.status
-        end
-        status == 200
-      rescue StandardError => e
-        Rails.logger.error "Error: #{name} is not available: #{e.message}"
-        false
-      end
     end
 
     protected

--- a/lib/tasks/curator_tasks.rake
+++ b/lib/tasks/curator_tasks.rake
@@ -95,6 +95,9 @@ rescue Curator::Exceptions::SolrUnavailable, Curator::Exceptions::AuthorityApiUn
   raise e.message
 end
 
+# NOTE: per this comment https://github.com/sciencehistory/kithe/blob/56a65a97292c3d0e273a822080df6d1db8616cfa/app/indexing/kithe/indexable.rb#L57
+# If we are updating a batch of record in a call back without a background job we should wrap in the index_with batching: true
+
 def reindex_all_with_batching
   Curator::Indexable.index_with(batching: true) do
     ActiveRecord::Base.connection_pool.with_connection do

--- a/spec/jobs/curator/filestreams/iiif_manifest_prewarm_job_spec.rb
+++ b/spec/jobs/curator/filestreams/iiif_manifest_prewarm_job_spec.rb
@@ -3,28 +3,22 @@
 require 'rails_helper'
 require_relative '../shared/jobs_shared'
 
-RSpec.describe Curator::Filestreams::IIIFCacheInvalidateJob, type: :job do
+RSpec.describe Curator::Filestreams::IIIFManifestPrewarmJob, type: :job do
   describe 'expected job behavior' do
     subject { described_class }
 
-    let(:job_args) { 'bpl-dev:987654321' }
+    let(:job_args) { 'bpl-dev:8049g5699' }
     let(:expected_queue) { 'iiif' }
 
     it_behaves_like 'queueable'
 
     describe '#perform_later' do
-      let(:iiif_server_url) { "#{Curator.config.iiif_server_url}/tasks" }
-      let(:body) do
-        {
-          verb: 'PurgeItemFromCache',
-          identifier: job_args
-        }
-      end
+      let(:iiif_manifest_url) { "#{Curator.config.iiif_server_url}/iiif/2/#{job_args}/info.json" }
 
       around(:each) do |spec|
         ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
         ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-        VCR.use_cassette('jobs/filestreams/iiif_cache_invalidate') do
+        VCR.use_cassette('jobs/filestreams/iiif_manifest_prewarm') do
           spec.run
         end
         ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
@@ -33,7 +27,7 @@ RSpec.describe Curator::Filestreams::IIIFCacheInvalidateJob, type: :job do
 
       it 'sends a request to invalidate the IIIF cache' do
         subject.perform_later(job_args)
-        expect(a_request(:post, iiif_server_url).with(body: body)).to have_been_made.at_least_once
+        expect(a_request(:get, iiif_manifest_url)).to have_been_made.at_least_once
       end
     end
   end

--- a/spec/models/curator/controlled_terms/genre_spec.rb
+++ b/spec/models/curator/controlled_terms/genre_spec.rb
@@ -5,12 +5,25 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Genre, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('gmgpc') }
+    let!(:id_from_auth) { 'tgm008084' }
+    let!(:term_data) { { id_from_auth: id_from_auth } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_genre', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -12,7 +12,18 @@ require_relative '../shared/mappings/mapped_terms'
 RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
-  it_behaves_like 'id_from_auth_findable'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:id_from_auth) { '7004939' }
+    let!(:authority) { find_authority_by_code('tgn') }
+    let!(:term_data) { { id_from_auth: id_from_auth, label: 'Piacenza', area_type: 'city', coordinates: '45.016667,9.666667' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_geographic', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/geographic_spec.rb
+++ b/spec/models/curator/controlled_terms/geographic_spec.rb
@@ -5,12 +5,14 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+  it_behaves_like 'id_from_auth_findable'
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup
@@ -59,6 +61,24 @@ RSpec.describe Curator::ControlledTerms::Geographic, type: :model do
                         class_name('Curator::Institution').
                         with_foreign_key(:location_id).
                         dependent(:destroy) }
+  end
+
+  describe 'Scopes' do
+    describe '.tgns' do
+      subject { described_class.tgns.to_sql }
+
+      let!(:expected_sql) { described_class.with_authority.where(authority: { code: 'tgn' }).references(:authority).to_sql }
+
+      it { is_expected.to eql(expected_sql) }
+    end
+
+    describe '.geonames' do
+      subject { described_class.geonames.to_sql }
+
+      let!(:expected_sql) { described_class.with_authority.where(authority: { code: 'geonames' }).references(:authority).to_sql }
+
+      it { is_expected.to eql(expected_sql) }
+    end
   end
 
   describe 'Callbacks' do

--- a/spec/models/curator/controlled_terms/language_spec.rb
+++ b/spec/models/curator/controlled_terms/language_spec.rb
@@ -5,11 +5,24 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 RSpec.describe Curator::ControlledTerms::Language, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('iso639-2') }
+    let!(:id_from_auth) { 'bar' }
+    let!(:term_data) { { id_from_auth: id_from_auth, label: 'Bar' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_language', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/name_spec.rb
+++ b/spec/models/curator/controlled_terms/name_spec.rb
@@ -5,12 +5,25 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Name, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('gmgpc') }
+    let!(:id_from_auth) { 'tgm008084' }
+    let!(:term_data) { { id_from_auth: id_from_auth } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_name', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/resource_type_spec.rb
+++ b/spec/models/curator/controlled_terms/resource_type_spec.rb
@@ -5,12 +5,25 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::ResourceType, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('resourceTypes') }
+    let!(:id_from_auth) { 'foo' }
+    let!(:term_data) { { id_from_auth: id_from_auth, label: 'Foo' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_resource_type', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/role_spec.rb
+++ b/spec/models/curator/controlled_terms/role_spec.rb
@@ -5,12 +5,25 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Role, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('marcrelator') }
+    let!(:id_from_auth) { 'bar' }
+    let!(:term_data) { { id_from_auth: id_from_auth, label: 'Bar' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_role', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/controlled_terms/subject_spec.rb
+++ b/spec/models/curator/controlled_terms/subject_spec.rb
@@ -5,12 +5,25 @@ require_relative '../shared/controlled_terms/nomenclature'
 require_relative '../shared/controlled_terms/authority_delegation'
 require_relative '../shared/controlled_terms/canonicable'
 require_relative '../shared/controlled_terms/id_from_auth_unique_validatable'
+require_relative '../shared/controlled_terms/id_from_auth_findable'
 require_relative '../shared/controlled_terms/reindex_descriptable'
 require_relative '../shared/mappings/mapped_terms'
 
 RSpec.describe Curator::ControlledTerms::Subject, type: :model do
   it_behaves_like 'nomenclature'
   it_behaves_like 'authority_delegation'
+
+  it_behaves_like 'id_from_auth_findable' do
+    # rubocop:disable RSpec/LetSetup
+    let!(:authority) { find_authority_by_code('lcsh') }
+    let!(:id_from_auth) { 'sh00000000' }
+    let!(:term_data) { { id_from_auth: id_from_auth, label: 'Test' } }
+
+    before(:each) { VCR.insert_cassette('services/controlled_terms/id_from_auth_findable_subject', allow_playback_repeats: true) }
+
+    after(:each) { VCR.eject_cassette }
+    # rubocop:enable RSpec/LetSetup
+  end
 
   it_behaves_like 'id_from_auth_uniqueness_validatable' do
     # rubocop:disable RSpec/LetSetup

--- a/spec/models/curator/shared/controlled_terms/id_from_auth_findable.rb
+++ b/spec/models/curator/shared/controlled_terms/id_from_auth_findable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'id_from_auth_findable', type: :model do
+  describe 'Class Methods' do
+    subject { described_class }
+
+    it { is_expected.to respond_to(:find_id_from_auth, :find_id_from_auth!).with(1).argument }
+  end
+end

--- a/spec/models/curator/shared/controlled_terms/id_from_auth_findable.rb
+++ b/spec/models/curator/shared/controlled_terms/id_from_auth_findable.rb
@@ -5,5 +5,33 @@ RSpec.shared_examples 'id_from_auth_findable', type: :model do
     subject { described_class }
 
     it { is_expected.to respond_to(:find_id_from_auth, :find_id_from_auth!).with(1).argument }
+
+    describe 'find_id_from_auth' do
+      subject { described_class.find_id_from_auth(id_from_auth) }
+
+      let!(:nomenclature) { create(factory_key_for(described_class), term_data: term_data, authority: authority) }
+
+      it { is_expected.to be_truthy.and eql(nomenclature) }
+
+      context 'when not found' do
+        subject { described_class.find_id_from_auth('notarealidfromauth') }
+
+        it { is_expected.to be_nil }
+      end
+    end
+
+    describe 'find_id_from_auth!' do
+      subject { described_class.find_id_from_auth!(id_from_auth) }
+
+      let!(:nomenclature) { create(factory_key_for(described_class), term_data: term_data, authority: authority) }
+
+      it { is_expected.to be_truthy.and eql(nomenclature) }
+
+      context 'when not found' do
+        it 'is expected to raise an ActiveRecord::RecordNotFound error' do
+          expect { described_class.find_id_from_auth!('notarealidfromauth') }.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find #{described_class.name}/)
+        end
+      end
+    end
   end
 end

--- a/spec/models/curator/shared/mintable.rb
+++ b/spec/models/curator/shared/mintable.rb
@@ -2,82 +2,113 @@
 
 RSpec.shared_examples_for 'mintable', type: :model do |oai_specific: true, oai_parent: false|
   describe 'Mintable' do
-    it { is_expected.to respond_to(:ark_id, :ark_params, :ark_noid, :ark_identifier, :ark_preview_identifier, :ark_iiif_manifest_identifier) }
+    describe 'ClassMethods' do
+      subject { described_class }
 
-    describe 'Database' do
-      it { is_expected.to have_db_column(:ark_id).of_type(:string).with_options(null: false) }
-      it { is_expected.to have_db_index(:ark_id).unique(true) }
-    end
+      let!(:mintable_object) { create(factory_key_for(described_class)) }
+      let!(:invalid_ark_id) { 'bpl-dev:notavalidark' }
 
-    describe '#ark_params' do
-      let!(:expected_ark_param_keys) { %i(namespace_ark namespace_id parent_pid secondary_parent_pids model_type local_original_identifier local_original_identifier_type) }
+      it { is_expected.to respond_to(:find_ark, :find_ark!).with(1).argument }
 
-      it 'expects ark_params to be a hash with specific keys' do
-        expect(subject.ark_params).to be_a_kind_of(Hash)
+      describe 'find_ark!' do
+        it 'expects method to return the mintable_object' do
+          expect(described_class.find_ark!(mintable_object.ark_id).id).to eql(mintable_object.id)
+        end
 
-        expected_ark_param_keys.each do |expected_key|
-          expect(subject.ark_params).to have_key(expected_key)
+        it 'expects an ActiveRecord::RecordNotFound error to be raised with invalid_ark_id' do
+          expect { described_class.find_ark!(invalid_ark_id) }.to raise_error(ActiveRecord::RecordNotFound, "Couldn't find #{described_class.name}")
         end
       end
 
-      context 'Not an OAI object' do
-        specify { expect(subject).not_to be_oai_object }
-
-        it 'expects not to match /oai/ in the namespace_id val' do
-          expect(subject.ark_params[:namespace_id]).not_to match(/oai/)
-        end
-      end
-
-      context 'OAI Object', if: oai_specific do
-        context 'Checks #oai_object?', unless: oai_parent do
-          before(:each) do
-            subject.administrative.oai_header_id = 'someval'
-          end
-
-          after(:each) do
-            subject.administrative.oai_header_id = nil
-          end
-
-          it 'expects to match /oai/ in the namespace_id val' do
-            expect(subject.ark_params[:namespace_id]).to match(/oai/)
-          end
+      describe 'find_ark' do
+        it 'expects method to return the mintable_object' do
+          expect(described_class.find_ark(mintable_object.ark_id).id).to eql(mintable_object.id)
         end
 
-        # For Curator::Filestreams::FileSet
-        context 'Checks parent#oai_object', if: oai_parent do
-          before(:each) do
-            subject.file_set_of.administrative.oai_header_id = 'someval'
-          end
-
-          after(:each) do
-            subject.file_set_of.administrative.oai_header_id = nil
-          end
-
-          it 'expects to match /oai/ in the namespace_id val' do
-            expect(subject.ark_params[:namespace_id]).to match(/oai/)
-          end
+        it 'expects method to return nil with invalid_ark_id' do
+          expect(described_class.find_ark(invalid_ark_id)).to be_nil
         end
       end
     end
 
-    describe 'Validations' do
-      before(:context) { described_class.skip_callback(:validation, :before, Curator::MintableCallbacks) }
+    describe 'InstanceMethods' do
+      it { is_expected.to respond_to(:ark_id, :ark_params, :ark_noid, :ark_identifier, :ark_preview_identifier, :ark_iiif_manifest_identifier) }
 
-      after(:context) { described_class.set_callback(:validation, :before, Curator::MintableCallbacks) }
+      describe 'Database' do
+        it { is_expected.to have_db_column(:ark_id).of_type(:string).with_options(null: false) }
+        it { is_expected.to have_db_index(:ark_id).unique(true) }
+      end
 
-      it { is_expected.to validate_presence_of(:ark_id).on(:create) }
-      it { is_expected.to validate_uniqueness_of(:ark_id).on(:create) }
-    end
+      describe '#ark_params' do
+        let!(:expected_ark_param_keys) { %i(namespace_ark namespace_id parent_pid secondary_parent_pids model_type local_original_identifier local_original_identifier_type) }
 
-    describe '#Curator::MintableCallbacks.before_validation on create' do
-      subject { build(factory_key_for(described_class), ark_id: nil) }
+        it 'expects ark_params to be a hash with specific keys' do
+          expect(subject.ark_params).to be_a_kind_of(Hash)
 
-      it 'generates an #ark_id #before_validation on create if there is none' do
-        # valid? invokes the before_validation callback without saving
-        VCR.use_cassette("services/mintable_#{described_class.name.demodulize.underscore}") do
-          expect { subject.valid? }.to change(subject, :ark_id).
-          from(nil).
-          to(a_string_starting_with('bpl-dev'))
+          expected_ark_param_keys.each do |expected_key|
+            expect(subject.ark_params).to have_key(expected_key)
+          end
+        end
+
+        context 'Not an OAI object' do
+          specify { expect(subject).not_to be_oai_object }
+
+          it 'expects not to match /oai/ in the namespace_id val' do
+            expect(subject.ark_params[:namespace_id]).not_to match(/oai/)
+          end
+        end
+
+        context 'OAI Object', if: oai_specific do
+          context 'Checks #oai_object?', unless: oai_parent do
+            before(:each) do
+              subject.administrative.oai_header_id = 'someval'
+            end
+
+            after(:each) do
+              subject.administrative.oai_header_id = nil
+            end
+
+            it 'expects to match /oai/ in the namespace_id val' do
+              expect(subject.ark_params[:namespace_id]).to match(/oai/)
+            end
+          end
+
+          # For Curator::Filestreams::FileSet
+          context 'Checks parent#oai_object', if: oai_parent do
+            before(:each) do
+              subject.file_set_of.administrative.oai_header_id = 'someval'
+            end
+
+            after(:each) do
+              subject.file_set_of.administrative.oai_header_id = nil
+            end
+
+            it 'expects to match /oai/ in the namespace_id val' do
+              expect(subject.ark_params[:namespace_id]).to match(/oai/)
+            end
+          end
+        end
+      end
+
+      describe 'Validations' do
+        before(:context) { described_class.skip_callback(:validation, :before, Curator::MintableCallbacks) }
+
+        after(:context) { described_class.set_callback(:validation, :before, Curator::MintableCallbacks) }
+
+        it { is_expected.to validate_presence_of(:ark_id).on(:create) }
+        it { is_expected.to validate_uniqueness_of(:ark_id).on(:create) }
+      end
+
+      describe '#Curator::MintableCallbacks.before_validation on create' do
+        subject { build(factory_key_for(described_class), ark_id: nil) }
+
+        it 'generates an #ark_id #before_validation on create if there is none' do
+          # valid? invokes the before_validation callback without saving
+          VCR.use_cassette("services/mintable_#{described_class.name.demodulize.underscore}") do
+            expect { subject.valid? }.to change(subject, :ark_id).
+            from(nil).
+            to(a_string_starting_with('bpl-dev'))
+          end
         end
       end
     end

--- a/spec/services/curator/filestreams/iiif_manifest_prewarm_service_spec.rb
+++ b/spec/services/curator/filestreams/iiif_manifest_prewarm_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../shared/remote_service'
+
+RSpec.describe Curator::Filestreams::IIIFManifestPrewarmService, type: :service do
+  subject { described_class }
+
+  it_behaves_like 'remote_service'
+
+  it 'expects the .base_url to eq the Curator.config.iiif_server_url' do
+    expect(subject.base_url).to eq(Curator.config.iiif_server_url)
+  end
+
+  describe '#call' do
+    subject do
+      VCR.use_cassette('services/filestreams/iiif_manifest_prewarm') do
+        described_class.call(ark_id)
+      end
+    end
+
+    let(:ark_id) { 'bpl-dev:8049g5699' }
+    let(:iiif_manifest_url) { "#{Curator.config.iiif_server_url}/iiif/2/#{ark_id}/info.json" }
+
+    it 'expects the result to be successful' do
+      expect(subject).to be_truthy
+      expect(subject).to be_a_kind_of(String).and include(iiif_manifest_url)
+    end
+  end
+end

--- a/spec/vcr/jobs/filestreams/iiif_manifest_prewarm.yml
+++ b/spec/vcr/jobs/filestreams/iiif_manifest_prewarm.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://iiif-dc3dev.bpl.org/iiif/2/bpl-dev:8049g5699/info.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - iiif-dc3dev.bpl.org
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 29 Apr 2024 20:02:44 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '903'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Accept-Charset, Accept-Encoding, Accept-Language, Origin
+      - Accept-Encoding
+      X-Powered-By:
+      - Cantaloupe/5.0.5
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=2592000, public, no-transform
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"@context":"http://iiif.io/api/image/2/context.json","@id":"https://iiif-dc3dev.bpl.org/iiif/2/bpl-dev:8049g5699","protocol":"http://iiif.io/api/image","width":8503,"height":6386,"sizes":[{"width":133,"height":100},{"width":266,"height":200},{"width":531,"height":399},{"width":1063,"height":798},{"width":2126,"height":1597},{"width":4252,"height":3193},{"width":8503,"height":6386}],"tiles":[{"width":1024,"height":1024,"scaleFactors":[1,2,4,8,16,32,64]}],"profile":["http://iiif.io/api/image/2/level2.json",{"formats":["jpg","tif","gif","png"],"qualities":["bitonal","default","gray","color"],"supports":["regionByPx","sizeByW","sizeByWhListed","cors","regionSquare","sizeByDistortedWh","canonicalLinkHeader","sizeByConfinedWh","sizeByPct","jsonldMediaType","regionByPct","rotationArbitrary","sizeByH","baseUriRedirect","rotationBy90s","profileLinkHeader","sizeByForcedWh","sizeByWh","mirroring"]}]}'
+  recorded_at: Mon, 29 Apr 2024 20:02:44 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/services/controlled_terms/id_from_auth_findable_genre.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_findable_genre.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/search/loc/graphicMaterials?q=tgm008084
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"30e4153c0f76872f4caf8f07c79244d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2f5e19df-b88a-4283-8963-f3aa1f8a5825
+      X-Runtime:
+      - '0.123307'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"info:lc/vocabulary/graphicMaterials/tgm008084","label":"Portrait
+        prints"}]'
+  recorded_at: Mon, 29 Apr 2024 18:56:16 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/services/controlled_terms/id_from_auth_findable_name.yml
+++ b/spec/vcr/services/controlled_terms/id_from_auth_findable_name.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/qa/search/loc/graphicMaterials?q=tgm008084
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"30e4153c0f76872f4caf8f07c79244d3"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 56458b90-4df6-465f-be53-7c801aa9da0e
+      X-Runtime:
+      - '0.311324'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"info:lc/vocabulary/graphicMaterials/tgm008084","label":"Portrait
+        prints"}]'
+  recorded_at: Mon, 29 Apr 2024 18:56:07 GMT
+recorded_with: VCR 6.2.0

--- a/spec/vcr/services/filestreams/iiif_manifest_prewarm.yml
+++ b/spec/vcr/services/filestreams/iiif_manifest_prewarm.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://iiif-dc3dev.bpl.org/iiif/2/bpl-dev:8049g5699/info.json
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - iiif-dc3dev.bpl.org
+      User-Agent:
+      - http.rb/5.2.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 29 Apr 2024 20:26:01 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '903'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept, Accept-Charset, Accept-Encoding, Accept-Language, Origin
+      - Accept-Encoding
+      X-Powered-By:
+      - Cantaloupe/5.0.5
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - max-age=2592000, public, no-transform
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"@context":"http://iiif.io/api/image/2/context.json","@id":"https://iiif-dc3dev.bpl.org/iiif/2/bpl-dev:8049g5699","protocol":"http://iiif.io/api/image","width":8503,"height":6386,"sizes":[{"width":133,"height":100},{"width":266,"height":200},{"width":531,"height":399},{"width":1063,"height":798},{"width":2126,"height":1597},{"width":4252,"height":3193},{"width":8503,"height":6386}],"tiles":[{"width":1024,"height":1024,"scaleFactors":[1,2,4,8,16,32,64]}],"profile":["http://iiif.io/api/image/2/level2.json",{"formats":["jpg","tif","gif","png"],"qualities":["bitonal","default","gray","color"],"supports":["regionByPx","sizeByW","sizeByWhListed","cors","regionSquare","sizeByDistortedWh","canonicalLinkHeader","sizeByConfinedWh","sizeByPct","jsonldMediaType","regionByPct","rotationArbitrary","sizeByH","baseUriRedirect","rotationBy90s","profileLinkHeader","sizeByForcedWh","sizeByWh","mirroring"]}]}'
+  recorded_at: Mon, 29 Apr 2024 20:26:01 GMT
+recorded_with: VCR 6.2.0


### PR DESCRIPTION
- Added custom finder methods `find_ark` and `find_ark!` for `DigitalObject`, `Collection`, and `Institution`
- Added custom finder methods `find_id_from_auth` and `find_id_from_auth!` for `ControlledTerms::Nomenclature` excluding `License` and `RightsStatement`
- Made all indexing association callback methods queue to indexing background job instead of updating the index in callback method. Resolves #351 
- Added IIIF pre-warm manifest job/ service. Modified workflow call back to queue the pre-warming job(which calls pre-warming service) to generate iiif manifest for image file sets when set to 'complete'. Resolves #324 