### PR TITLE
Add `web_vtt_captions` to attachment indexer and audio file sets

### DIFF
--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -63,10 +63,10 @@ module Curator
     end
 
     included do
-      # in including model class, set to an _instance_ of a Curator::Indexer or Traject::Indexer subclass.
-      # as in: self.curator_indexable_mapper = MyWorkIndexer.new
+      # in including model class, set subclass of a Curator::Indexer or Traject::Indexer subclass.
+      # as in: self.curator_indexable_mapper = MyWorkIndexer
       #
-      # Re-using the same instance performs better because of how traject is set up,
+      # We want to create a new instance of a mapper so that it is thread safe for sidekiq jobs,
       # although may do weird things with dev-mode class reloading
       class_attribute :curator_indexable_mapper
 
@@ -81,7 +81,7 @@ module Curator
     # By default will use:
     #  - curator_indexable_mapper
     #  - a per-update writer, or thread/block-specific writer configured with `self.index_with`
-    def update_index(mapper: curator_indexable_mapper, writer: nil)
+    def update_index(mapper: curator_indexable_mapper.new, writer: nil)
       RecordIndexUpdater.new(self, mapper: mapper, writer: writer).update_index
     end
 

--- a/app/indexers/concerns/curator/indexable/record_index_updater.rb
+++ b/app/indexers/concerns/curator/indexable/record_index_updater.rb
@@ -40,6 +40,8 @@ module Curator
         else
           writer.delete(record.ark_id)
         end
+      ensure
+        writer&.close
       end
 
       # The Traject::Indexer we'll use to map the #record into an index representation,

--- a/app/indexers/concerns/curator/indexer/attachment_indexer.rb
+++ b/app/indexers/concerns/curator/indexer/attachment_indexer.rb
@@ -12,7 +12,7 @@ module Curator
                                     image_access_800 image_georectified_primary image_primary image_negative_primary
                                     image_service image_thumbnail_300 metadata_foxml metadata_ia metadata_ia_scan
                                     metadata_marc_xml metadata_mods metadata_oai text_coordinates_access
-                                    text_coordinates_primary text_plain video_access_mp4 video_access_webm video_primary).freeze
+                                    text_coordinates_primary text_plain video_access_mp4 video_access_webm video_primary web_vtt_captions).freeze
       # HAS_MANY_ATTACHMENT_TYPES = %i().freeze
 
       included do

--- a/app/jobs/curator/indexer/deletion_job.rb
+++ b/app/jobs/curator/indexer/deletion_job.rb
@@ -11,6 +11,8 @@ module Curator
     def perform(ark_id)
       writer = Curator.config.indexable_settings.writer_instance!
       writer.delete(ark_id)
+    ensure
+      writer&.close
     end
 
     protected

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -9,7 +9,7 @@ module Curator
     include Curator::Mappings::Exemplary::Object
     include Curator::Indexable
 
-    self.curator_indexable_mapper = Curator::CollectionIndexer.new
+    self.curator_indexable_mapper = Curator::CollectionIndexer
 
     scope :for_serialization, -> { includes(exemplary_image_mapping: :exemplary_file_set).with_metastreams }
     scope :for_reindex_all, -> { for_serialization.joins(:administrative, :workflow) }

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -12,7 +12,7 @@ module Curator
 
     has_paper_trail skip: %i(lock_version)
 
-    self.curator_indexable_mapper = Curator::DigitalObjectIndexer.new
+    self.curator_indexable_mapper = Curator::DigitalObjectIndexer
 
     scope :for_serialization, -> { includes(:file_sets, exemplary_image_mapping: :exemplary_file_set).with_metastreams }
     scope :for_reindex_all, -> { for_serialization.joins(:administrative, :descriptive, :workflow) }

--- a/app/models/curator/filestreams/audio.rb
+++ b/app/models/curator/filestreams/audio.rb
@@ -15,6 +15,7 @@ module Curator
       has_one_attached :audio_access
       has_one_attached :document_access
       has_one_attached :text_plain
+      has_one_attached :web_vtt_captions
     end
 
     has_paper_trail skip: %i(lock_version)

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -21,7 +21,7 @@ module Curator
     #   includes(attachment_reflections)
     # end
 
-    self.curator_indexable_mapper = Curator::FileSetIndexer.new
+    self.curator_indexable_mapper = Curator::FileSetIndexer
 
     scope :for_serialization, -> { with_metastreams }
 

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -9,7 +9,7 @@ module Curator
     include Curator::Metastreamable::Basic
     include Curator::Mappings::Exemplary::Object
 
-    self.curator_indexable_mapper = Curator::InstitutionIndexer.new
+    self.curator_indexable_mapper = Curator::InstitutionIndexer
 
     scope :with_location, -> { includes(location: :authority) }
     scope :for_serialization, -> { includes(exemplary_image_mapping: :exemplary_file_set).with_metastreams.with_location.includes(:host_collections) }
@@ -63,7 +63,7 @@ module Curator
           Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 2.seconds)
         end
 
-        reindex_jobs << Curator::Indexer::IndexingJob.new(col.class.name col.id).set(wait: 2.seconds)
+        reindex_jobs << Curator::Indexer::IndexingJob.new(col.class.name, col.id).set(wait: 2.seconds)
 
         ActiveJob.perform_all_later(reindex_jobs)
       end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./docker/bpldc_authority_entry.sh:/bpldc_authority_entry.sh
     environment:
       - RAILS_ENV=development
-      - WEB_CONCURRENCY=0
+      - WEB_CONCURRENCY=2
       - RAILS_LOG_TO_STDOUT=true
       - POSTGRES_HOST=pg
       - BPLDC_REDIS_CACHE_URL=redis://cache:6379/1
@@ -59,7 +59,7 @@ services:
     environment:
       - RAILS_ENV=development
       - RAILS_LOG_TO_STDOUT=true
-      - WEB_CONCURRENCY=0
+      - WEB_CONCURRENCY=2
       - ARK_MANAGER_DATABASE_HOST=pg
       - ARK_MANAGER_REDIS_CACHE_URL=redis://cache:6379/0
     depends_on:

--- a/spec/indexers/concerns/curator/indexable/record_index_updater_spec.rb
+++ b/spec/indexers/concerns/curator/indexable/record_index_updater_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Curator::Indexable::RecordIndexUpdater do
 
   describe '#mapper' do
     it 'returns the curator_indexable_mapper' do
-      expect(subject.mapper.class.superclass).to eq Curator::Indexer
+      expect(subject.mapper).to be <= Curator::Indexer
     end
   end
 

--- a/spec/indexers/concerns/curator/indexable_spec.rb
+++ b/spec/indexers/concerns/curator/indexable_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Curator::Indexable do
   describe 'included class attributes' do
     describe 'curator_indexable_mapper' do
       it 'returns as expected' do
-        expect(@indexable_object.curator_indexable_mapper.class.superclass).to eq Curator::Indexer
+        expect(@indexable_object.curator_indexable_mapper).to be <= Curator::Indexer
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Curator::Indexable do
     describe 'called directly on object' do
       it 'makes an update request to the solr_url' do
         inst_to_update = @indexable_object.clone
-        inst_to_update.curator_indexable_mapper = Curator::Indexer.new
+        inst_to_update.curator_indexable_mapper = Curator::Indexer
         inst_to_update.update_index
         assert_requested :post, solr_update_url,
                          body: body_for_update_request(inst_to_update)

--- a/spec/models/curator/filestreams/audio_spec.rb
+++ b/spec/models/curator/filestreams/audio_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Curator::Filestreams::Audio, type: :model do
 
     it_behaves_like 'thumbnailable'
     it_behaves_like 'has_file_attachments' do
-      let(:has_one_file_attachments) { %i(audio_access audio_primary document_access document_primary text_plain) }
+      let(:has_one_file_attachments) { %i(audio_access audio_primary document_access document_primary text_plain web_vtt_captions) }
     end
   end
 end


### PR DESCRIPTION
- Added `web_vtt_captions` to attachments indexer `HAS_ONE_ATTACHMENT_TYPES` constant

- Added `ensure` blocks to close the `traject` writer to make thread safe/ prevent memory leaks

- Instantiate `curator_indexable_mapper` on `update_index` instead of method to ensure further thread safety inside `sidekiq` jobs