### PR TITLE
Enhancements and fixes

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,6 +1,6 @@
 # Place any default configuration for solr_wrapper here
 port: 8984
-version: 8.11.2
+version: 8.11.3
 instance_dir: ./spec/internal/tmp/solr-test
 collection:
   persist: false

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -9,22 +9,28 @@ module Curator
     # TODO: add indexing for: edit_access_group_ssim
     configure do
       to_field %w(title_info_primary_tsi title_info_primary_ssi), obj_extract('name')
+
       to_field 'title_info_primary_ssort' do |record, accumulator|
         accumulator << Curator::Parsers::InputParser.get_proper_title(record.name).last
       end
+
       to_field 'abstract_tsi', obj_extract('abstract')
       to_field %w(physical_location_ssim physical_location_tim institution_name_ssi institution_name_ti),
                obj_extract('institution', 'name')
       to_field 'institution_ark_id_ssi', obj_extract('institution', 'ark_id')
+
       to_field %w(genre_basic_ssim genre_basic_tim) do |record, accumulator|
         accumulator << 'Collections'
         # iterate over child DigitalObject and get genre values
         genre_labels = []
+
         Curator.metastreams.descriptive_class.with_desc_terms.where(digital_object_id: record.admin_set_object_ids).find_each do |desc|
           genre_labels += desc.genres.basic_genres.collect(&:label)
         end
 
         genre_labels.each do |genre_label|
+          next if genre_label == 'Serial Publications'
+
           accumulator << genre_label if accumulator.exclude?(genre_label)
         end
       end

--- a/app/indexers/curator/collection_indexer.rb
+++ b/app/indexers/curator/collection_indexer.rb
@@ -29,7 +29,7 @@ module Curator
         end
 
         genre_labels.each do |genre_label|
-          next if genre_label == 'Serial Publications'
+          next if genre_label == 'Serial publications'
 
           accumulator << genre_label if accumulator.exclude?(genre_label)
         end

--- a/app/indexers/curator/digital_object_indexer.rb
+++ b/app/indexers/curator/digital_object_indexer.rb
@@ -16,11 +16,14 @@ module Curator
       to_field %w(collection_name_ssim collection_name_tim) do |record, accumulator|
         accumulator.concat record.is_member_of_collection.pluck(:name)
       end
+
       to_field 'collection_ark_id_ssim' do |record, accumulator|
         accumulator.concat record.is_member_of_collection.pluck(:ark_id)
       end
+
       to_field 'contained_by_ssi', obj_extract('contained_by', 'ark_id')
-      to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_set_members.pluck(:file_name_base).uniq }
+      to_field('filenames_ssim') { |rec, acc| acc.concat rec.file_set_members.distinct.pluck(:file_name_base) }
+
       each_record do |record, context|
         serializer = Curator::DigitalObjectSerializer.new(record, adapter_key: :mods)
         context.output_hash['mods_xml_ss'] = Base64.strict_encode64(Zlib::Deflate.deflate(serializer.serialize))
@@ -31,9 +34,11 @@ module Curator
             has_searchable_pages = true if image_file_set.text_plain_attachment.present?
             georeferenced = true if image_file_set.image_georectified_primary_attachment.present?
           end
+
           context.output_hash['has_searchable_pages_bsi'] = has_searchable_pages.presence
           context.output_hash['georeferenced_bsi'] = georeferenced.presence
         end
+
         next if record.text_file_sets.blank?
 
         text_plain_attachment = record.text_file_sets.first.text_plain_attachment
@@ -43,6 +48,8 @@ module Curator
         text_plain_attachment.download do |file|
           context.output_hash['ocr_tiv'] = Curator::Parsers::InputParser.clean_text(file)
         end
+
+        context.output_hash['has_transcription_bsi'] = true
       end
     end
   end

--- a/app/indexers/curator/file_set_indexer.rb
+++ b/app/indexers/curator/file_set_indexer.rb
@@ -24,6 +24,13 @@ module Curator
       to_field 'has_wordcoords_json_bsi' do |rec, acc|
         acc << true if rec.respond_to?(:text_coordinates_access_attachment) && rec.text_coordinates_access_attachment.present?
       end
+
+      to_field 'destination_site_ssim' do |rec, acc|
+        if rec.class.name == 'Curator::Filestreams::Image'
+          acc << 'newspapers' if rec.file_set_of&.administrative&.destination_site&.include?('newspapers')
+        end
+      end
+
       each_record do |record, context|
         next unless record.respond_to?(:text_plain_attachment) && record.text_plain_attachment.present?
 

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -15,6 +15,9 @@ module Curator
 
     scope :for_serialization, -> { includes(:file_sets, exemplary_image_mapping: :exemplary_file_set).with_metastreams }
     scope :for_reindex_all, -> { for_serialization.joins(:administrative, :descriptive, :workflow) }
+    scope :issue_object, -> { where.not(contained_by_id: nil) }
+    scope :with_admin_set_ark, ->(admin_set_ark_id) { joins(:admin_set).where(admin_set: { ark_id: admin_set_ark_id }) }
+
     scope :local_id_finder, lambda { |admin_set_ark_id, identifier, oai_header_id = nil|
       return joins(:admin_set, :administrative).where(collections: { ark_id: admin_set_ark_id }).merge(Curator.metastreams.administrative_class.local_id_finder(oai_header_id)).limit(1) if oai_header_id
 
@@ -62,6 +65,7 @@ module Curator
 
     has_many :file_set_member_mappings, -> { includes(:file_set) }, inverse_of: :digital_object,
              class_name: 'Curator::Mappings::FileSetMember', dependent: :destroy
+
     with_options through: :file_set_member_mappings, source: :file_set do
       has_many :file_set_members, class_name: 'Curator::Filestreams::FileSet'
       has_many :audio_file_set_members, class_name: 'Curator::Filestreams::Audio'

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -15,7 +15,7 @@ module Curator
 
     scope :for_serialization, -> { includes(:file_sets, exemplary_image_mapping: :exemplary_file_set).with_metastreams }
     scope :for_reindex_all, -> { for_serialization.joins(:administrative, :descriptive, :workflow) }
-    scope :issue_object, -> { where.not(contained_by_id: nil) }
+    scope :issue_objects, -> { where.not(contained_by_id: nil) }
     scope :with_admin_set_ark, ->(admin_set_ark_id) { joins(:admin_set).where(admin_set: { ark_id: admin_set_ark_id }) }
 
     scope :local_id_finder, lambda { |admin_set_ark_id, identifier, oai_header_id = nil|

--- a/app/services/curator/institution_updater_service.rb
+++ b/app/services/curator/institution_updater_service.rb
@@ -23,7 +23,7 @@ module Curator
         @record.host_collections_attributes = host_collections_attributes if host_collections_attributes.present?
 
         location = location_object(location_json_attrs)
-        @record.location = location unless @record.location_id == location.id
+        @record.location = location unless @record.location_id == location&.id
 
         attach_files!(@record)
         @record.save!

--- a/spec/indexers/curator/digital_object_indexer_spec.rb
+++ b/spec/indexers/curator/digital_object_indexer_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Curator::DigitalObjectIndexer, type: :indexer do
         it 'sets the ocr field' do
           attach_text_file(text_file_set)
           expect(indexed['ocr_tiv']).to include 'Lorem ipsum'
+          expect(indexed['has_transcription_bsi']).to be_truthy
         end
       end
     end

--- a/spec/internal/.solr_wrapper
+++ b/spec/internal/.solr_wrapper
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 8.11.2
+version: 8.11.3
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/spec/internal/.solr_wrapper_test
+++ b/spec/internal/.solr_wrapper_test
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-version: 8.11.2
+version: 8.11.3
 port: 8984
 instance_dir: tmp/solr-test
 collection:

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -163,6 +163,31 @@ RSpec.describe Curator::DigitalObject, type: :model do
       end
     end
 
+    describe '.issue_object' do
+      subject { described_class }
+
+      let(:expected_scope_sql) { described_class.where.not(contained_by_id: nil).to_sql }
+
+      it { is_expected.to respond_to(:issue_object) }
+
+      it 'expects the scope sql to match the expected_scope_sql' do
+        expect(subject.issue_object.to_sql).to eq(expected_scope_sql)
+      end
+    end
+
+    describe '.with_admin_set_ark' do
+      subject { described_class }
+
+      let(:admin_set_ark_id) { 'bpl-dev:123456789' }
+      let(:expected_scope_sql) { described_class.joins(:admin_set).where(admin_set: { ark_id: admin_set_ark_id }).to_sql }
+
+      it { is_expected.to respond_to(:with_admin_set_ark).with(1).argument }
+
+      it 'expects the scope sql to match the expected_scope_sql' do
+        expect(subject.with_admin_set_ark(admin_set_ark_id).to_sql).to eq(expected_scope_sql)
+      end
+    end
+
     it_behaves_like 'local_id_finder' do
       let(:admin_set_ark_id) { 'bpl-dev:123456789' }
       let(:identifier) { create_list(:curator_descriptives_identifier, 3).as_json }

--- a/spec/models/curator/digital_object_spec.rb
+++ b/spec/models/curator/digital_object_spec.rb
@@ -163,15 +163,15 @@ RSpec.describe Curator::DigitalObject, type: :model do
       end
     end
 
-    describe '.issue_object' do
+    describe '.issue_objects' do
       subject { described_class }
 
       let(:expected_scope_sql) { described_class.where.not(contained_by_id: nil).to_sql }
 
-      it { is_expected.to respond_to(:issue_object) }
+      it { is_expected.to respond_to(:issue_objects) }
 
       it 'expects the scope sql to match the expected_scope_sql' do
-        expect(subject.issue_object.to_sql).to eq(expected_scope_sql)
+        expect(subject.issue_objects.to_sql).to eq(expected_scope_sql)
       end
     end
 


### PR DESCRIPTION
- Made all `solr_wrapper` config files use `8.11.3` as the version

- Added `has_trasncription_bsi` to `digital_object` solr record if `ocr_tiv` is present, resolves #360

- Use safe operator on location variable for institution updater service, fixes #358

- Created `issue_objects` and `with_admin_set_ark` scopes on digital objects for easier querying, resolves #359

- Prevent `Serial Publications` from being added to genre facet on collections indexer, resolves #335

- Added newspapers to the `destination_site_ssim` field of file sets that are images and with parents that have newspapers in the same field, resolves #312