### PR TITLE
Roll back touch_parent removal in workflow

### DIFF
--- a/app/jobs/curator/ark_destroy_job.rb
+++ b/app/jobs/curator/ark_destroy_job.rb
@@ -4,7 +4,7 @@ module Curator
   class ArkDestroyJob < ApplicationJob
     queue_as :arks
 
-    retry_on Curator::Exceptions::ArkManagerApiUnavailable, ActiveRecord::RecordNotDestroyed, wait: 5.seconds, attempts: 3
+    retry_on Curator::Exceptions::ArkManagerApiUnavailable, ActiveRecord::RecordNotDestroyed, wait: 30.seconds, attempts: 3
 
     before_perform { remote_service_healthcheck! }
 

--- a/app/jobs/curator/filestreams/derivatives_job.rb
+++ b/app/jobs/curator/filestreams/derivatives_job.rb
@@ -4,9 +4,9 @@ module Curator
   class Filestreams::DerivativesJob < ApplicationJob
     queue_as :filestream_derivatives
 
-    retry_on Curator::Exceptions::AviProcessorApiUnavailable, ActiveRecord::StaleObjectError, wait: 5.seconds, attempts: 5
-    retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
-    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 5.seconds
+    retry_on Curator::Exceptions::AviProcessorApiUnavailable, ActiveRecord::StaleObjectError, wait: 30.seconds, attempts: 3
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 30.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, wait: 30.seconds, attempts: 1
 
     before_perform { remote_service_healthcheck! }
 

--- a/app/jobs/curator/filestreams/iiif_cache_invalidate_job.rb
+++ b/app/jobs/curator/filestreams/iiif_cache_invalidate_job.rb
@@ -5,9 +5,9 @@ module Curator
     include Curator::Filestreams::IIIFReadyable
     queue_as :iiif
 
-    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 5.seconds, attempts: 5
-    retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
-    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 5.seconds
+    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 30.seconds, attempts: 3
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 10.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, wait: 10.seconds, attempts: 1
 
     before_perform { remote_service_healthcheck! }
 

--- a/app/jobs/curator/filestreams/iiif_info_prewarm_job.rb
+++ b/app/jobs/curator/filestreams/iiif_info_prewarm_job.rb
@@ -5,9 +5,9 @@ module Curator
     include Curator::Filestreams::IIIFReadyable
     queue_as :iiif
 
-    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 15.seconds, attempts: 5
-    retry_on Curator::Exceptions::RemoteServiceError, wait: 15.seconds, attempts: 2
-    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 10.seconds
+    retry_on Curator::Exceptions::IIIFServerUnavailable, wait: 30.seconds, attempts: 3
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 10.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, wait: 10.seconds, attempts: 1
 
     before_perform { remote_service_healthcheck! }
 

--- a/app/jobs/curator/iiif_manifest_invalidate_job.rb
+++ b/app/jobs/curator/iiif_manifest_invalidate_job.rb
@@ -4,9 +4,9 @@ module Curator
   class IIIFManifestInvalidateJob < ApplicationJob
     queue_as :default
 
-    retry_on Curator::Exceptions::IIIFManifestEndpointUnavailable, wait: 5.seconds, attempts: 5
-    retry_on Curator::Exceptions::RemoteServiceError, wait: 5.seconds, attempts: 2
-    retry_on Curator::Exceptions::CuratorError, attempts: 1, wait: 5.seconds
+    retry_on Curator::Exceptions::IIIFManifestEndpointUnavailable, wait: 30.seconds, attempts: 3
+    retry_on Curator::Exceptions::RemoteServiceError, wait: 10.seconds, attempts: 2
+    retry_on Curator::Exceptions::CuratorError, wait: 5.seconds, attempts: 1
 
     # @param Curator::DigitalObject#ark_id [String]
     def perform(ark_id)

--- a/app/jobs/curator/indexer/deletion_job.rb
+++ b/app/jobs/curator/indexer/deletion_job.rb
@@ -4,7 +4,7 @@ module Curator
   class Indexer::DeletionJob < ApplicationJob
     queue_as :indexing
 
-    retry_on Curator::Exceptions::SolrUnavailable, ActiveRecord::StaleObjectError, attempts: 3, wait: 5.seconds
+    retry_on Curator::Exceptions::SolrUnavailable, ActiveRecord::StaleObjectError, attempts: 3, wait: 30.seconds
 
     before_perform { remote_service_healthcheck! }
 

--- a/app/jobs/curator/indexer/indexing_job.rb
+++ b/app/jobs/curator/indexer/indexing_job.rb
@@ -5,8 +5,8 @@ module Curator
     queue_as :indexing
 
     retry_on Curator::Exceptions::SolrUnavailable, Curator::Exceptions::AuthorityApiUnavailable,
-             ActiveRecord::StaleObjectError, Curator::Exceptions::AllmapsAnnotationsUnavailable, attempts: 3, wait: 5.seconds
-    retry_on Curator::Exceptions::GeographicIndexerError, wait: 5.seconds, attempts: 1 do |_job, error|
+             ActiveRecord::StaleObjectError, Curator::Exceptions::AllmapsAnnotationsUnavailable, attempts: 3, wait: 30.seconds
+    retry_on Curator::Exceptions::GeographicIndexerError, wait: 30.seconds, attempts: 1 do |_job, error|
       logger.error "#{error.message}; URL PATH: #{error&.geo_auth_url}"
     end
 

--- a/app/models/curator/metastreams/workflow.rb
+++ b/app/models/curator/metastreams/workflow.rb
@@ -115,7 +115,7 @@ module Curator
 
     def finalize_complete
       prewarm_iiif_info
-      # touch_parent
+      touch_parent
     end
 
     def prewarm_iiif_info
@@ -126,9 +126,8 @@ module Curator
       Curator::Filestreams::IIIFInfoPrewarmJob.set(wait: 5.seconds).perform_later(workflowable.ark_id)
     end
 
-    # NOTE: this is probably not needed anymore but I am leaving it here in case we need to roll back. Will remove in future iterations
-    # def touch_parent
-    #   workflowable.file_set_of.touch if workflowable_type == 'Curator::Filestreams::FileSet'
-    # end
+    def touch_parent
+      workflowable.file_set_of&.touch if workflowable_type == 'Curator::Filestreams::FileSet'
+    end
   end
 end

--- a/lib/curator/services/transaction_handler.rb
+++ b/lib/curator/services/transaction_handler.rb
@@ -5,8 +5,8 @@ module Curator
     module TransactionHandler
       extend ActiveSupport::Concern
 
-      MAX_RETRIES = 3
-      RETRY_SLEEP_SECONDS = 5
+      MAX_RETRIES = 2
+      RETRY_SLEEP_SECONDS = 3
       # These are errors that will be passed to the @result variable. That way these can be raised on failure up the chain
       RESULT_ERRORS = [
                         ActiveRecord::RecordNotFound,
@@ -64,15 +64,18 @@ module Curator
               @record.reload if @record.present? && !@record.new_record?
               retry
             else
-              Rails.logger.error '===============MAX RETRIES REACHED!============'
+              Rails.logger.error '============!!!MAX RETRIES REACHED!!!=========='
               Rails.logger.error "=================#{e.inspect}=================="
+              Rails.logger.error '==============================================='
 
               raise ActiveRecord::RecordNotSaved.new("Max retries reached on stale object! Caused by: #{e.message}", e.record)
             end
           end
         end
       rescue *RESULT_ERRORS => e
+        Rails.logger.error '==============================================='
         Rails.logger.error "=================#{e.inspect}=================="
+        Rails.logger.error '==============================================='
         @success = false
         @result = e
       ensure


### PR DESCRIPTION
- Rolled back removal of `touch_parent` in `workflow`
- Added more `wait` time padding for retry jobs for certain exceptions
- Reduced number of `retry` attempts and `sleep` seconds in transaction handler