### PR TITLE
rake task to update allmaps georeferencing status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ structure.sql
 .idea/
 # Ignore coverage reports
 coverage/*
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -1,28 +1,11 @@
 # Curator
 [![Build Status](https://travis-ci.org/boston-library/curator.svg?branch=master)](https://travis-ci.org/boston-library/curator) [![Coverage Status](https://coveralls.io/repos/github/boston-library/curator/badge.svg?branch=master)](https://coveralls.io/github/boston-library/curator?branch=master)
 
-## Warning
-
-
-This Project is currently in active **development**
-
-
 ## Description
-Rails(~> 7.0) engine that sets up the basic data elements and routes for a more data driven JSON API for digital repositories.
+Rails(~> 7.0) engine that provides data models and services for a JSON API for digital asset management.
 Implements ActiveStorage for Cloud or local storage for files.
-Currently all data models have been created with basic routes and json serializers
 
-## Todo
-
-1. Development
-  * Create Additional Seralizer Functionality (In priority)
-  - ~~Build JSON/XML Serializer~~
-    - Refactor to be less complex
-    - Use `AdapterBase` class to build extended functionality for the following
-      * ~~Mods XML~~
-      * Dublic Core XML
-      * Marc XML
-      * RDF
+Please see the [Wiki](https://github.com/boston-library/curator/wiki) for more information.
 
 ## Installation (for development only)
 
@@ -41,9 +24,9 @@ Currently all data models have been created with basic routes and json serialize
 
 5. Check `spec/internal/config/database.yml` and make sure your `postgres` credentials are correct.
 
-6. `cd` into the `spec/internal` directory and:
-    * run `$ rails curator:setup` -- this will run the database setup scripts for you
-    * run `$ rails generate curator:install` (optional) -- this will add an initializer for customizing `Curator.config` settings
+6. Run `$ rails curator:setup` -- this will run the database setup scripts for you
+
+7. (Optional) run `$ rails generate curator:install` -- this will add an initializer for customizing `Curator.config` settings
 
 
 ## Running (for development only)
@@ -67,19 +50,17 @@ To set up these services:
     - If both containers return `{exist: false}` run the following two commands:
       - `az storage container create -n primary --connection-string "UseDevelopmentStorage=true" --public-access off`
       - `az storage container create -n derivatives --connection-string "UseDevelopmentStorage=true" --public-access container`
-
-
-4 In the Curator project, start Solr using the following command (see [solr_wrapper](https://github.com/cbeer/solr_wrapper) for more documentation):
-    * `$ cd ./spec/internal && solr_wrapper` (development)
-    * `$ solr_wrapper` (test)
+5. In the Curator project, start Solr using the following command (see [solr_wrapper](https://github.com/cbeer/solr_wrapper) for more documentation):
+    - `$ cd ./spec/internal && solr_wrapper` (development)
+    - `$ solr_wrapper` (test)
 
 
 ## Contributing
-Any Input/ Suggestions are appreciated as we develop this. Please contact [Ben](mailto:bbarber@bpl.org) or [Eben](mailto:eenglish@bpl.org).
+Any input/suggestions are appreciated as we develop this. Please contact [Ben](mailto:bbarber@bpl.org) or [Eben](mailto:eenglish@bpl.org).
 
 ### Running specs
 
-Solr needs to be running before specs can be run.
+In addition to the Docker containers described above, Solr needs to be running before specs can be run.
 
 Prior to starting Solr, create config directory (only needs to be run once):
 ```

--- a/lib/curator/configuration.rb
+++ b/lib/curator/configuration.rb
@@ -7,6 +7,11 @@ module Curator
       @allmaps_annotations_url || ENV['ALLMAPS_ANNOTATIONS_URL']
     end
 
+    attr_writer :allmaps_data_export_url
+    def allmaps_data_export_url
+      @allmaps_data_export_url || ENV['ALLMAPS_DATA_EXPORT_URL']
+    end
+
     attr_writer :ark_manager_api_url
     def ark_manager_api_url
       @ark_manager_api_url || ENV['ARK_MANAGER_API_URL']

--- a/lib/tasks/allmaps_status.rake
+++ b/lib/tasks/allmaps_status.rake
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+namespace :curator do
+  desc 'check Allmaps georeferencing status for cartographic materials and reindex'
+  task allmaps_status: :environment do
+    data_resp = Faraday.get(Curator.config.allmaps_data_export_url)
+    raise Curator::Exceptions::AllmapsAnnotationsUnavailable, 'COULD NOT PARSE ALLMAPS DATA EXPORT' unless data_resp.status == 200
+
+    allmaps_data = JSON.parse(data_resp.body)
+    regexp_pattern = /https:\/\/ark.digitalcommonwealth.org\/ark:\/50959\/[0-9a-z]{9}\/manifest/
+    ark_ids = []
+    # iterate over the data, find items with IIIF manifest links
+    allmaps_data['items'].each do |am_item|
+      manifest_url = am_item.to_s.match(regexp_pattern).to_s
+      ark_ids << "commonwealth:#{manifest_url.split('/')[-2]}" if manifest_url.present?
+    end
+
+    # reindex any items that are currently un-georeferenced,
+    # query Solr, since we don't store Allmaps status in Curator data model
+    solr = RSolr.connect(url: Curator.config.solr_url)
+    q_params = %w(destination_site_ssim:nblmc hosting_status_ssi:hosted type_of_resource_ssim:Cartographic
+                  curator_model_suffix_ssi:DigitalObject processing_state_ssi:complete -georeferenced_allmaps_bsi:true)
+    resp = solr.get('select', params: { q: q_params.join(' AND '), rows: 50_000, fl: 'id' })
+    nongeorefd = resp.dig('response', 'docs').map { |doc| doc['id'] }
+
+    ark_ids.uniq.each do |ark_id|
+      next unless nongeorefd.include?(ark_id)
+
+      Curator.digital_object_class.find_ark(ark_id).queue_indexing_job
+      sleep(1)
+    end
+  end
+end

--- a/lib/tasks/allmaps_status.rake
+++ b/lib/tasks/allmaps_status.rake
@@ -8,12 +8,12 @@ namespace :curator do
     raise Curator::Exceptions::AllmapsAnnotationsUnavailable, 'COULD NOT PARSE ALLMAPS DATA EXPORT' unless data_resp.status == 200
 
     allmaps_data = JSON.parse(data_resp.body)
-    regexp_pattern = /https:\/\/ark.digitalcommonwealth.org\/ark:\/50959\/[0-9a-z]{9}\/manifest/
+    regexp_pattern = /#{Curator.config.ark_manager_api_url}\/ark:\/50959\/[0-9a-z]{9}\/manifest/
     ark_ids = []
     # iterate over the data, find items with IIIF manifest links
     allmaps_data['items'].each do |am_item|
       manifest_url = am_item.to_s.match(regexp_pattern).to_s
-      ark_ids << "commonwealth:#{manifest_url.split('/')[-2]}" if manifest_url.present?
+      ark_ids << "#{Curator.config.default_ark_params[:namespace_id]}:#{manifest_url.split('/')[-2]}" if manifest_url.present?
     end
 
     # reindex any items that are currently un-georeferenced,

--- a/lib/tasks/allmaps_status.rake
+++ b/lib/tasks/allmaps_status.rake
@@ -3,6 +3,7 @@
 namespace :curator do
   desc 'check Allmaps georeferencing status for cartographic materials and reindex'
   task allmaps_status: :environment do
+    Rails.logger.info 'Running allmaps_status task, checking for newly georeferenced items...'
     data_resp = Faraday.get(Curator.config.allmaps_data_export_url)
     raise Curator::Exceptions::AllmapsAnnotationsUnavailable, 'COULD NOT PARSE ALLMAPS DATA EXPORT' unless data_resp.status == 200
 
@@ -26,8 +27,10 @@ namespace :curator do
     ark_ids.uniq.each do |ark_id|
       next unless nongeorefd.include?(ark_id)
 
+      Rails.logger.info "Reindexing #{ark_id} to update georeferencing status"
       Curator.digital_object_class.find_ark(ark_id).queue_indexing_job
       sleep(1)
     end
+    Rails.logger.info 'allmaps_status task completed.'
   end
 end

--- a/lib/tasks/allmaps_status.rake
+++ b/lib/tasks/allmaps_status.rake
@@ -11,7 +11,7 @@ namespace :curator do
     regexp_pattern = /#{Curator.config.ark_manager_api_url}\/ark:\/50959\/[0-9a-z]{9}\/manifest/
     ark_ids = []
     # iterate over the data, find items with IIIF manifest links
-    allmaps_data['items'].each do |am_item|
+    allmaps_data['items']&.each do |am_item|
       manifest_url = am_item.to_s.match(regexp_pattern).to_s
       ark_ids << "#{Curator.config.default_ark_params[:namespace_id]}:#{manifest_url.split('/')[-2]}" if manifest_url.present?
     end
@@ -22,14 +22,13 @@ namespace :curator do
     q_params = %w(destination_site_ssim:nblmc hosting_status_ssi:hosted type_of_resource_ssim:Cartographic
                   curator_model_suffix_ssi:DigitalObject processing_state_ssi:complete -georeferenced_allmaps_bsi:true)
     resp = solr.get('select', params: { q: q_params.join(' AND '), rows: 50_000, fl: 'id' })
-    nongeorefd = resp.dig('response', 'docs').map { |doc| doc['id'] }
+    nongeorefd = resp.dig('response', 'docs')&.map { |doc| doc['id'] }
 
     ark_ids.uniq.each do |ark_id|
       next unless nongeorefd.include?(ark_id)
 
       Rails.logger.info "Reindexing #{ark_id} to update georeferencing status"
       Curator.digital_object_class.find_ark(ark_id).queue_indexing_job
-      sleep(1)
     end
     Rails.logger.info 'allmaps_status task completed.'
   end

--- a/spec/factories/curator/metastreams/administratives.rb
+++ b/spec/factories/curator/metastreams/administratives.rb
@@ -15,8 +15,12 @@ FactoryBot.define do
       hosting_status { 'hosted' }
     end
 
-    trait :non_havestable do
+    trait :non_harvestable do
       harvestable { false }
+    end
+
+    trait :nblmc_destination_site do
+      destination_site { %w[nblmc] }
     end
 
     trait :for_institution do

--- a/spec/factories/curator/metastreams/administratives.rb
+++ b/spec/factories/curator/metastreams/administratives.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :nblmc_destination_site do
-      destination_site { %w[nblmc] }
+      destination_site { %w(nblmc) }
     end
 
     trait :for_institution do

--- a/spec/internal/.env.test
+++ b/spec/internal/.env.test
@@ -14,3 +14,4 @@ IIIF_SERVER_URL=https://iiif-dc3dev.bpl.org
 IIIF_SERVER_USER=
 IIIF_SERVER_SECRET=
 ALLMAPS_ANNOTATIONS_URL=https://annotations.allmaps.org
+ALLMAPS_DATA_EXPORT_URL=http://127.0.0.1:3000/allmaps_annotations_export_test.json

--- a/spec/services/curator/metastreams/administrative_updater_service_spec.rb
+++ b/spec/services/curator/metastreams/administrative_updater_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Curator::Metastreams::AdministrativeUpdaterService, type: :service do
   before(:all) do
-    @administrative ||= build(:curator_metastreams_administrative, :is_flagged, :non_havestable)
+    @administrative ||= build(:curator_metastreams_administrative, :is_flagged, :non_harvestable)
     @digital_object ||= create(:curator_digital_object, administrative: @administrative)
     @administratable_updated_at = @digital_object.updated_at
     @update_attributes ||= {

--- a/spec/tasks/allmaps_status_spec.rb
+++ b/spec/tasks/allmaps_status_spec.rb
@@ -4,16 +4,18 @@ require 'rails_helper'
 Rails.application.load_tasks
 
 # because this task loads a static export file, and we can't run specs against production data,
-# we need to mock up a test export file using the ids from dynamically created DigitalObject fixtures
+# we need to mock up a test export file using the id from a DigitalObject fixture
 RSpec.describe 'curator:allmaps_status task', type: :task do
   let!(:descriptive) { build(:curator_metastreams_descriptive, :with_all_desc_terms, desc_term_count: 1) }
   let!(:administrative) { build(:curator_metastreams_administrative, :nblmc_destination_site) }
-  let!(:digital_object) { create(:curator_digital_object, ark_id: "#{Curator.config.default_ark_params[:namespace_id]}:a0b1c2d3e",
-                                 administrative: administrative, descriptive: descriptive) }
+  let!(:digital_object) do
+    create(:curator_digital_object, ark_id: "#{Curator.config.default_ark_params[:namespace_id]}:a0b1c2d3e",
+           administrative: administrative, descriptive: descriptive)
+  end
   let!(:ark_id) { digital_object.ark_id }
   let!(:solr_client) { RSolr.connect url: Curator.config.solr_url }
   let(:solr_response_doc) { solr_client.get('select', params: { q: "id:\"#{ark_id}\"" }).dig('response', 'docs')&.first || {} }
-  let(:digital_object_timestamp) { solr_response_doc['timestamp'] }
+  let(:digital_object_solr_timestamp) { solr_response_doc['timestamp'] }
 
   before(:each) do
     digital_object.workflow.processing_state = 'complete'
@@ -56,11 +58,11 @@ RSpec.describe 'curator:allmaps_status task', type: :task do
   end
 
   it 'triggers a reindex for the ARK ids in the data export file' do
-    current_timestamp = DateTime.now
+    initial_timestamp = DateTime.now
     sleep(2)
     VCR.use_cassette('tasks/allmaps_status') do
       Rake::Task['curator:allmaps_status'].invoke
     end
-    expect(Time.parse(digital_object_timestamp) > current_timestamp).to be_truthy
+    expect(Time.zone.parse(digital_object_solr_timestamp) > initial_timestamp).to be_truthy
   end
 end

--- a/spec/tasks/allmaps_status_spec.rb
+++ b/spec/tasks/allmaps_status_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+Rails.application.load_tasks
+
+# because this task loads a static export file, we can't run specs against production data,
+# so we mock up a test export file using ids for dynamically created DigitalObject fixtures
+RSpec.describe 'curator:allmaps_status task', type: :task do
+  let!(:institution) { create(:curator_institution, :with_location) }
+  let!(:collection) { create(:curator_collection, institution: institution) }
+  let!(:digital_object) { create(:curator_digital_object, admin_set: collection) }
+  let!(:ark_id) { digital_object.ark_id }
+  let!(:solr_client) { RSolr.connect url: Curator.config.solr_url }
+  let(:digital_object_timestamp) { } # TK, figure out how to fetch a single record with RSolr
+  before(:each) do
+    annotation_data = { type: 'AnnotationPage',
+                        '@context' => 'http://www.w3.org/ns/anno.jsonld',
+                        items: [
+                          {
+                            id: 'https://annotations.allmaps.org/maps/123456789abcdef',
+                            type: 'Annotation',
+                            target: {
+                              source: {
+                                id: "#{Curator.config.iiif_server_url}#{ark_id}",
+                                partOf: [
+                                  {
+                                    id: "#{Curator.config.ark_manager_api_url}/ark:/50959/#{ark_id.split(':').last}/canvas/abcd123456",
+                                    type: 'Canvas',
+                                    partOf: [
+                                      {
+                                        id: "#{Curator.config.ark_manager_api_url}/ark:/50959/#{ark_id.split(':').last}/manifest",
+                                        type: 'Manifest'
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        ]
+    }
+    # TK write the data to spec/internal/public/allmaps_annotations_export_test.json
+  end
+
+  it 'triggers a reindex for items in the data export file' do
+    current_timestamp = Time.current
+    VCR.use_cassette('tasks/allmaps_status') do
+      Rails.logger.silence do
+        Rake::Task['curator:allmaps_status'].invoke
+      end
+    end
+    expect(record_timestamps.count).to eq(ark_ids.count)
+    expect(record_timestamps).to all(be > current_timestamp)
+  end
+end

--- a/spec/tasks/allmaps_status_spec.rb
+++ b/spec/tasks/allmaps_status_spec.rb
@@ -3,17 +3,21 @@
 require 'rails_helper'
 Rails.application.load_tasks
 
-# because this task loads a static export file, we can't run specs against production data,
-# so we mock up a test export file using ids for dynamically created DigitalObject fixtures
+# because this task loads a static export file, and we can't run specs against production data,
+# we need to mock up a test export file using the ids from dynamically created DigitalObject fixtures
 RSpec.describe 'curator:allmaps_status task', type: :task do
-  let!(:institution) { create(:curator_institution, :with_location) }
-  let!(:collection) { create(:curator_collection, institution: institution) }
-  let!(:digital_object) { create(:curator_digital_object, admin_set: collection) }
+  let!(:descriptive) { build(:curator_metastreams_descriptive, :with_all_desc_terms, desc_term_count: 1) }
+  let!(:administrative) { build(:curator_metastreams_administrative, :nblmc_destination_site) }
+  let!(:digital_object) { create(:curator_digital_object, ark_id: "#{Curator.config.default_ark_params[:namespace_id]}:a0b1c2d3e",
+                                 administrative: administrative, descriptive: descriptive) }
   let!(:ark_id) { digital_object.ark_id }
   let!(:solr_client) { RSolr.connect url: Curator.config.solr_url }
-  let(:solr_response_doc) { solr_client.get('get', params: "id:#{ark_id}").dig('response', 'docs')&.first || {} }
+  let(:solr_response_doc) { solr_client.get('select', params: { q: "id:\"#{ark_id}\"" }).dig('response', 'docs')&.first || {} }
   let(:digital_object_timestamp) { solr_response_doc['timestamp'] }
+
   before(:each) do
+    digital_object.workflow.processing_state = 'complete'
+    digital_object.update_index
     annotation_data = { type: 'AnnotationPage',
                         '@context' => 'http://www.w3.org/ns/anno.jsonld',
                         items: [
@@ -40,19 +44,23 @@ RSpec.describe 'curator:allmaps_status task', type: :task do
                           }
                         ]
     }
-    File.open(Rails.root.join('public/allmaps_annotations_export_test.json'), 'w+') do |f|
-      f.write(JSON.pretty_generate(annotation_data))
-    end
+    stub_request(:any, Curator.config.allmaps_data_export_url).to_return(body: JSON.pretty_generate(annotation_data), status: 200)
   end
 
-  it 'triggers a reindex for items in the data export file' do
-    current_timestamp = Time.current
+  around(:each) do |spec|
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+    spec.run
+    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = false
+  end
+
+  it 'triggers a reindex for the ARK ids in the data export file' do
+    current_timestamp = DateTime.now
+    sleep(2)
     VCR.use_cassette('tasks/allmaps_status') do
-      # Rails.logger.silence do
-      #   Rake::Task['curator:allmaps_status'].invoke
-      # end
       Rake::Task['curator:allmaps_status'].invoke
     end
-    expect(digital_object_timestamp).to be_greater_than current_timestamp
+    expect(Time.parse(digital_object_timestamp) > current_timestamp).to be_truthy
   end
 end

--- a/spec/tasks/allmaps_status_spec.rb
+++ b/spec/tasks/allmaps_status_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'curator:allmaps_status task', type: :task do
 
   it 'triggers a reindex for the ARK ids in the data export file' do
     initial_timestamp = DateTime.now
-    sleep(2)
     VCR.use_cassette('tasks/allmaps_status') do
       Rake::Task['curator:allmaps_status'].invoke
     end

--- a/spec/vcr/tasks/allmaps_status.yml
+++ b/spec/vcr/tasks/allmaps_status.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://127.0.0.1:3000/allmaps_annotations_export_test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      last-modified:
+      - Wed, 11 Feb 2026 22:02:26 GMT
+      content-type:
+      - application/json
+      content-length:
+      - '698'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "AnnotationPage",
+          "@context": "http://www.w3.org/ns/anno.jsonld",
+          "items": [
+            {
+              "id": "https://annotations.allmaps.org/maps/123456789abcdef",
+              "type": "Annotation",
+              "target": {
+                "source": {
+                  "id": "https://iiif-dc3dev.bpl.orgbpl-dev:a0b1c2d3e",
+                  "partOf": [
+                    {
+                      "id": "http://127.0.0.1:3002/ark:/50959/a0b1c2d3e/canvas/abcd123456",
+                      "type": "Canvas",
+                      "partOf": [
+                        {
+                          "id": "http://127.0.0.1:3002/ark:/50959/a0b1c2d3e/manifest",
+                          "type": "Manifest"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+  recorded_at: Wed, 11 Feb 2026 22:02:26 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
This PR adds a rake task that:
1. Parses a nightly export of all locally-hosted objects georeferenced in Allmaps
2. Checks to see if there are any newly georeferenced objects that are not indexed accordingly
3. Queues an indexing job for those newly georeferenced objects

The goal will be to add a cron task on the server where the app is deployed to run this rake task on a regular basis.