### PR TITLE
Add `web_vtt_captions` to video file sets

### DIFF
--- a/.github/workflows/action-build.yaml
+++ b/.github/workflows/action-build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.3.10
+          ruby-version: 3.3.11
           # Automatically runs 'bundle install' and caches gems
           bundler-cache: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
   gem 'dotenv-rails', '~> 2.8'
   gem 'factory_bot_rails', '~> 6.5'
   gem 'faker', '~> 3.2'
-  gem 'puma', '~> 6.6'
+  gem 'puma', '~> 7.2'
   gem 'rubocop', '~> 1.80.2', require: false
   gem 'rubocop-factory_bot', '~> 2.27.1', require: false
   gem 'rubocop-performance', '~> 1.25.0', require: false

--- a/app/models/curator/filestreams/video.rb
+++ b/app/models/curator/filestreams/video.rb
@@ -16,6 +16,7 @@ module Curator
       has_one_attached :text_plain
       has_one_attached :video_access_mp4
       has_one_attached :video_access_webm
+      has_one_attached :web_vtt_captions
     end
 
     has_paper_trail skip: %i(lock_version)

--- a/curator.gemspec
+++ b/curator.gemspec
@@ -41,11 +41,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'concurrent-ruby-ext', '~> 1.3'
   spec.add_dependency 'connection_pool', '~> 2.5'
   spec.add_dependency 'down', '~> 5.4'
-  spec.add_dependency 'htmlentities', '~> 4.3' # TODO: Look into replacing this since the last released in 2014. I recommend turning this into its own parser class.
+  spec.add_dependency 'htmlentities', '~> 4.4' # TODO: Look into replacing this since the last released in 2014. I recommend turning this into its own parser class. - UPDATE it had a release as of late 2025 but not sure how much time the owner is going to dedicate to this
   spec.add_dependency 'http', '~> 5.3'
   spec.add_dependency 'mime-types', '~> 3.7'
-  spec.add_dependency 'nokogiri', '>= 1.18.10'
-  spec.add_dependency 'oj', '~> 3.16'
+  spec.add_dependency 'nokogiri', '>= 1.19.3'
+  spec.add_dependency 'oj', '~> 3.17'
   spec.add_dependency 'ox', ' ~> 2.14'
   spec.add_dependency 'paper_trail', '~> 15.2.0'
   spec.add_dependency 'paper_trail-association_tracking', '~> 2.3'

--- a/spec/controllers/curator/filestreams/file_sets_controller_spec.rb
+++ b/spec/controllers/curator/filestreams/file_sets_controller_spec.rb
@@ -30,6 +30,9 @@ RSpec.describe Curator::Filestreams::FileSetsController, type: :controller do
           # file_attributes[0]['metadata']['ingest_filepath'] = file_fixture('image_thumbnail_300.jpg').to_s
           attributes[:files] = file_attributes
         end
+
+        attributes[:files] << load_json_fixture('video_file_3', 'files') if file_set_type == 'video'
+
         attributes.merge!({
                    file_set_of: { ark_id: parent_obj.ark_id },
                    metastreams: relation_attributes.dup.delete('metastreams')

--- a/spec/fixtures/files/video_file_3.json
+++ b/spec/fixtures/files/video_file_3.json
@@ -1,0 +1,10 @@
+{
+  "files": [{
+    "file_name": "web_vtt_captions.vtt",
+    "file_type": "web_vtt_captions",
+    "content_type": "text/vtt",
+    "metadata": {
+      "ingest_filepath": "BPLDC/curator_fixtures/files/web_vtt_captions.vtt"
+    }
+  }]
+}

--- a/spec/fixtures/files/web_vtt_captions.vtt
+++ b/spec/fixtures/files/web_vtt_captions.vtt
@@ -1,0 +1,622 @@
+WEBVTT
+
+00:04:01.500 --> 00:04:29.069
+One of a metropolitan newspaper's most
+
+00:04:29.069 --> 00:04:31.540
+important nerve centers is advertising.
+
+00:04:32.230 --> 00:04:34.810
+The advertising director
+of the Boston Herald
+
+00:04:34.810 --> 00:04:36.439
+Traveler is George Ackerson.
+
+00:04:37.540 --> 00:04:40.040
+George, just what
+does a newspaper advertising
+
+00:04:40.040 --> 00:04:40.870
+department do?
+
+00:04:41.680 --> 00:04:44.980
+Jim here in this
+department we sell and process
+
+00:04:44.980 --> 00:04:48.870
+the hundreds of thousands of
+ads that in a year
+
+00:04:48.870 --> 00:04:52.459
+provide the revenue that
+is necessary for a
+
+00:04:52.459 --> 00:04:55.720
+newspaper to enable it
+to give the service to
+
+00:04:55.720 --> 00:04:56.930
+the community that we do.
+
+00:04:57.779 --> 00:05:00.579
+I wonder without mentioning
+the names of individuals
+
+00:05:00.579 --> 00:05:02.189
+in charge thereof,
+
+00:05:02.629 --> 00:05:05.029
+you couldn't tell us
+something about the individual
+
+00:05:05.029 --> 00:05:07.560
+departments within the advertising section.
+
+00:05:08.550 --> 00:05:11.589
+Well, first of all, Jim,
+we have the local advertising
+
+00:05:11.589 --> 00:05:14.930
+department which services
+the retail trade in
+
+00:05:14.930 --> 00:05:15.810
+Greater Boston.
+
+00:05:16.689 --> 00:05:19.129
+Then we have
+the National Advertising Department
+
+00:05:19.129 --> 00:05:22.689
+which has jurisdiction over advertising throughout
+
+00:05:22.689 --> 00:05:24.810
+the United States and
+all over the world for
+
+00:05:24.810 --> 00:05:25.370
+that matter.
+
+00:05:26.029 --> 00:05:28.689
+Then there's the classified advertising department
+
+00:05:28.689 --> 00:05:31.689
+which handles all the
+small ads from thousands
+
+00:05:31.689 --> 00:05:34.920
+of people, lost and
+found, real estate and so forth.
+
+00:05:35.199 --> 00:05:37.620
+And finally, we
+have the display department
+
+00:05:37.620 --> 00:05:40.980
+which pours all these
+together and makes them
+
+00:05:40.980 --> 00:05:43.000
+up into the paper
+that you see every day.
+
+00:05:43.860 --> 00:05:47.199
+Well, it sounds very much
+as though it's a teamwork
+
+00:05:47.199 --> 00:05:47.899
+proposition.
+
+00:05:48.759 --> 00:05:50.040
+Yes, it has to be Jim.
+
+00:05:50.370 --> 00:05:52.279
+And here's the way
+we break it down here.
+
+00:05:52.430 --> 00:05:55.199
+First of all, under
+me, there is Harry McGowan,
+
+00:05:55.430 --> 00:05:57.519
+who is assistant advertising director.
+
+00:05:58.459 --> 00:05:59.899
+Under him is Paul Roberts,
+
+00:06:00.500 --> 00:06:03.600
+National Advertising Manager Bob Farron,
+
+00:06:04.019 --> 00:06:07.370
+classified advertising manager, Jim Daly, who
+
+00:06:07.370 --> 00:06:09.000
+manages the display department,
+
+00:06:09.480 --> 00:06:10.720
+and Steve Lynch,
+
+00:06:11.360 --> 00:06:13.199
+who is our promotion department manager,
+
+00:06:13.819 --> 00:06:16.120
+missing from the picture
+Jim is Vincent DeCane,
+
+00:06:16.279 --> 00:06:18.199
+who is our local advertising manager.
+
+00:06:18.620 --> 00:06:20.899
+Well how about us taking
+a look at some of
+
+00:06:20.899 --> 00:06:23.019
+the rest of this advertising operation?
+
+00:06:24.040 --> 00:06:26.720
+Jim, this is
+the classified telephone room.
+
+00:06:27.519 --> 00:06:30.100
+In this room, these trained specialists
+
+00:06:30.970 --> 00:06:34.840
+handle about a million
+telephone calls a year.
+
+00:06:35.620 --> 00:06:38.840
+About half of these
+calls are outgoing calls
+
+00:06:38.840 --> 00:06:41.399
+to regular classified advertisers.
+
+00:06:42.180 --> 00:06:45.220
+The remainder are voluntary calls, incoming
+
+00:06:45.220 --> 00:06:47.579
+from residents all over New England,
+
+00:06:48.079 --> 00:06:50.800
+and placing ads ranging
+from lost dogs and lost
+
+00:06:50.800 --> 00:06:53.600
+cats to selling used furniture,
+
+00:06:54.430 --> 00:06:56.659
+real estate and used cars.
+
+00:06:57.990 --> 00:07:00.519
+We have conceived this
+room, Jim, based around
+
+00:07:00.800 --> 00:07:04.189
+a brand new private
+telephone number which is
+
+00:07:04.189 --> 00:07:06.430
+different from the newspaper's regular number.
+
+00:07:06.540 --> 00:07:12.310
+That number is Algonquin
+41234 and by calling
+
+00:07:12.310 --> 00:07:15.569
+that number you can
+get the best service in
+
+00:07:15.569 --> 00:07:16.060
+Boston.
+
+00:07:17.220 --> 00:07:19.370
+George, what other
+improvements are there in
+
+00:07:19.370 --> 00:07:21.779
+this new Boston
+Herald Traveler building that
+
+00:07:21.779 --> 00:07:24.339
+are likely to
+help the advertising department?
+
+00:07:25.399 --> 00:07:27.930
+Jim, I know that in
+a moment or two Stan
+
+00:07:27.930 --> 00:07:31.060
+White our production manager
+is going to show
+
+00:07:31.060 --> 00:07:33.459
+you a lot of
+the new production facilities.
+
+00:07:33.720 --> 00:07:36.069
+But right here we
+have something that we have
+
+00:07:36.069 --> 00:07:38.399
+great hopes for
+in the advertising department.
+
+00:07:38.689 --> 00:07:43.159
+This is a photon machine
+which sets ads by photo
+
+00:07:43.159 --> 00:07:46.300
+composition instead of the traditional method
+
+00:07:46.300 --> 00:07:50.860
+of pouring molten metal
+into mold so to speak.
+
+00:07:51.519 --> 00:07:53.689
+We're experimenting with
+this and doing more
+
+00:07:53.689 --> 00:07:56.040
+and more advertising work with it.
+
+00:07:56.159 --> 00:07:58.540
+And I think in the
+future this will carry the
+
+00:07:58.540 --> 00:08:02.189
+burden of advertising composition.
+
+00:08:02.189 --> 00:10:17.659
+[Silence]
+
+00:10:18.659 --> 00:10:21.240
+From the presses,
+the finished newspapers go
+
+00:10:21.240 --> 00:10:24.279
+by conveyor to the
+mail room, which is adjacent
+
+00:10:24.279 --> 00:10:25.200
+to the press room.
+
+00:10:26.000 --> 00:10:29.409
+It's almost the size
+of a football field about
+
+00:10:29.409 --> 00:10:32.909
+the size of the
+composing room and it's amazingly
+
+00:10:32.909 --> 00:10:36.870
+automatic operation is quarterbacked by the
+
+00:10:36.870 --> 00:10:39.440
+circulation manager of
+the Boston Herald Traveler, Ben Moltzman.
+
+00:10:39.909 --> 00:10:44.549
+Ben, what is the purpose
+of every once in a
+
+00:10:44.549 --> 00:10:46.860
+while a newspaper coming
+off that belt at
+
+00:10:46.860 --> 00:10:47.940
+an angle?
+
+00:10:48.629 --> 00:10:51.480
+Well the 25th paper is
+kicked out at the press
+
+00:10:51.480 --> 00:10:54.269
+room level to indicate to
+the mailers when it comes
+
+00:10:54.269 --> 00:10:58.220
+up on the conveyor
+that it is the 25th paper and they
+
+00:10:58.220 --> 00:11:00.029
+take them off and lift the 25.
+
+00:11:01.250 --> 00:11:03.480
+And those men down at
+the bottom who are putting
+
+00:11:03.480 --> 00:11:05.740
+them into bundles, how
+many papers in a bundle?
+
+00:11:05.860 --> 00:11:07.049
+As it continues its ride.
+
+00:11:07.169 --> 00:11:10.409
+Today we have a 44
+page paper and they're putting
+
+00:11:10.409 --> 00:11:11.629
+them in bundles of 50.
+
+00:11:11.950 --> 00:11:12.600
+Lifts of 25.
+
+00:11:13.620 --> 00:11:16.220
+They are what we're
+doing now, what we call flying
+
+00:11:16.220 --> 00:11:18.100
+the papers onto the conveyor.
+
+00:11:18.549 --> 00:11:22.500
+They are on their way
+to a machine with a
+
+00:11:22.500 --> 00:11:23.870
+big circle and a chute.
+
+00:11:24.070 --> 00:11:24.370
+What's that?
+
+00:11:24.649 --> 00:11:27.169
+This roller table here
+takes each bundle down
+
+00:11:27.200 --> 00:11:30.139
+and at the end of
+the table it trips a
+
+00:11:30.139 --> 00:11:33.840
+mechanism that the forces
+the papers into
+
+00:11:33.840 --> 00:11:36.519
+the wire-tying machine
+which again is synchronized
+
+00:11:36.519 --> 00:11:40.240
+with this motion and
+is automatically tied and
+
+00:11:40.240 --> 00:11:42.600
+ejected down the chute 
+by the next bundle.
+
+00:11:43.220 --> 00:11:45.980
+We understand that the
+presses can turn out newspapers
+
+00:11:45.980 --> 00:11:48.240
+at the rate
+of 42,000 an hour.
+
+00:11:48.659 --> 00:11:50.320
+Is this room equipped
+to handle that sort of
+
+00:11:50.320 --> 00:11:50.659
+traffic?
+
+00:11:50.860 --> 00:11:52.740
+That's what this room
+is designed to handle.
+
+00:11:53.100 --> 00:11:57.269
+It looks like an
+amazingly accessible room where you
+
+00:11:57.269 --> 00:11:57.980
+can get around.
+
+00:11:58.250 --> 00:12:00.840
+That is the real feature
+of this room, I believe,
+
+00:12:01.000 --> 00:12:03.419
+is that particularly with
+a large Sunday paper
+
+00:12:03.419 --> 00:12:06.240
+you have to have
+complete accessibility at all
+
+00:12:06.240 --> 00:12:10.389
+times, particularly to set
+up your room to ensure
+
+00:12:10.389 --> 00:12:12.720
+that you do not
+have any interruption with the
+
+00:12:12.720 --> 00:12:13.679
+flow of your paper and
+
+00:12:13.820 --> 00:12:15.679
+we have accomplished
+this in this mail-room.
+
+00:12:16.370 --> 00:12:17.720
+Speaking of Sunday newspapers,
+
+00:12:18.149 --> 00:12:20.340
+I notice a group of
+men working around a circular
+
+00:12:20.340 --> 00:12:22.740
+machine over here and
+they have what appears
+
+00:12:22.740 --> 00:12:23.820
+to be the Sunday supplement.
+
+00:12:24.009 --> 00:12:24.649
+What does that do?
+
+00:12:25.149 --> 00:12:27.250
+Well, that is a
+Sheridan stuffing machine.
+
+00:12:27.549 --> 00:12:30.100
+We are the first
+newspaper in New England to
+
+00:12:30.100 --> 00:12:31.509
+install this machine.
+
+00:12:31.809 --> 00:12:35.600
+It automatically feeds
+all of Sunday supplements,
+
+00:12:35.860 --> 00:12:37.240
+the roto comic and magazine,
+
+00:12:37.870 --> 00:12:40.450
+and any other section
+which we might have to
+
+00:12:40.450 --> 00:12:42.980
+complete this supplement
+for our Sunday readers
+
+00:12:42.980 --> 00:12:45.220
+and assure them that
+their paper is complete
+
+00:12:45.220 --> 00:12:45.889
+every Sunday.
+
+00:12:46.480 --> 00:12:50.190
+And I also understand,
+Ben, that the mailing of
+
+00:12:50.190 --> 00:12:52.570
+papers is taken care of
+at the same time without
+
+00:12:52.570 --> 00:12:54.240
+interfering with the other operations.
+
+00:12:54.360 --> 00:12:56.149
+Yes, that's particularly
+true in the morning.
+
+00:12:56.289 --> 00:12:59.409
+We have a belt that
+runs along the floor and
+
+00:12:59.409 --> 00:13:02.070
+the process of mail,
+put them in bags.
+
+00:13:02.250 --> 00:13:05.629
+And this particular chute
+here, this belt chute
+
+00:13:05.629 --> 00:13:09.149
+delivers them to a
+mail chute and deposits
+
+00:13:09.149 --> 00:13:11.870
+them on the platform
+away from the other operation.
+
+00:13:12.549 --> 00:13:14.740
+And then they go to
+the readers of the Herald
+
+00:13:14.740 --> 00:13:15.370
+and Traveler.
+
+00:13:16.070 --> 00:13:18.309
+And they leave our
+tying machine to down these
+
+00:13:18.309 --> 00:13:20.830
+chutes and 83 trucks
+ready to dispatch them
+
+00:13:20.830 --> 00:13:21.669
+throughout New England.
+
+00:13:25.720 --> 00:13:28.059
+Here on the loading
+platform Ben we come fairly
+
+00:13:28.059 --> 00:13:29.820
+close to the
+last step in delivery.
+
+00:13:29.980 --> 00:13:30.279
+Do we not?
+
+00:13:30.559 --> 00:13:31.360
+That's true Jim.
+
+00:13:32.019 --> 00:13:33.419
+This is completely automatic.
+
+00:13:33.720 --> 00:13:37.419
+These tables have
+motorized belts which take
+
+00:13:37.419 --> 00:13:40.120
+the papers from the
+Chutes and deflect them
+
+00:13:40.120 --> 00:13:42.720
+down these gravity feeders.
+
+00:13:43.299 --> 00:13:45.899
+As you see there's
+an arm underneath these roller
+
+00:13:45.899 --> 00:13:48.779
+feeders that extends into the truck.
+
+00:13:48.820 --> 00:13:50.980
+it makes it cuts down
+the work for the driver.
+
+00:13:51.620 --> 00:13:54.940
+Also we have
+14 loading positions here.
+
+00:13:55.100 --> 00:13:59.840
+and the deflectors are automatically controlled
+
+00:13:59.840 --> 00:14:01.750
+by buttons.
+
+00:14:03.059 --> 00:14:08.340
+These men find this
+to a great advantage, particularly
+
+00:14:08.340 --> 00:14:10.539
+when you take
+the production of high-speed
+
+00:14:10.539 --> 00:14:11.100
+presses.
+
+00:14:11.860 --> 00:14:13.960
+Is your delivery system largely motorized?
+
+00:14:14.179 --> 00:14:18.059
+It is today, as
+you know, the train transportation
+
+00:14:18.059 --> 00:14:19.250
+is declining.
+
+00:14:19.250 --> 00:14:21.980
+We are now delivering
+with our own equipment
+
+00:14:21.980 --> 00:14:24.340
+within the radius of 50
+from Boston.  
+
+00:14:27.389 --> 00:16:59.940
+[silence]

--- a/spec/internal/config/puma.rb
+++ b/spec/internal/config/puma.rb
@@ -36,15 +36,15 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 # Allow puma to be restarted by `rails restart` command.
 
 # NOTE: These need to be added in the curator_app config/puma.rb
-on_worker_fork do
+before_worker_fork do
   Curator::Services::RemoteService.clear!
 end
 
-on_worker_boot do
+before_worker_boot do
   Curator::Services::RemoteService.reload!
 end
 
-on_worker_shutdown do
+before_worker_shutdown do
   Curator::Services::RemoteService.clear!
 end
 

--- a/spec/models/curator/filestreams/video_spec.rb
+++ b/spec/models/curator/filestreams/video_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Curator::Filestreams::Video, type: :model do
     it_behaves_like 'thumbnailable'
 
     it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(document_primary document_access text_plain video_primary video_access_mp4 video_access_webm) }
+      let(:has_one_file_attachments) { %i(document_primary document_access text_plain video_primary video_access_mp4 video_access_webm web_vtt_captions) }
     end
   end
 end

--- a/spec/services/curator/filestreams/file_set_factory_service_spec.rb
+++ b/spec/services/curator/filestreams/file_set_factory_service_spec.rb
@@ -71,4 +71,29 @@ RSpec.describe Curator::Filestreams::FileSetFactoryService, type: :service do
       end
     end
   end
+
+  context 'with video file sets' do
+    before(:all) do
+      @video_file_set_json = load_json_fixture('video_file_set', 'file_set')
+      @video_files_json = load_json_fixture('video_file_2', 'files')
+      @video_files_json += load_json_fixture('video_file_3', 'files')
+      # create parent DigitalObject
+      VCR.use_cassette('services/filestreams/video_factory_service') do
+        parent_obj = create(:curator_digital_object, ark_id: 'bpl-dev:0a075df91ec')
+        @video_file_set_json['file_set_of']['ark_id'] = parent_obj.ark_id
+        @video_file_set_json['files'] = @video_files_json
+        expect do
+          @video_success, @video_file_set = handle_factory_result(described_class, @video_file_set_json)
+        end.to change(Curator::Filestreams::FileSet, :count).by(1)
+      end
+    end
+
+    specify { expect(@video_success).to be_truthy }
+    specify { expect(@video_file_set).to be_valid }
+
+    it 'is expected to have attachments' do
+      expect(@video_file_set.video_access_mp4).to be_attached
+      expect(@video_file_set.web_vtt_captions).to be_attached
+    end
+  end
 end

--- a/spec/tasks/allmaps_status_spec.rb
+++ b/spec/tasks/allmaps_status_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'curator:allmaps_status task', type: :task do
 
   it 'triggers a reindex for the ARK ids in the data export file' do
     initial_timestamp = DateTime.now
-    VCR.use_cassette('tasks/allmaps_status') do
+    VCR.use_cassette('tasks/allmaps_status', record: :once) do
       Rake::Task['curator:allmaps_status'].invoke
     end
     expect(Time.zone.parse(digital_object_solr_timestamp) > initial_timestamp).to be_truthy

--- a/spec/vcr/services/filestreams/video_factory_service.yml
+++ b/spec/vcr/services/filestreams/video_factory_service.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://127.0.0.1:3002/api/v2/arks
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"namespace_ark":"50959","namespace_id":"bpl-dev","url_base":"https://search-dc3dev.bpl.org","model_type":"Curator::Filestreams::Video","parent_pid":"bpl-dev:0a075df91ec","secondary_parent_pids":[],"local_original_identifier_type":"filename","local_original_identifier":"06_01_016692"}}'
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3002
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - DENY
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f8867b92a26772a39287bc8e6f2e115b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4a2b2c1a-0799-4263-8f12-1fa3360da095
+      X-Runtime:
+      - '1.161096'
+      Server-Timing:
+      - sql.active_record;dur=30.35, start_processing.action_controller;dur=0.01,
+        start_transaction.active_record;dur=0.02, transaction.active_record;dur=10.53,
+        render_partial.action_view;dur=0.27, render_template.action_view;dur=1.81,
+        process_action.action_controller;dur=994.86
+      Vary:
+      - Origin
+      Content-Length:
+      - '406'
+    body:
+      encoding: UTF-8
+      string: '{"ark":{"id":5,"pid":"bpl-dev:h989r3203","created_at":"2026-06-09T15:35:59.402Z","updated_at":"2026-06-09T15:35:59.402Z","parent_pid":"bpl-dev:0a075df91ec","model_type":"Curator::Filestreams::Video","local_original_identifier":"06_01_016692","local_original_identifier_type":"filename","namespace_ark":"50959","namespace_id":"bpl-dev","secondary_parent_pids":[],"url_base":"https://search-dc3dev.bpl.org"}}'
+  recorded_at: Tue, 09 Jun 2026 15:36:00 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr/tasks/allmaps_status.yml
+++ b/spec/vcr/tasks/allmaps_status.yml
@@ -51,4 +51,49 @@ http_interactions:
           ]
         }
   recorded_at: Wed, 11 Feb 2026 22:02:26 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3000/allmaps_annotations_export_test.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.5
+  response:
+    status:
+      code: 200
+      message: ''
+    headers: {}
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "type": "AnnotationPage",
+          "@context": "http://www.w3.org/ns/anno.jsonld",
+          "items": [
+            {
+              "id": "https://annotations.allmaps.org/maps/123456789abcdef",
+              "type": "Annotation",
+              "target": {
+                "source": {
+                  "id": "https://iiif-dc3dev.bpl.orgbpl-dev:a0b1c2d3e",
+                  "partOf": [
+                    {
+                      "id": "http://127.0.0.1:3002/ark:/50959/a0b1c2d3e/canvas/abcd123456",
+                      "type": "Canvas",
+                      "partOf": [
+                        {
+                          "id": "http://127.0.0.1:3002/ark:/50959/a0b1c2d3e/manifest",
+                          "type": "Manifest"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+  recorded_at: Mon, 08 Jun 2026 19:36:52 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr/tasks/reindex_all.yml
+++ b/spec/vcr/tasks/reindex_all.yml
@@ -8118,4 +8118,483 @@ http_interactions:
           "error": "Manifest not found: 98e1b7893d2e703f"
         }
   recorded_at: Thu, 29 Jan 2026 16:40:23 GMT
-recorded_with: VCR 6.3.1
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/1005467
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"b8a8cb27e089326b304524c13cbc64ef"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aec29cb5-2a3f-410d-ac13-e90edd09e4b1
+      X-Runtime:
+      - '0.841113'
+      Server-Timing:
+      - sql.active_record;dur=4.71, start_processing.action_controller;dur=0.28, cache_read.active_support;dur=1.91,
+        cache_generate.active_support;dur=768.89, cache_write.active_support;dur=1.39,
+        process_action.action_controller;dur=774.95
+      Content-Length:
+      - '272'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.2833","longitude":"-71.1167","combined":"42.2833,-71.1167"},"hier_geo":{"city_section":"Roslindale","city":"Boston","continent":"North
+        and Central America","county":"Suffolk","country":"United States","state":"Massachusetts"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:11 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2050042
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f60d89b4333c40d9816a003455dd0e9b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1a4bfd13-c377-4e5b-8899-1d8777009615
+      X-Runtime:
+      - '0.596741'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.00, cache_read.active_support;dur=0.20,
+        cache_generate.active_support;dur=591.77, cache_write.active_support;dur=1.01,
+        process_action.action_controller;dur=594.05
+      Content-Length:
+      - '236'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
+        and Central America","county":"Essex","country":"United States","state":"Massachusetts"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:13 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2050042
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"f60d89b4333c40d9816a003455dd0e9b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f6e96fa6-2331-40e3-81c8-58b3e933cdea
+      X-Runtime:
+      - '0.016642'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, cache_read.active_support;dur=15.15,
+        cache_fetch_hit.active_support;dur=0.00, process_action.action_controller;dur=15.48
+      Content-Length:
+      - '236'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.4667","longitude":"-70.95","combined":"42.4667,-70.95"},"hier_geo":{"city":"Lynn","continent":"North
+        and Central America","county":"Essex","country":"United States","state":"Massachusetts"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:13 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2362636
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"bddf582b4ec532fdcdfac3fd48f0bd34"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4ae62639-7720-4c3a-acda-12c311da03c1
+      X-Runtime:
+      - '0.552372'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, cache_read.active_support;dur=0.26,
+        cache_generate.active_support;dur=547.56, cache_write.active_support;dur=0.93,
+        process_action.action_controller;dur=549.60
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"43.7333","longitude":"-70.1167","combined":"43.7333,-70.1167"},"hier_geo":{"island":"Great
+        Chebeague Island","continent":"North and Central America","county":"Cumberland","country":"United
+        States","state":"Maine"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:14 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2120926
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c129836d4e6eb7932603b6ce55c28aa8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5c278dfe-412e-4f4a-b5f9-d740d940e764
+      X-Runtime:
+      - '0.444144'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, cache_read.active_support;dur=0.19,
+        cache_generate.active_support;dur=435.20, cache_write.active_support;dur=0.94,
+        process_action.action_controller;dur=438.08
+      Content-Length:
+      - '249'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"44.9333","longitude":"-91.3833","combined":"44.9333,-91.3833"},"hier_geo":{"city":"Chippewa
+        Falls","continent":"North and Central America","county":"Chippewa","country":"United
+        States","state":"Wisconsin"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:14 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/1004027
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"d660cb537eae2b38a2d76743067df5ef"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2b2ff97d-4f66-4f24-870a-52a59852c805
+      X-Runtime:
+      - '0.436580'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.00, cache_read.active_support;dur=0.18,
+        cache_generate.active_support;dur=434.04, cache_write.active_support;dur=0.45,
+        process_action.action_controller;dur=435.06
+      Content-Length:
+      - '266'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.35","longitude":"-71.0833","combined":"42.35,-71.0833"},"hier_geo":{"city_section":"Back
+        Bay","city":"Boston","continent":"North and Central America","county":"Suffolk","country":"United
+        States","state":"Massachusetts"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:15 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2362636
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"bddf582b4ec532fdcdfac3fd48f0bd34"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b65eb224-fe96-4864-ae1f-69194ed64d8d
+      X-Runtime:
+      - '0.003060'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.00, cache_read.active_support;dur=0.22,
+        cache_fetch_hit.active_support;dur=0.00, process_action.action_controller;dur=0.45
+      Content-Length:
+      - '257'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"43.7333","longitude":"-70.1167","combined":"43.7333,-70.1167"},"hier_geo":{"island":"Great
+        Chebeague Island","continent":"North and Central America","county":"Cumberland","country":"United
+        States","state":"Maine"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:15 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/2120926
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"c129836d4e6eb7932603b6ce55c28aa8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 68d547a1-7bc3-4422-afe9-902aefd2416c
+      X-Runtime:
+      - '0.002185'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.00, cache_read.active_support;dur=0.20,
+        cache_fetch_hit.active_support;dur=0.00, process_action.action_controller;dur=0.73
+      Content-Length:
+      - '249'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"44.9333","longitude":"-91.3833","combined":"44.9333,-91.3833"},"hier_geo":{"city":"Chippewa
+        Falls","continent":"North and Central America","county":"Chippewa","country":"United
+        States","state":"Wisconsin"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:15 GMT
+- request:
+    method: get
+    uri: http://127.0.0.1:3001/geomash/tgn/1004027
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Connection:
+      - Keep-Alive
+      Host:
+      - 127.0.0.1:3001
+      User-Agent:
+      - http.rb/5.3.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Etag:
+      - W/"d660cb537eae2b38a2d76743067df5ef"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7723d85e-823b-4876-8a69-c957b936dba5
+      X-Runtime:
+      - '0.002647'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.00, cache_read.active_support;dur=0.34,
+        cache_fetch_hit.active_support;dur=0.00, process_action.action_controller;dur=0.66
+      Content-Length:
+      - '266'
+    body:
+      encoding: UTF-8
+      string: '{"coords":{"latitude":"42.35","longitude":"-71.0833","combined":"42.35,-71.0833"},"hier_geo":{"city_section":"Back
+        Bay","city":"Boston","continent":"North and Central America","county":"Suffolk","country":"United
+        States","state":"Massachusetts"},"non_hier_geo":null}'
+  recorded_at: Mon, 08 Jun 2026 19:40:15 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
- Added `web_vtt_captions` attachment type for video file sets

- Resolves #388

- Bumped a couple dependencies

- Updated `puma` to 7.2.1 and changed config to prevent breaking changes in puma > 7

- Only record  `vcr` cassette  for `allmaps` status once