### PR TITLE
Fixes and tuning

### DIFF
--- a/app/callbacks/curator/mintable_callbacks.rb
+++ b/app/callbacks/curator/mintable_callbacks.rb
@@ -46,7 +46,7 @@ module Curator
     # NOTE: only use for after_destroy_commit
 
     def self.after_commit(mintable)
-      Curator::ArkDestroyJob.set(wait: 2.seconds).perform_later(mintable.ark_id)
+      Curator::ArkDestroyJob.set(wait: 5.seconds).perform_later(mintable.ark_id)
     end
 
     class << self

--- a/app/indexers/concerns/curator/indexable.rb
+++ b/app/indexers/concerns/curator/indexable.rb
@@ -86,11 +86,11 @@ module Curator
     end
 
     def queue_indexing_job
-      Curator::Indexer::IndexingJob.set(wait: 2.seconds).perform_later(self.class.name, id)
+      Curator::Indexer::IndexingJob.set(wait: 5.seconds).perform_later(self.class.name, id)
     end
 
     def queue_deletion_job
-      Curator::Indexer::DeletionJob.set(wait: 2.seconds).perform_later(ark_id)
+      Curator::Indexer::DeletionJob.set(wait: 5.seconds).perform_later(ark_id)
     end
   end
 end

--- a/app/models/curator/collection.rb
+++ b/app/models/curator/collection.rb
@@ -66,7 +66,7 @@ module Curator
       return if collection_members.blank?
 
       reindex_jobs = collection_members.pluck(:digital_object_id).map do |digital_object_id|
-        Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 2.seconds)
+        Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 5.seconds)
       end
 
       ActiveJob.perform_all_later(reindex_jobs)

--- a/app/models/curator/digital_object.rb
+++ b/app/models/curator/digital_object.rb
@@ -180,7 +180,7 @@ module Curator
     end
 
     def invalidate_iiif_manifest
-      Curator::IIIFManifestInvalidateJob.set(wait: 2.seconds).perform_later(ark_id)
+      Curator::IIIFManifestInvalidateJob.set(wait: 5.seconds).perform_later(ark_id)
     end
   end
 end

--- a/app/models/curator/filestreams/file_set.rb
+++ b/app/models/curator/filestreams/file_set.rb
@@ -131,7 +131,7 @@ module Curator
       return if file_set_member_of_mappings.blank?
 
       reindex_jobs = file_set_members_of_ids.map do |digital_object_id|
-        Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 2.seconds)
+        Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 5.seconds)
       end
 
       ActiveJob.perform_all_later(reindex_jobs)
@@ -141,7 +141,7 @@ module Curator
       return if exemplary_image_of_collections.blank?
 
       reindex_jobs = exemplary_image_of_collection_ids.map do |collection_id|
-        Curator::Indexer::IndexingJob.new(Curator.collection_class.name, collection_id).set(wait: 2.seconds)
+        Curator::Indexer::IndexingJob.new(Curator.collection_class.name, collection_id).set(wait: 5.seconds)
       end
 
       ActiveJob.perform_all_later(reindex_jobs)

--- a/app/models/curator/filestreams/image.rb
+++ b/app/models/curator/filestreams/image.rb
@@ -80,11 +80,11 @@ module Curator
     end
 
     def invalidate_iiif_manifest
-      Curator::IIIFManifestInvalidateJob.set(wait: 3.seconds).perform_later(file_set_of.ark_id)
+      Curator::IIIFManifestInvalidateJob.set(wait: 5.seconds).perform_later(file_set_of.ark_id)
     end
 
     def invalidate_iiif_cache
-      Curator::Filestreams::IIIFCacheInvalidateJob.set(wait: 2.seconds).perform_later(ark_id)
+      Curator::Filestreams::IIIFCacheInvalidateJob.set(wait: 5.seconds).perform_later(ark_id)
     end
   end
 end

--- a/app/models/curator/institution.rb
+++ b/app/models/curator/institution.rb
@@ -60,10 +60,10 @@ module Curator
 
       collections.includes(:collection_members).find_each do |col|
         reindex_jobs = col.collection_members.pluck(:digital_object_id).map do |digital_object_id|
-          Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 2.seconds)
+          Curator::Indexer::IndexingJob.new(Curator.digital_object_class.name, digital_object_id).set(wait: 5.seconds)
         end
 
-        reindex_jobs << Curator::Indexer::IndexingJob.new(col.class.name, col.id).set(wait: 2.seconds)
+        reindex_jobs << Curator::Indexer::IndexingJob.new(col.class.name, col.id).set(wait: 5.seconds)
 
         ActiveJob.perform_all_later(reindex_jobs)
       end

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -108,14 +108,14 @@ module Curator
       # Skip Metadata File Set types since they are processed via a different workflow
       return if workflowable.class.name == 'Curator::Filestreams::Metadata'
 
-      Curator::Filestreams::DerivativesJob.set(wait: 2.seconds).perform_later(workflowable_type, workflowable_id)
+      Curator::Filestreams::DerivativesJob.set(wait: 5.seconds).perform_later(workflowable_type, workflowable_id)
     end
 
     alias regenerate_derivatives generate_derivatives
 
     def finalize_complete
       prewarm_iiif_info
-      touch_parent
+      # touch_parent
     end
 
     def prewarm_iiif_info
@@ -123,11 +123,12 @@ module Curator
 
       return if workflowable.class.name != 'Curator::Filestreams::Image'
 
-      Curator::Filestreams::IIIFInfoPrewarmJob.set(wait: 2.seconds).perform_later(workflowable.ark_id)
+      Curator::Filestreams::IIIFInfoPrewarmJob.set(wait: 5.seconds).perform_later(workflowable.ark_id)
     end
 
-    def touch_parent
-      workflowable.file_set_of.touch if workflowable_type == 'Curator::Filestreams::FileSet'
-    end
+    # NOTE: this is probably not needed anymore but I am leaving it here in case we need to roll back. Will remove in future iterations
+    # def touch_parent
+    #   workflowable.file_set_of.touch if workflowable_type == 'Curator::Filestreams::FileSet'
+    # end
   end
 end

--- a/app/services/curator/controlled_terms/authority_service.rb
+++ b/app/services/curator/controlled_terms/authority_service.rb
@@ -26,15 +26,19 @@ module Curator
     rescue HttpConnectionPool::Error => e
       Rails.logger.error 'HTTP Connection Pool Error!'
       Rails.logger.error "Reason: #{e.message}"
+      nil
     rescue HTTP::Error => e
       Rails.logger.error "Error Retrieving Json for Authority at #{request_uri}"
       Rails.logger.error "Reason: #{e.message}"
+      nil
     rescue Oj::Error => e
       Rails.logger.error "Error Parsing Json for Authority at #{request_uri}"
       Rails.logger.error "Reason: #{e.message}"
+      nil
     rescue Curator::Exceptions::RemoteServiceError => e
       Rails.logger.error "Error Retrieving Json for Authority at #{request_uri}"
       Rails.logger.error "Reason: #{e.message}"
+      nil
     end
 
     protected

--- a/app/services/curator/minter_service.rb
+++ b/app/services/curator/minter_service.rb
@@ -16,17 +16,21 @@ module Curator
     rescue HttpConnectionPool::Error => e
       Rails.logger.error 'HTTP Connection Pool Error!'
       Rails.logger.error "Reason: #{e.message}"
+      nil
     rescue HTTP::Error => e
       Rails.logger.error 'HTTP Error Occurred Generating Ark'
       Rails.logger.error "Reason #{e.message}"
+      nil
     rescue Oj::Error => e
       Rails.logger.error 'Invalid JSON From Ark Response'
       Rails.logger.error "Reason #{e.message}"
+      nil
     rescue Curator::Exceptions::RemoteServiceError => e
       Rails.logger.error 'Error Occurred Generating Ark'
       Rails.logger.error "Reason #{e.message}"
       Rails.logger.error "Response code #{e.code}"
       Rails.logger.error "Response #{e.json_response}"
+      nil
     end
 
     protected


### PR DESCRIPTION
- Fixed issue with return values on rescue in `AuthorityService` and `MinterService`

- Increase job wait times to 5 seconds before performing to help pad and prevent race conditions

- Comment out `touch_parent` in workflow to prevent duplicate job enqueues